### PR TITLE
Feature/import location members

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,5 +1,7 @@
 class Location < ApplicationRecord
   has_many :ndcs
+  has_many :location_members
+  has_many :members, through: :location_members
   validates :iso_code3, presence: true, uniqueness: true
   # TODO: not until data provided
   # validates :iso_code2, presence: true, uniqueness: true

--- a/app/models/location_member.rb
+++ b/app/models/location_member.rb
@@ -1,0 +1,4 @@
+class LocationMember < ApplicationRecord
+  belongs_to :location
+  belongs_to :member, class_name: 'Location', foreign_key: :member_id
+end

--- a/app/services/import_location_members.rb
+++ b/app/services/import_location_members.rb
@@ -1,0 +1,44 @@
+require 'csv'
+
+class ImportLocationMembers
+  def call
+    bucket_name = Rails.application.secrets.s3_bucket_name
+    file_name = 'data/locations_groupings.csv'
+    s3 = Aws::S3::Client.new
+    begin
+      file = s3.get_object(bucket: bucket_name, key: file_name)
+    rescue Aws::S3::Errors::NoSuchKey
+      Rails.logger.error "File #{file_name} not found in #{bucket_name}"
+      return
+    end
+    content = file.body.read
+    import_records(content)
+  end
+
+  private
+
+  def import_records(content)
+    CSV.parse(content, headers: true).each.with_index(2) do |row|
+      iso_code3 = iso_code3(row)
+      parent_iso_code3 = parent_iso_code3(row)
+      member = iso_code3 && Location.find_by_iso_code3(iso_code3)
+      location = parent_iso_code3 &&
+        Location.find_by_iso_code3(parent_iso_code3)
+      if location && member
+        LocationMember.find_or_create_by(
+          location_id: location.id, member_id: member.id
+        )
+      else
+        Rails.logger.warn "Unable to create member #{row}"
+      end
+    end
+  end
+
+  def iso_code3(row)
+    row['iso_code3'] && row['iso_code3'].strip.upcase
+  end
+
+  def parent_iso_code3(row)
+    row['parent_iso_code3'] && row['parent_iso_code3'].strip.upcase
+  end
+end

--- a/db/migrate/20170823121414_create_location_members.rb
+++ b/db/migrate/20170823121414_create_location_members.rb
@@ -1,0 +1,10 @@
+class CreateLocationMembers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :location_members do |t|
+      t.references :location, index: true, foreign_key: {on_delete: :cascade}
+      t.references :member, index: true, foreign_key: {to_table: :locations, on_delete: :cascade}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822124135) do
+ActiveRecord::Schema.define(version: 20170823121414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "location_members", force: :cascade do |t|
+    t.bigint "location_id"
+    t.bigint "member_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_location_members_on_location_id"
+    t.index ["member_id"], name: "index_location_members_on_member_id"
+  end
 
   create_table "locations", force: :cascade do |t|
     t.text "iso_code3", null: false
@@ -40,5 +49,7 @@ ActiveRecord::Schema.define(version: 20170822124135) do
     t.index ["location_id"], name: "index_ndcs_on_location_id"
   end
 
+  add_foreign_key "location_members", "locations", column: "member_id", on_delete: :cascade
+  add_foreign_key "location_members", "locations", on_delete: :cascade
   add_foreign_key "ndcs", "locations", on_delete: :cascade
 end

--- a/doc/upload_template_specs.md
+++ b/doc/upload_template_specs.md
@@ -210,6 +210,14 @@ Countries and country groups for which data is collected are referenced by a cod
 | ndcp_navigators_name | String, name as used in NDCP Navigators |
 | unfccc_group | String, e.g. UNFCCC Non-Annex I |
 
+### Country groups and regions
+
+| column name | data type |
+| ---| --|
+| **parent_iso_code3** | String, 3-digit iso code for country groups, e.g. 'EU28'|
+|name | String, name of country who is a member of a group, e.g. 'Poland' (not required)|
+| **iso_code3** | String, 3-digit iso code for country who is member of a group, e.g. 'POL'|
+
 ### Emissions
 
 | column name | data type |

--- a/lib/tasks/locations.rake
+++ b/lib/tasks/locations.rake
@@ -1,6 +1,13 @@
 namespace :locations do
-  desc 'Import locations from local .csv file'
+  desc 'Import locations from remote .csv file'
   task import: :environment do
     ImportLocations.new.call
+  end
+end
+
+namespace :location_members do
+  desc 'Import location members from remote .csv file'
+  task import: :environment do
+    ImportLocationMembers.new.call
   end
 end

--- a/spec/factories/location_members.rb
+++ b/spec/factories/location_members.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :location_member do
+    location
+    member
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -6,4 +6,14 @@ RSpec.describe Location, type: :model do
       FactoryGirl.build(:location, iso_code3: nil)
     ).to have(1).errors_on(:iso_code3)
   end
+  let(:eu28) {
+    FactoryGirl.create(:location, iso_code3: 'EU28', location_type: 'GROUP')
+  }
+  let(:pol) {
+    FactoryGirl.create(:location, iso_code3: 'POL', location_type: 'COUNTRY')
+  }
+  it 'has members' do
+    eu28.members << pol
+    expect(eu28.members).to eq([pol])
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,13 +28,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 Aws.config[:s3] = {
   stub_responses: {
-    list_objects: {contents: [{key: 'ndcs/AFG.md'}, {key: 'ndcs/ALB.md'}]},
-    get_object: {
-      body: <<~END
-        iso_code3,iso_code2,pik_name,cait_name,ndcp_navigators_name,wri_standard_name,unfccc_group,location_type,show_in_cw
-        ABW,,Aruba,,,,,COUNTRY,No
-      END
-    }
+    list_objects: {contents: [{key: 'ndcs/AFG.md'}, {key: 'ndcs/ALB.md'}]}
   }
 }
 

--- a/spec/services/import_location_members_spec.rb
+++ b/spec/services/import_location_members_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ImportLocationMembers do
+  before(:each) do
+    Aws.config[:s3][:stub_responses][:get_object] = {
+      body: <<~END
+        parent_iso_code3,name,iso_code3,,
+        EU28,Poland,POL,,'
+      END
+    }
+  end
+
+  subject { ImportLocationMembers.new.call }
+
+  before(:each) do
+    FactoryGirl.create(:location, iso_code3: 'EU28', location_type: 'GROUP')
+    FactoryGirl.create(:location, iso_code3: 'POL', location_type: 'COUNTRY')
+  end
+
+  it 'Creates a new location member' do
+    expect { subject }.to change { LocationMember.count }.by(1)
+  end
+end

--- a/spec/services/import_locations_spec.rb
+++ b/spec/services/import_locations_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ImportLocations do
+  before(:each) do
+    Aws.config[:s3][:stub_responses][:get_object] = {
+      body: <<~END
+        iso_code3,iso_code2,pik_name,cait_name,ndcp_navigators_name,wri_standard_name,unfccc_group,location_type,show_in_cw
+        ABW,,Aruba,,,,,COUNTRY,No
+      END
+    }
+  end
+
   subject { ImportLocations.new.call }
 
   it 'Creates a new location' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150400822

Establishes groups of countries, i.e. links 'EU28' to it's member states

Data file in S3

`rake location_members:import`

Anything without an iso code does not get imported - mismatched countries have been flagged to the client.