### PR TITLE
Feature: compare accordion

### DIFF
--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -82,20 +82,21 @@ class Accordion extends Component {
                           {def.description}
                         </dd>
                         {compare &&
-                          <div className={styles.compare}>
-                            <dd className={styles.definitionCompare}>
-                              {data[countriesToCompare[0]]
-                                ? data[countriesToCompare[0]][index]
-                                    .definitions[defIndex].description
-                                : ''}
-                            </dd>
-                            <dd className={styles.definitionCompare}>
-                              {data[countriesToCompare[1]]
-                                ? data[countriesToCompare[1]][index]
-                                    .definitions[defIndex].description
-                                : ''}
-                            </dd>
-                          </div>}
+                          <dd className={styles.definitionCompare}>
+                            {data[countriesToCompare[0]]
+                              ? data[countriesToCompare[0]][index].definitions[
+                                  defIndex
+                                ].description
+                              : ''}
+                          </dd>}
+                        {compare &&
+                          <dd className={styles.definitionCompare}>
+                            {data[countriesToCompare[1]]
+                              ? data[countriesToCompare[1]][index].definitions[
+                                  defIndex
+                                ].description
+                              : ''}
+                          </dd>}
                       </div>)
                     )}
                   </dl>

--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-collapse';
 import Icon from 'components/icon';
-import qs from 'query-string';
 import cx from 'classnames';
+import qs from 'query-string';
 
 import dropdownArrow from 'assets/icons/dropdown-arrow.svg';
 import layout from 'styles/layout.scss';
@@ -12,8 +12,7 @@ import styles from './accordion-styles.scss';
 class Accordion extends Component {
   handleOnClick = (slug) => {
     const { location, history } = this.props;
-    const search = qs.parse(location.search);
-    const newSearch = { ...search, activeSection: slug };
+    const newSearch = { ...this.props.search, activeSection: slug };
     history.push({
       pathname: location.pathname,
       search: qs.stringify(newSearch)
@@ -21,12 +20,16 @@ class Accordion extends Component {
   };
 
   render() {
-    const { location, data } = this.props;
-    const search = qs.parse(location.search);
-    const activeSection = search.activeSection ? search.activeSection : null;
+    const {
+      data,
+      country,
+      activeSection,
+      compare,
+      countriesToCompare
+    } = this.props;
     return (
       <div>
-        {data.map((section, index) =>
+        {data[country].map((section, index) =>
           (<section key={section.slug} className={styles.accordion}>
             <button
               className={styles.header}
@@ -36,6 +39,15 @@ class Accordion extends Component {
               <div className={layout.content}>
                 <div className={styles.title}>
                   {section.title}
+                  {compare &&
+                    <div>
+                      <span>
+                        {countriesToCompare[0] || 'none'},{' '}
+                      </span>
+                      <span>
+                        {countriesToCompare[1] || 'none'}
+                      </span>
+                    </div>}
                   <Icon
                     icon={dropdownArrow}
                     className={cx(
@@ -55,14 +67,35 @@ class Accordion extends Component {
               <div className={styles.accordionContent}>
                 <div className={layout.content}>
                   <dl className={styles.definitionList}>
-                    {section.definitions.map(def =>
+                    {section.definitions.map((def, defIndex) =>
                       (<div className={styles.definition} key={def.title}>
                         <dt className={styles.definitionTitle}>
                           {def.title}
                         </dt>
-                        <dd className={styles.definitionDesc}>
+                        <dd
+                          className={
+                            compare
+                              ? styles.definitionCompare
+                              : styles.definitionDesc
+                          }
+                        >
                           {def.description}
                         </dd>
+                        {compare &&
+                          <div className={styles.compare}>
+                            <dd className={styles.definitionCompare}>
+                              {data[countriesToCompare[0]]
+                                ? data[countriesToCompare[0]][index]
+                                    .definitions[defIndex].description
+                                : ''}
+                            </dd>
+                            <dd className={styles.definitionCompare}>
+                              {data[countriesToCompare[1]]
+                                ? data[countriesToCompare[1]][index]
+                                    .definitions[defIndex].description
+                                : ''}
+                            </dd>
+                          </div>}
                       </div>)
                     )}
                   </dl>
@@ -77,15 +110,14 @@ class Accordion extends Component {
 }
 
 Accordion.propTypes = {
-  location: PropTypes.object,
+  data: PropTypes.object.isRequired,
+  country: PropTypes.string,
+  activeSection: PropTypes.string,
+  compare: PropTypes.bool,
+  countriesToCompare: PropTypes.array,
   history: PropTypes.object,
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      slug: PropTypes.string,
-      definitions: PropTypes.array.isRequired
-    })
-  )
+  location: PropTypes.object,
+  search: PropTypes.object
 };
 
 export default Accordion;

--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -11,8 +11,8 @@ import styles from './accordion-styles.scss';
 
 class Accordion extends Component {
   handleOnClick = (slug) => {
-    const { location, history } = this.props;
-    const newSearch = { ...this.props.search, activeSection: slug };
+    const { location, history, search } = this.props;
+    const newSearch = { ...search, activeSection: slug };
     history.push({
       pathname: location.pathname,
       search: qs.stringify(newSearch)

--- a/app/javascript/app/components/accordion/accordion-styles.scss
+++ b/app/javascript/app/components/accordion/accordion-styles.scss
@@ -68,4 +68,6 @@
 .definitionCompare {
   width: 50%;
   margin-right: 20px;
+  color: $theme-color;
+  font-family: $font-family-2;
 }

--- a/app/javascript/app/components/accordion/accordion-styles.scss
+++ b/app/javascript/app/components/accordion/accordion-styles.scss
@@ -50,7 +50,7 @@
 }
 
 .definitionTitle {
-  width: 200px;
+  width: 25%;
   min-width: 200px;
   margin-right: 40px;
   color: $theme-color;
@@ -59,6 +59,19 @@
 }
 
 .definitionDesc {
+  width: 75%;
   color: $theme-color;
   font-family: $font-family-2;
+  margin-right: 20px;
+}
+
+.definitionCompare {
+  width: 50%;
+  margin-right: 20px;
+}
+
+.compare {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
 }

--- a/app/javascript/app/components/accordion/accordion-styles.scss
+++ b/app/javascript/app/components/accordion/accordion-styles.scss
@@ -52,7 +52,7 @@
 .definitionTitle {
   width: 25%;
   min-width: 200px;
-  margin-right: 40px;
+  margin-right: 20px;
   color: $theme-color;
   font-weight: $font-weight-bold;
   font-family: $font-family-2;
@@ -68,10 +68,4 @@
 .definitionCompare {
   width: 50%;
   margin-right: 20px;
-}
-
-.compare {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
 }

--- a/app/javascript/app/components/accordion/accordion.js
+++ b/app/javascript/app/components/accordion/accordion.js
@@ -1,10 +1,21 @@
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
+import qs from 'query-string';
 import Component from './accordion-component';
 
-const mapStateToProps = (state, { location, match }) => ({
-  location,
-  data: state.ndc.data[match.params.iso]
-});
+const mapStateToProps = (state, { location, match }) => {
+  const search = qs.parse(location.search);
+  return {
+    data: state.ndc.data,
+    country: match.params.iso,
+    activeSection: search.activeSection,
+    compare: parseInt(search.compare, 10) === 1,
+    countriesToCompare: search.countriesToCompare
+      ? search.countriesToCompare.split(',')
+      : [],
+    search,
+    location
+  };
+};
 
 export default withRouter(connect(mapStateToProps, null)(Component));

--- a/app/javascript/app/components/header/header-styles.scss
+++ b/app/javascript/app/components/header/header-styles.scss
@@ -4,6 +4,7 @@
   background-color: $theme-color;
   color: $white;
   padding: 50px 0 0;
+  display: flex;
 }
 
 .large {

--- a/app/javascript/app/components/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/components/ndc-country/ndc-country-component.jsx
@@ -1,13 +1,41 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import Accordion from 'components/accordion';
+import Button from 'components/button';
+import qs from 'query-string';
 
-const NDCCountry = () =>
-  (<div>
-    <Header>
-      <Intro title="Country name" />
-    </Header>
-    <Accordion />
-  </div>);
-export default NDCCountry;
+class NDCCountry extends Component {
+  handleCompareClick = () => {
+    const { location, history } = this.props;
+    const search = qs.parse(location.search);
+    const newSearch = { ...search, compare: search.compare === '1' ? 0 : 1 };
+    history.push({
+      pathname: location.pathname,
+      search: qs.stringify(newSearch)
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <Header>
+          <Intro title="Country name" />
+          <Button className="compare-button" onClick={this.handleCompareClick}>
+            <span>Compare</span>
+          </Button>
+        </Header>
+        <Accordion />
+      </div>
+    );
+  }
+}
+
+NDCCountry.propTypes = {
+  location: PropTypes.object,
+  history: PropTypes.object
+};
+
+export default withRouter(NDCCountry);

--- a/app/javascript/app/data/initial-state.js
+++ b/app/javascript/app/data/initial-state.js
@@ -47,6 +47,48 @@ export default {
             }
           ]
         }
+      ],
+      esp: [
+        {
+          title: 'Climate change mitigation',
+          slug: 'climate-change-mitigation',
+          definitions: [
+            {
+              title: 'Type of targets',
+              description:
+                'Absolute target: 36% GHG emissions reduction compared to 2005 by 2025, 43% by 2030 (indicative)'
+            },
+            {
+              title: 'Costs of mitigation / investment needs',
+              description: 'no (partial) costs mentioned'
+            },
+            {
+              title: 'Focus on renewable energy',
+              description:
+                'Focus area: increase RE share to 45% by 2030 (Solar power, wind power, biomass, hydropower)'
+            }
+          ]
+        },
+        {
+          title: 'Climate Change Adaptation',
+          slug: 'climate-change-adaption',
+          definitions: [
+            {
+              title: 'Type of targets',
+              description:
+                'Absolute target: 36% GHG emissions reduction compared to 2005 by 2025, 43% by 2030 (indicative)'
+            },
+            {
+              title: 'Costs of mitigation / investment needs',
+              description: 'no (partial) costs mentioned'
+            },
+            {
+              title: 'Focus on renewable energy',
+              description:
+                'Focus area: increase RE share to 45% by 2030 (Solar power, wind power, biomass, hydropower)'
+            }
+          ]
+        }
       ]
     },
     search: ''


### PR DESCRIPTION
![comparecountries](https://user-images.githubusercontent.com/20288774/29373133-873ed3ca-82ad-11e7-9ea1-c8b27fea76ad.gif)

An additional PR to Accordion feature which extends it to handle changing from normal accordion to the compare accordion. Visit http://localhost/ndcs/bra to view all features:
- Button in header to switch between compare and regular
- sync all compare and active country comparisons in the url
- only render additional definition list data inside accordion if in compare mode

Note: this is to demo the compare function inside a single accordion component. The accordion could be adapted to accept children but the store model for this view is quite specific. Please let me know your thoughts. The reason I have made this way is to create the simplest set of components possible.

Comments: I think there must be a nicer way to manage these url changes outside of the component, maybe creating a helper to do so.