### PR TITLE
Return error payload when not found

### DIFF
--- a/app/controllers/api/v1/ndc_full_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_full_texts_controller.rb
@@ -15,7 +15,10 @@ module Api
         )
         ndcs = apply_query_with_highlights(ndcs, true)
         @ndc = ndcs.first
-        render status: :not_found and return unless @ndc
+        render json: {
+          error: 'NDC not found',
+          status: 404
+        }, status: :not_found and return unless @ndc
         render json: @ndc,
                serializer: Api::V1::NdcFullTextSerializer,
                query: params[:query]


### PR DESCRIPTION
`curl -i http://localhost:3000/api/v1/ndcs/CAN/full`

```
HTTP/1.1 404 Not Found
Content-Type: application/json; charset=utf-8
Cache-Control: no-cache
X-Request-Id: e680309e-5cbf-41b1-b71a-1e754bd93280
X-Runtime: 0.044632
Transfer-Encoding: chunked

{"error":"NDC not found","status":404}
```