### PR TITLE
Fix: update accordion to use container

### DIFF
--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-collapse';
 import Icon from 'components/icon';
@@ -9,22 +9,9 @@ import dropdownArrow from 'assets/icons/dropdown-arrow.svg';
 import layout from 'styles/layout.scss';
 import styles from './accordion-styles.scss';
 
-class Accordion extends Component {
-  handleOnClick(slug) {
-    const { location, history } = this.props;
-    const search = qs.parse(location.search);
-    const newSlug =
-      !search.activeSection || search.activeSection === slug ? 'none' : slug;
-    const newSearch = { ...search, activeSection: newSlug };
-
-    history.replace({
-      pathname: location.pathname,
-      search: qs.stringify(newSearch)
-    });
-  }
-
+class Accordion extends PureComponent {
   render() {
-    const { location, data } = this.props;
+    const { location, data, handleOnClick } = this.props;
     const search = qs.parse(location.search);
     const activeSection = search.activeSection ? search.activeSection : null;
     return (
@@ -33,7 +20,7 @@ class Accordion extends Component {
           (<section key={section.slug} className={styles.accordion}>
             <button
               className={styles.header}
-              onClick={() => this.handleOnClick(section.slug)}
+              onClick={() => handleOnClick(section.slug)}
             >
               <div className={layout.content}>
                 <div className={styles.title}>
@@ -78,8 +65,8 @@ class Accordion extends Component {
 }
 
 Accordion.propTypes = {
-  location: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired,
+  location: PropTypes.object,
+  handleOnClick: PropTypes.func,
   data: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,

--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-collapse';
 import Icon from 'components/icon';
-import qs from 'query-string';
 import cx from 'classnames';
 
 import dropdownArrow from 'assets/icons/dropdown-arrow.svg';
@@ -11,9 +10,7 @@ import styles from './accordion-styles.scss';
 
 class Accordion extends PureComponent {
   render() {
-    const { location, data, handleOnClick } = this.props;
-    const search = qs.parse(location.search);
-    const activeSection = search.activeSection ? search.activeSection : null;
+    const { data, handleOnClick, activeSection } = this.props;
     return (
       <div>
         {data.map((section, index) =>
@@ -65,7 +62,7 @@ class Accordion extends PureComponent {
 }
 
 Accordion.propTypes = {
-  location: PropTypes.object,
+  activeSection: PropTypes.string,
   handleOnClick: PropTypes.func,
   data: PropTypes.arrayOf(
     PropTypes.shape({

--- a/app/javascript/app/components/accordion/accordion.js
+++ b/app/javascript/app/components/accordion/accordion.js
@@ -5,9 +5,14 @@ import { connect } from 'react-redux';
 import qs from 'query-string';
 import AccordionComponent from './accordion-component';
 
-const mapStateToProps = (state, { match }) => ({
-  data: state.countryNDC.data[match.params.iso]
-});
+const mapStateToProps = (state, { match, location }) => {
+  const search = qs.parse(location.search);
+  const activeSection = search.activeSection ? search.activeSection : null;
+  return {
+    data: state.countryNDC.data[match.params.iso],
+    activeSection
+  };
+};
 
 const AccordionContainer = (props) => {
   const handleOnClick = (slug) => {

--- a/app/javascript/app/components/accordion/accordion.js
+++ b/app/javascript/app/components/accordion/accordion.js
@@ -1,9 +1,37 @@
+import { createElement } from 'react';
 import { withRouter } from 'react-router';
+import Proptypes from 'prop-types';
 import { connect } from 'react-redux';
-import Component from './accordion-component';
+import qs from 'query-string';
+import AccordionComponent from './accordion-component';
 
 const mapStateToProps = (state, { match }) => ({
   data: state.countryNDC.data[match.params.iso]
 });
 
-export default withRouter(connect(mapStateToProps, null)(Component));
+const AccordionContainer = (props) => {
+  const handleOnClick = (slug) => {
+    const { location, history } = props;
+    const search = qs.parse(location.search);
+    const newSlug =
+      !search.activeSection || search.activeSection === slug ? 'none' : slug;
+    const newSearch = { ...search, activeSection: newSlug };
+
+    history.replace({
+      pathname: location.pathname,
+      search: qs.stringify(newSearch)
+    });
+  };
+
+  return createElement(AccordionComponent, {
+    ...props,
+    handleOnClick
+  });
+};
+
+AccordionContainer.propTypes = {
+  location: Proptypes.object,
+  history: Proptypes.object
+};
+
+export default withRouter(connect(mapStateToProps, null)(AccordionContainer));


### PR DESCRIPTION
Updates the accordion component to make the Component only dom and put all actions and logic in the container:
- use createElement to extend the component container and handle click action
- move url parsing to mapStateToProps to make Component really stupid.