### PR TITLE
Correctly handle the `topojson` field

### DIFF
--- a/app/services/import_locations.rb
+++ b/app/services/import_locations.rb
@@ -43,9 +43,13 @@ class ImportLocations
     response = Net::HTTP.get(uri)
     parsed_response = JSON.parse(response, symbolize_names: true)
     parsed_response[:rows].each do |row|
-      Location.
-        where(iso_code3: row[:iso]).
-        update(topojson: row[:topojson])
+      begin
+        Location.
+          where(iso_code3: row[:iso]).
+          update(topojson: JSON.parse(row[:topojson]))
+      rescue JSON::ParserError => e
+        STDERR.puts "Error importing data for #{row[:iso]}: #{e}"
+      end
     end
   end
 


### PR DESCRIPTION
The `topojson` field in the cartodb payloads used for the topojson import is, sadly, a string instead of an object.

This commit fixes the import process so that this string is correctly handled. As such, some errors may occur with invalid payloads.

If an error occurs, the import process will jump over it and print an error message.