### PR TITLE
Filter out any extra documents per country temporarily

### DIFF
--- a/app/controllers/api/v1/ndc_full_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_full_texts_controller.rb
@@ -3,6 +3,7 @@ module Api
     class NdcFullTextsController < ApiController
       def index
         @ndcs = Ndc.includes(:location)
+        apply_temporary_hack
         @ndcs = apply_query_with_highlights(@ndcs, false)
         render json: @ndcs,
                each_serializer: Api::V1::NdcFullTextSearchResultSerializer,
@@ -38,6 +39,27 @@ module Api
           ndcs = ndcs.with_pg_search_highlight
         end
         ndcs
+      end
+
+      def apply_temporary_hack
+        # temporary hack to only return a single document per country
+        query = <<~EOT
+          WITH obsolete_ndcs AS (
+            SELECT min_id, dup_id FROM (
+              SELECT min_id, UNNEST(duplicated_ids) AS dup_id FROM (
+                SELECT MIN(id) AS min_id, ARRAY_AGG(id) AS duplicated_ids, COUNT(*)
+                FROM ndcs
+                GROUP BY (location_id)
+                HAVING COUNT(*) > 1
+              ) s
+            ) ss
+            WHERE ss.dup_id != ss.min_id
+          ) SELECT ARRAY_AGG(dup_id) AS dup_ids FROM obsolete_ndcs
+        EOT
+        result = Ndc.find_by_sql(query)
+        dup_ids = result.first && result.first['dup_ids'] || []
+        @ndcs = @ndcs.where('id NOT IN (?)', dup_ids) if dup_ids.any?
+        # end of temporary hack
       end
     end
   end


### PR DESCRIPTION
This is a temporary hack. We need to revisit the issue of multiple NDC documents / country in this context. The gist of it - for now should return only one document.