### PR TITLE
Fixes 404 returned incorrectly when no matches

### DIFF
--- a/app/controllers/api/v1/ndc_full_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_full_texts_controller.rb
@@ -13,8 +13,8 @@ module Api
         ndcs = Ndc.joins(:location).where(
           'locations.iso_code3' => params[:code].upcase
         )
-        ndcs = apply_query_with_highlights(ndcs, true)
-        @ndc = ndcs.first
+        ndcs_highlighted = apply_query_with_highlights(ndcs, true)
+        @ndc = ndcs_highlighted.first || ndcs.first
         unless @ndc
           render json: {
             error: 'NDC not found',
@@ -22,8 +22,7 @@ module Api
           }, status: :not_found and return
         end
         render json: @ndc,
-               serializer: Api::V1::NdcFullTextSerializer,
-               query: params[:query]
+               serializer: Api::V1::NdcFullTextSerializer
       end
 
       private

--- a/app/serializers/api/v1/ndc_full_text_serializer.rb
+++ b/app/serializers/api/v1/ndc_full_text_serializer.rb
@@ -22,12 +22,10 @@ module Api
       end
 
       def highlights_present?
-        begin
-          object.pg_search_highlight
-          true
-        rescue PgSearch::PgSearchHighlightNotSelected
-          false
-        end
+        object.pg_search_highlight
+        true
+      rescue PgSearch::PgSearchHighlightNotSelected
+        false
       end
     end
   end

--- a/app/serializers/api/v1/ndc_full_text_serializer.rb
+++ b/app/serializers/api/v1/ndc_full_text_serializer.rb
@@ -14,15 +14,20 @@ module Api
       end
 
       def html
-        if query_present?
+        if highlights_present?
           object.pg_search_highlight.html_safe
         else
           object.full_text.html_safe
         end
       end
 
-      def query_present?
-        @instance_options[:query].present?
+      def highlights_present?
+        begin
+          object.pg_search_highlight
+          true
+        rescue PgSearch::PgSearchHighlightNotSelected
+          false
+        end
       end
     end
   end

--- a/spec/controllers/api/v1/ndc_full_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_full_texts_controller_spec.rb
@@ -59,5 +59,10 @@ RSpec.describe Api::V1::NdcFullTextsController, type: :controller do
       json_response = JSON.parse(response.body)
       expect(json_response['html']).to match(pol_html_with_highlight)
     end
+    it 'returns NDC content in html without highlights if no matches' do
+      get :show, params: {code: pol.iso_code3.downcase, query: 'goodbye'}
+      json_response = JSON.parse(response.body)
+      expect(json_response['html']).to match(pol_html)
+    end
   end
 end


### PR DESCRIPTION
The endpoint did not expect a query to be passed that has no matches in the document (normally you'd get here with a query you know has matches, from the search result page); it returned 404 incorrectly in such case, now it will return the full html without any highlights if there are no matches.