### PR TITLE
/ndcs/:code/full => /api/v1/ndcs/:code/full

### DIFF
--- a/app/controllers/api/v1/ndc_full_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_full_texts_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class NdcFullTextsController < BaseController
+      def show
+        @ndc = Ndc.joins(:location).where(
+          'locations.iso_code3' => params[:code].upcase
+        ).first
+        render status: :not_found and return unless @ndc
+        render html: @ndc.full_text.html_safe
+      end
+    end
+  end
+end

--- a/app/controllers/ndc_full_texts_controller.rb
+++ b/app/controllers/ndc_full_texts_controller.rb
@@ -1,9 +1,0 @@
-class NdcFullTextsController < BaseController
-  def show
-    @ndc = Ndc.joins(:location).where(
-      'locations.iso_code3' => params[:code].upcase
-    ).first
-    render status: :not_found and return unless @ndc
-    render html: @ndc.full_text.html_safe
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :countries, only: [:index], controller: :countries
+      resources :ndcs, param: :code, only: [:index, :show] do
+        get :full, on: :member, controller: :ndc_full_texts, action: :show
+      end
     end
-  end
-
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :ndcs, param: :code, only: [:index, :show] do
-    get :full, on: :member, controller: :ndc_full_texts, action: :show
   end
 
   root 'application#index'

--- a/spec/controllers/api/v1/ndc_full_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_full_texts_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe NdcFullTextsController, type: :controller do
+RSpec.describe Api::V1::NdcFullTextsController, type: :controller do
   describe 'GET show' do
     let(:poland) { FactoryGirl.create(:location, iso_code3: 'POL') }
     let(:poland_img_src) { 'POL-1.PNG' }


### PR DESCRIPTION
Changes backend route `/ndcs/:code/full` to `/api/v1/ndcs/:code/full` for consistency and to avoid potential conflicts with frontend routes.