### PR TITLE
Feature/historical emissions endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'turbolinks', '~> 5'
 gem 'aws-sdk', '~> 2'
 
 gem 'active_model_serializers', '~> 0.10.0'
+gem 'oj'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    oj (3.3.5)
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
@@ -258,6 +259,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl_rails
   listen (>= 3.0.5, < 3.2)
+  oj
   pg (~> 0.20)
   pg_search
   puma (~> 3.7)

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -1,0 +1,56 @@
+module Api
+  module V1
+    class HistoricalEmissionsController < ApiController
+      def index
+        render json: records,
+               each_serializer: Api::V1::HistoricalEmissions::RecordSerializer
+      end
+
+      private
+
+      def records
+        records = ::HistoricalEmissions::Record.
+          includes(
+            :location,
+            :data_source,
+            :sector,
+            :gas
+          )
+
+        if location_list
+          records = records.where(
+            locations: {iso_code3: location_list}
+          )
+        end
+
+        if params[:gas]
+          records = records.where(
+            historical_emissions_gases: {id: params[:gas]}
+          )
+        end
+
+        if params[:source]
+          records = records.where(
+            historical_emissions_data_sources: {id: params[:source]}
+          )
+        end
+
+        if params[:sector]
+          records = records.where(
+            historical_emissions_sectors: {id: params[:sector]}
+          )
+        end
+
+        records
+      end
+
+      def location_list
+        if params[:location].blank?
+          nil
+        else
+          params[:location].split(',')
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -10,7 +10,7 @@ module Api
 
     class HistoricalEmissionsController < ApiController
       def index
-        render json: records,
+        render json: ::HistoricalEmissions::Record.find_by_params(params),
                each_serializer: Api::V1::HistoricalEmissions::RecordSerializer,
                params: params
       end
@@ -24,46 +24,6 @@ module Api
 
         render json: HistoricalEmissionsMetadata.new(*args),
                serializer: Api::V1::HistoricalEmissions::MetadataSerializer
-      end
-
-      private
-
-      def records
-        records = ::HistoricalEmissions::Record.
-          includes(
-            :location,
-            :data_source,
-            :sector,
-            :gas
-          )
-
-        filters(records)
-      end
-
-      def filters(records)
-        if location_list
-          records = records.where(
-            locations: {iso_code3: location_list}
-          )
-        end
-
-        {
-          historical_emissions_gases: :gas,
-          historical_emissions_data_sources: :source,
-          historical_emissions_sectors: :sector
-        }.each do |k, v|
-          records = records.where(k => {id: params[v]}) if params[v]
-        end
-
-        records
-      end
-
-      def location_list
-        if params[:location].blank?
-          nil
-        else
-          params[:location].split(',')
-        end
       end
     end
   end

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -17,28 +17,22 @@ module Api
             :gas
           )
 
+        filters(records)
+      end
+
+      def filters(records)
         if location_list
           records = records.where(
             locations: {iso_code3: location_list}
           )
         end
 
-        if params[:gas]
-          records = records.where(
-            historical_emissions_gases: {id: params[:gas]}
-          )
-        end
-
-        if params[:source]
-          records = records.where(
-            historical_emissions_data_sources: {id: params[:source]}
-          )
-        end
-
-        if params[:sector]
-          records = records.where(
-            historical_emissions_sectors: {id: params[:sector]}
-          )
+        {
+          historical_emissions_gases: :gas,
+          historical_emissions_data_sources: :source,
+          historical_emissions_sectors: :sector
+        }.each do |k, v|
+          records = records.where(Hash[k, {id: params[v]}]) if params[v]
         end
 
         records

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -33,7 +33,7 @@ module Api
           historical_emissions_data_sources: :source,
           historical_emissions_sectors: :sector
         }.each do |k, v|
-          records = records.where(Hash[k, {id: params[v]}]) if params[v]
+          records = records.where(k => {id: params[v]}) if params[v]
         end
 
         records

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -1,10 +1,29 @@
 module Api
   module V1
+    HistoricalEmissionsMetadata = Struct.new(
+      :data_sources,
+      :sectors,
+      :gases
+    ) do
+      alias_method :read_attribute_for_serialization, :send
+    end
+
     class HistoricalEmissionsController < ApiController
       def index
         render json: records,
                each_serializer: Api::V1::HistoricalEmissions::RecordSerializer,
                params: params
+      end
+
+      def meta
+        args = [
+          ::HistoricalEmissions::DataSource.all,
+          ::HistoricalEmissions::Sector.all,
+          ::HistoricalEmissions::Gas.all
+        ]
+
+        render json: HistoricalEmissionsMetadata.new(*args),
+               serializer: Api::V1::HistoricalEmissions::MetadataSerializer
       end
 
       private

--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -3,7 +3,8 @@ module Api
     class HistoricalEmissionsController < ApiController
       def index
         render json: records,
-               each_serializer: Api::V1::HistoricalEmissions::RecordSerializer
+               each_serializer: Api::V1::HistoricalEmissions::RecordSerializer,
+               params: params
       end
 
       private

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -1,4 +1,0 @@
-class DataSource < ApplicationRecord
-  has_many :sectors
-  validates :name, presence: true
-end

--- a/app/models/gas.rb
+++ b/app/models/gas.rb
@@ -1,4 +1,0 @@
-class Gas < ApplicationRecord
-  has_many :historical_emissions
-  validates :name, presence: true
-end

--- a/app/models/historical_emission.rb
+++ b/app/models/historical_emission.rb
@@ -1,6 +1,0 @@
-class HistoricalEmission < ApplicationRecord
-  belongs_to :location
-  belongs_to :data_source
-  belongs_to :sector
-  belongs_to :gas
-end

--- a/app/models/historical_emissions.rb
+++ b/app/models/historical_emissions.rb
@@ -1,0 +1,5 @@
+module HistoricalEmissions
+  def self.table_name_prefix
+    'historical_emissions_'
+  end
+end

--- a/app/models/historical_emissions/data_source.rb
+++ b/app/models/historical_emissions/data_source.rb
@@ -1,0 +1,6 @@
+module HistoricalEmissions
+  class DataSource < ApplicationRecord
+    has_many :sectors, class_name: 'HistoricalEmissions::Sector'
+    validates :name, presence: true
+  end
+end

--- a/app/models/historical_emissions/gas.rb
+++ b/app/models/historical_emissions/gas.rb
@@ -1,0 +1,6 @@
+module HistoricalEmissions
+  class Gas < ApplicationRecord
+    has_many :records, class_name: 'HistoricalEmissions::Record'
+    validates :name, presence: true
+  end
+end

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -17,8 +17,6 @@ module HistoricalEmissions
       filters(records, params)
     end
 
-    private_class_method
-
     def self.filters(records, params)
       unless params[:location].blank?
         records = records.where(
@@ -36,5 +34,7 @@ module HistoricalEmissions
 
       records
     end
+
+    private_class_method :filters
   end
 end

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -1,0 +1,8 @@
+module HistoricalEmissions
+  class Record < ApplicationRecord
+    belongs_to :location
+    belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
+    belongs_to :sector, class_name: 'HistoricalEmissions::Sector'
+    belongs_to :gas, class_name: 'HistoricalEmissions::Gas'
+  end
+end

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -4,5 +4,37 @@ module HistoricalEmissions
     belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
     belongs_to :sector, class_name: 'HistoricalEmissions::Sector'
     belongs_to :gas, class_name: 'HistoricalEmissions::Gas'
+
+    def self.find_by_params(params)
+      records = ::HistoricalEmissions::Record.
+        includes(
+          :location,
+          :data_source,
+          :sector,
+          :gas
+        )
+
+      filters(records, params)
+    end
+
+    private_class_method
+
+    def self.filters(records, params)
+      unless params[:location].blank?
+        records = records.where(
+          locations: {iso_code3: params[:location].split(',')}
+        )
+      end
+
+      {
+        historical_emissions_gases: :gas,
+        historical_emissions_data_sources: :source,
+        historical_emissions_sectors: :sector
+      }.each do |k, v|
+        records = records.where(k => {id: params[v]}) if params[v]
+      end
+
+      records
+    end
   end
 end

--- a/app/models/historical_emissions/sector.rb
+++ b/app/models/historical_emissions/sector.rb
@@ -1,0 +1,10 @@
+module HistoricalEmissions
+  class Sector < ApplicationRecord
+    belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
+    belongs_to :parent, class_name: 'HistoricalEmissions::Sector',
+                        foreign_key: 'parent_id',
+                        required: false
+    has_many :records, class_name: 'HistoricalEmissions::Record'
+    validates :name, presence: true
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,7 +2,9 @@ class Location < ApplicationRecord
   has_many :ndcs, dependent: :destroy
   has_many :location_members, dependent: :destroy
   has_many :members, through: :location_members
-  has_many :historical_emissions, dependent: :destroy
+  has_many :historical_emissions,
+           class_name: 'HistoricalEmissions::Record',
+           dependent: :destroy
   has_many :values, class_name: 'CaitIndc::Value'
   has_many :indicators,
            class_name: 'CaitIndc::Indicator',

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,8 +1,0 @@
-class Sector < ApplicationRecord
-  belongs_to :data_source
-  belongs_to :parent, class_name: 'Sector',
-                      foreign_key: 'parent_id',
-                      required: false
-  has_many :historical_emissions
-  validates :name, presence: true
-end

--- a/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module HistoricalEmissions
+      class MetadataSerializer < ActiveModel::Serializer
+        attributes :data_source, :sector, :gas
+
+        def data_source
+          object.data_sources.map do |g|
+            g.slice(:id, :name)
+          end
+        end
+
+        def sector
+          object.sectors.map do |g|
+            g.slice(:id, :name)
+          end
+        end
+
+        def gas
+          object.gases.map do |g|
+            g.slice(:id, :name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -23,6 +23,16 @@ module Api
         def sector
           object.sector.name
         end
+
+        def emissions
+          date_before = @instance_options[:params]["date_before"]&.to_i
+          date_after = @instance_options[:params]["date_after"]&.to_i
+
+          object.emissions.select do |em|
+            (date_before ? em["year"] <= date_before : true) &&
+            (date_after ? em["year"] >= date_after : true)
+          end
+        end
       end
     end
   end

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -25,12 +25,12 @@ module Api
         end
 
         def emissions
-          date_before = @instance_options[:params]["date_before"]&.to_i
-          date_after = @instance_options[:params]["date_after"]&.to_i
+          date_before = @instance_options[:params]['date_before']&.to_i
+          date_after = @instance_options[:params]['date_after']&.to_i
 
           object.emissions.select do |em|
-            (date_before ? em["year"] <= date_before : true) &&
-            (date_after ? em["year"] >= date_after : true)
+            (date_before ? em['year'] <= date_before : true) &&
+              (date_after ? em['year'] >= date_after : true)
           end
         end
       end

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    module HistoricalEmissions
+      class RecordSerializer < ActiveModel::Serializer
+        belongs_to :location
+        belongs_to :gas
+        belongs_to :data_source, key: :source
+        belongs_to :sector
+        attribute :emissions
+
+        def location
+          object.location.iso_code3
+        end
+
+        def gas
+          object.gas.name
+        end
+
+        def data_source
+          object.data_source.name
+        end
+
+        def sector
+          object.sector.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -1,7 +1,11 @@
-META_SECTORS_FILEPATH = 'he_2/CW_HistoricalEmissions_metadata_sectors.csv'.freeze
-DATA_CAIT_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_CAIT.csv'.freeze
-DATA_PIK_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_PIK.csv'.freeze
-DATA_UNFCCC_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_UNFCCC.csv'.freeze
+META_SECTORS_FILEPATH = 'he_2/CW_HistoricalEmissions_metadata_sectors.csv'.
+  freeze
+DATA_CAIT_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_CAIT.csv'.
+  freeze
+DATA_PIK_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_PIK.csv'.
+  freeze
+DATA_UNFCCC_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_UNFCCC.csv'.
+  freeze
 
 class ImportHistoricalEmissions
   def call
@@ -72,7 +76,6 @@ class ImportHistoricalEmissions
 
   def import_records(content)
     content.each do |row|
-      pp row
       begin
         HistoricalEmissions::Record.create!(record_attributes(row))
       rescue ActiveRecord::RecordInvalid => invalid

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -34,7 +34,9 @@ class ImportHistoricalEmissions
   def sector_attributes(row)
     {
       name: row[:sector],
-      data_source: HistoricalEmissions::DataSource.find_or_create_by(name: row[:source]),
+      data_source: HistoricalEmissions::DataSource.find_or_create_by(
+        name: row[:source]
+      ),
       parent: row[:subsectorof] &&
         HistoricalEmissions::Sector.find_or_create_by(name: row[:subsectorof])
     }
@@ -66,7 +68,7 @@ class ImportHistoricalEmissions
   end
 
   def import_records(content)
-   content.each do |row|
+    content.each do |row|
       begin
         HistoricalEmissions::Record.create!(record_attributes(row))
       rescue ActiveRecord::RecordInvalid => invalid

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -1,7 +1,7 @@
-META_SECTORS_FILEPATH = 'he_2/CW_HistoricalEmisisons_metadata_sectors.csv'.freeze
-DATA_CAIT_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_CAIT.csv'.freeze
-DATA_PIK_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_PIK.csv'.freeze
-DATA_UNFCCC_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_UNFCCC.csv'.freeze
+META_SECTORS_FILEPATH = 'he_2/CW_HistoricalEmissions_metadata_sectors.csv'.freeze
+DATA_CAIT_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_CAIT.csv'.freeze
+DATA_PIK_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_PIK.csv'.freeze
+DATA_UNFCCC_FILEPATH = 'he_2/CW_HistoricalEmissions_sampledata_UNFCCC.csv'.freeze
 
 class ImportHistoricalEmissions
   def call
@@ -72,6 +72,7 @@ class ImportHistoricalEmissions
 
   def import_records(content)
     content.each do |row|
+      pp row
       begin
         HistoricalEmissions::Record.create!(record_attributes(row))
       rescue ActiveRecord::RecordInvalid => invalid

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -1,6 +1,7 @@
-META_SECTORS_FILEPATH = 'he/CW_HistoricalEmisisons_metadata_sectors.csv'.freeze
-DATA_CAIT_FILEPATH = 'he/CW_HistoricalEmisisons_sampledata_CAIT.csv'.freeze
-DATA_PIK_FILEPATH = 'he/CW_HistoricalEmisisons_sampledata_PIK.csv'.freeze
+META_SECTORS_FILEPATH = 'he_2/CW_HistoricalEmisisons_metadata_sectors.csv'.freeze
+DATA_CAIT_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_CAIT.csv'.freeze
+DATA_PIK_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_PIK.csv'.freeze
+DATA_UNFCCC_FILEPATH = 'he_2/CW_HistoricalEmisisons_sampledata_UNFCCC.csv'.freeze
 
 class ImportHistoricalEmissions
   def call
@@ -8,6 +9,7 @@ class ImportHistoricalEmissions
     import_sectors(S3CSVReader.read(META_SECTORS_FILEPATH))
     import_records(S3CSVReader.read(DATA_CAIT_FILEPATH))
     import_records(S3CSVReader.read(DATA_PIK_FILEPATH))
+    import_records(S3CSVReader.read(DATA_UNFCCC_FILEPATH))
   end
 
   private
@@ -37,6 +39,7 @@ class ImportHistoricalEmissions
       data_source: HistoricalEmissions::DataSource.find_or_create_by(
         name: row[:source]
       ),
+      annex_type: row[:annex_type],
       parent: row[:subsectorof] &&
         HistoricalEmissions::Sector.find_or_create_by(name: row[:subsectorof])
     }

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,1 @@
+Oj.optimize_rails()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
         resources :regions, only: [:index], controller: :regions
       end
 
-      resources :emissions, only: [:index], controller: :historical_emissions
+      resources :emissions, only: [:index], controller: :historical_emissions do
+        get :meta, on: :collection, controller: :historical_emissions, action: :meta
+      end
 
       resources :ndcs, param: :code, only: [:index, :show] do
         get :full, on: :member, controller: :ndc_full_texts, action: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
         resources :regions, only: [:index], controller: :regions
       end
 
+      resources :emissions, only: [:index], controller: :historical_emissions
+
       resources :ndcs, param: :code, only: [:index, :show] do
         get :full, on: :member, controller: :ndc_full_texts, action: :show
         get :full, on: :collection, controller: :ndc_full_texts, action: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       end
 
       resources :emissions, only: [:index], controller: :historical_emissions do
-        get :meta, on: :collection, controller: :historical_emissions, action: :meta
+        get :meta, on: :collection
       end
 
       resources :ndcs, param: :code, only: [:index, :show] do

--- a/db/migrate/20170907105915_rename_historical_emisisons_tables.rb
+++ b/db/migrate/20170907105915_rename_historical_emisisons_tables.rb
@@ -1,0 +1,8 @@
+class RenameHistoricalEmisisonsTables < ActiveRecord::Migration[5.1]
+  def up
+    rename_table :data_sources, :historical_emissions_data_sources
+    rename_table :gases, :historical_emissions_gases
+    rename_table :historical_emissions, :historical_emissions_records
+    rename_table :sectors, :historical_emissions_sectors
+  end
+end

--- a/db/migrate/20170907105915_rename_historical_emissions_tables.rb
+++ b/db/migrate/20170907105915_rename_historical_emissions_tables.rb
@@ -1,4 +1,4 @@
-class RenameHistoricalEmisisonsTables < ActiveRecord::Migration[5.1]
+class RenameHistoricalEmissionsTables < ActiveRecord::Migration[5.1]
   def up
     rename_table :data_sources, :historical_emissions_data_sources
     rename_table :gases, :historical_emissions_gases

--- a/db/migrate/20170913132252_add_annex_type_to_historical_emissions_sectors.rb
+++ b/db/migrate/20170913132252_add_annex_type_to_historical_emissions_sectors.rb
@@ -1,0 +1,5 @@
+class AddAnnexTypeToHistoricalEmissionsSectors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :historical_emissions_sectors, :annex_type, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 20170914191538) do
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "annex_type"
     t.index ["data_source_id"], name: "index_historical_emissions_sectors_on_data_source_id"
     t.index ["parent_id"], name: "index_historical_emissions_sectors_on_parent_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -215,21 +215,8 @@ ActiveRecord::Schema.define(version: 20170914191538) do
     t.index ["location_id"], name: "index_ndcs_on_location_id"
   end
 
-<<<<<<< HEAD
-  create_table "sectors", force: :cascade do |t|
-    t.bigint "parent_id"
-    t.bigint "data_source_id"
-    t.text "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["data_source_id"], name: "index_sectors_on_data_source_id"
-    t.index ["parent_id"], name: "index_sectors_on_parent_id"
-  end
-
   add_foreign_key "adaptation_values", "adaptation_variables", column: "variable_id", on_delete: :cascade
   add_foreign_key "adaptation_values", "locations", on_delete: :cascade
-=======
->>>>>>> change schema, models and import process
   add_foreign_key "cait_indc_indicators", "cait_indc_categories", column: "category_id", on_delete: :cascade
   add_foreign_key "cait_indc_indicators", "cait_indc_charts", column: "chart_id", on_delete: :cascade
   add_foreign_key "cait_indc_indicators", "cait_indc_indicator_types", column: "indicator_type_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,29 +95,39 @@ ActiveRecord::Schema.define(version: 20170914191538) do
     t.index ["location_id"], name: "index_cait_indc_values_on_location_id"
   end
 
-  create_table "data_sources", force: :cascade do |t|
+  create_table "historical_emissions_data_sources", force: :cascade do |t|
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "gases", force: :cascade do |t|
+  create_table "historical_emissions_gases", force: :cascade do |t|
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "historical_emissions", force: :cascade do |t|
+  create_table "historical_emissions_records", force: :cascade do |t|
     t.bigint "location_id"
     t.bigint "data_source_id"
     t.bigint "sector_id"
     t.bigint "gas_id"
     t.text "gwp"
     t.jsonb "emissions"
-    t.index ["data_source_id"], name: "index_historical_emissions_on_data_source_id"
-    t.index ["gas_id"], name: "index_historical_emissions_on_gas_id"
-    t.index ["location_id"], name: "index_historical_emissions_on_location_id"
-    t.index ["sector_id"], name: "index_historical_emissions_on_sector_id"
+    t.index ["data_source_id"], name: "index_historical_emissions_records_on_data_source_id"
+    t.index ["gas_id"], name: "index_historical_emissions_records_on_gas_id"
+    t.index ["location_id"], name: "index_historical_emissions_records_on_location_id"
+    t.index ["sector_id"], name: "index_historical_emissions_records_on_sector_id"
+  end
+
+  create_table "historical_emissions_sectors", force: :cascade do |t|
+    t.bigint "parent_id"
+    t.bigint "data_source_id"
+    t.text "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["data_source_id"], name: "index_historical_emissions_sectors_on_data_source_id"
+    t.index ["parent_id"], name: "index_historical_emissions_sectors_on_parent_id"
   end
 
   create_table "location_members", force: :cascade do |t|
@@ -204,6 +214,7 @@ ActiveRecord::Schema.define(version: 20170914191538) do
     t.index ["location_id"], name: "index_ndcs_on_location_id"
   end
 
+<<<<<<< HEAD
   create_table "sectors", force: :cascade do |t|
     t.bigint "parent_id"
     t.bigint "data_source_id"
@@ -216,6 +227,8 @@ ActiveRecord::Schema.define(version: 20170914191538) do
 
   add_foreign_key "adaptation_values", "adaptation_variables", column: "variable_id", on_delete: :cascade
   add_foreign_key "adaptation_values", "locations", on_delete: :cascade
+=======
+>>>>>>> change schema, models and import process
   add_foreign_key "cait_indc_indicators", "cait_indc_categories", column: "category_id", on_delete: :cascade
   add_foreign_key "cait_indc_indicators", "cait_indc_charts", column: "chart_id", on_delete: :cascade
   add_foreign_key "cait_indc_indicators", "cait_indc_indicator_types", column: "indicator_type_id", on_delete: :cascade
@@ -224,10 +237,12 @@ ActiveRecord::Schema.define(version: 20170914191538) do
   add_foreign_key "cait_indc_values", "cait_indc_indicators", column: "indicator_id", on_delete: :cascade
   add_foreign_key "cait_indc_values", "cait_indc_labels", column: "label_id", on_delete: :cascade
   add_foreign_key "cait_indc_values", "locations", on_delete: :cascade
-  add_foreign_key "historical_emissions", "data_sources", on_delete: :cascade
-  add_foreign_key "historical_emissions", "gases", on_delete: :cascade
-  add_foreign_key "historical_emissions", "locations", on_delete: :cascade
-  add_foreign_key "historical_emissions", "sectors", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "historical_emissions_gases", column: "gas_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "historical_emissions_sectors", column: "sector_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "locations", on_delete: :cascade
+  add_foreign_key "historical_emissions_sectors", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_sectors", "historical_emissions_sectors", column: "parent_id", on_delete: :cascade
   add_foreign_key "location_members", "locations", column: "member_id", on_delete: :cascade
   add_foreign_key "location_members", "locations", on_delete: :cascade
   add_foreign_key "ndc_sdg_ndc_target_sectors", "ndc_sdg_ndc_targets", column: "ndc_target_id"
@@ -236,6 +251,4 @@ ActiveRecord::Schema.define(version: 20170914191538) do
   add_foreign_key "ndc_sdg_ndc_targets", "ndcs"
   add_foreign_key "ndc_sdg_targets", "ndc_sdg_goals", column: "goal_id"
   add_foreign_key "ndcs", "locations", on_delete: :cascade
-  add_foreign_key "sectors", "data_sources", on_delete: :cascade
-  add_foreign_key "sectors", "sectors", column: "parent_id", on_delete: :cascade
 end

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Api::V1::HistoricalEmissionsController, type: :controller do
+  context do
+    let!(:some_historical_emissions_records) {
+      FactoryGirl.create_list(:historical_emissions_record, 3)
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index
+        expect(response).to be_success
+      end
+
+      it 'lists all historical emission records' do
+        get :index
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/factories/data_sources.rb
+++ b/spec/factories/data_sources.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :data_source do
-    name 'MyText'
-  end
-end

--- a/spec/factories/gases.rb
+++ b/spec/factories/gases.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :gas do
-    name 'MyText'
-  end
-end

--- a/spec/factories/historical_emissions.rb
+++ b/spec/factories/historical_emissions.rb
@@ -1,8 +1,0 @@
-FactoryGirl.define do
-  factory :historical_emission do
-    location
-    data_source
-    sector
-    gas
-  end
-end

--- a/spec/factories/historical_emissions_data_sources.rb
+++ b/spec/factories/historical_emissions_data_sources.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :historical_emissions_data_source,
+          class: 'HistoricalEmissions::DataSource' do
+    name 'MyText'
+  end
+end

--- a/spec/factories/historical_emissions_gases.rb
+++ b/spec/factories/historical_emissions_gases.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :historical_emissions_gas,
+          class: 'HistoricalEmissions::Gas' do
+    name 'MyText'
+  end
+end

--- a/spec/factories/historical_emissions_records.rb
+++ b/spec/factories/historical_emissions_records.rb
@@ -8,5 +8,6 @@ FactoryGirl.define do
                 factory: :historical_emissions_sector
     association :gas,
                 factory: :historical_emissions_gas
+    emissions [{year: 1990, value: 9001}]
   end
 end

--- a/spec/factories/historical_emissions_records.rb
+++ b/spec/factories/historical_emissions_records.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :historical_emissions_record,
+          class: 'HistoricalEmissions::Record' do
+    location
+    association :data_source,
+                factory: :historical_emissions_data_source
+    association :sector,
+                factory: :historical_emissions_sector
+    association :gas,
+                factory: :historical_emissions_gas
+  end
+end

--- a/spec/factories/historical_emissions_sectors.rb
+++ b/spec/factories/historical_emissions_sectors.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :historical_emissions_sector,
+          class: 'HistoricalEmissions::Sector' do
+    association :data_source,
+                factory: :historical_emissions_data_source
+    name 'MyText'
+  end
+end

--- a/spec/factories/sectors.rb
+++ b/spec/factories/sectors.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :sector do
-    data_source
-    name 'MyText'
-  end
-end

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe DataSource, type: :model do
-  it 'should be invalid when name not present' do
-    expect(
-      FactoryGirl.build(:data_source, name: nil)
-    ).to have(1).errors_on(:name)
-  end
-end

--- a/spec/models/historical_emissions/data_source_spec.rb
+++ b/spec/models/historical_emissions/data_source_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe HistoricalEmissions::DataSource, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryGirl.build(:historical_emissions_data_source, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+end

--- a/spec/models/historical_emissions/gas_spec.rb
+++ b/spec/models/historical_emissions/gas_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Gas, type: :model do
+RSpec.describe HistoricalEmissions::Gas, type: :model do
   it 'should be invalid when name not present' do
     expect(
-      FactoryGirl.build(:gas, name: nil)
+      FactoryGirl.build(:historical_emissions_gas, name: nil)
     ).to have(1).errors_on(:name)
   end
 end

--- a/spec/models/historical_emissions/record_spec.rb
+++ b/spec/models/historical_emissions/record_spec.rb
@@ -1,27 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe HistoricalEmission, type: :model do
+RSpec.describe HistoricalEmissions::Record, type: :model do
   it 'should be invalid when location not present' do
     expect(
-      FactoryGirl.build(:historical_emission, location: nil)
+      FactoryGirl.build(:historical_emissions_record, location: nil)
     ).to have(1).errors_on(:location)
   end
 
   it 'should be invalid when data_source not present' do
     expect(
-      FactoryGirl.build(:historical_emission, data_source: nil)
+      FactoryGirl.build(:historical_emissions_record, data_source: nil)
     ).to have(1).errors_on(:data_source)
   end
 
   it 'should be invalid when sector not present' do
     expect(
-      FactoryGirl.build(:historical_emission, sector: nil)
+      FactoryGirl.build(:historical_emissions_record, sector: nil)
     ).to have(1).errors_on(:sector)
   end
 
   it 'should be invalid when gas not present' do
     expect(
-      FactoryGirl.build(:historical_emission, gas: nil)
+      FactoryGirl.build(:historical_emissions_record, gas: nil)
     ).to have(1).errors_on(:gas)
   end
 end

--- a/spec/models/historical_emissions/sector_spec.rb
+++ b/spec/models/historical_emissions/sector_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Sector, type: :model do
+RSpec.describe HistoricalEmissions::Sector, type: :model do
   it 'should be invalid when name not present' do
     expect(
-      FactoryGirl.build(:sector, name: nil)
+      FactoryGirl.build(:historical_emissions_sector, name: nil)
     ).to have(1).errors_on(:name)
   end
 
   it 'should be invalid when data_source not present' do
     expect(
-      FactoryGirl.build(:sector, data_source: nil)
+      FactoryGirl.build(:historical_emissions_sector, data_source: nil)
     ).to have(1).errors_on(:data_source)
   end
 end

--- a/spec/services/import_historical_emissions_spec.rb
+++ b/spec/services/import_historical_emissions_spec.rb
@@ -1,18 +1,23 @@
 require 'rails_helper'
 
 object_contents = {
-  'he/CW_HistoricalEmisisons_metadata_sectors.csv' => <<~END,
-    Source,Sector,SubsectorOf
-    CAIT,Total excluding LUCF,
-    PIK,Total including LUCF,
+  'he_2/CW_HistoricalEmisisons_metadata_sectors.csv' => <<~END,
+    Source,SourceType,Sector,SubsectorOf
+    CAIT,,Total excluding LUCF,
+    PIK,,Total including LUCF,
+    UNFCCC,AI,Total GHG emissions without LULUCF,
   END
-  'he/CW_HistoricalEmisisons_sampledata_CAIT.csv' => <<~END,
+  'he_2/CW_HistoricalEmisisons_sampledata_CAIT.csv' => <<~END,
     Country,Source,Sector,Gas,GWP,1990,1991,1992
     ABW,CAIT,Total excluding LUCF,All GHG,AR2,15.21284765,15.28643902,14.01053087,14.02811754
   END
-  'he/CW_HistoricalEmisisons_sampledata_PIK.csv' => <<~END,
+  'he_2/CW_HistoricalEmisisons_sampledata_PIK.csv' => <<~END,
     Country,Source,Sector,Gas,GWP,1850,1851,1852
     ABW,PIK,Total including LUCF,CH4,AR2,0.00000469,0.00000475,0.00000483
+  END
+  'he_2/CW_HistoricalEmissions_sampledata_UNFCCC.csv' => <<~END,
+    Country,Source,Sector,Gas,GWP,1990,1991,1992
+    AUS,UNFCCC,Total GHG emissions without LULUCF,Aggregate F-gases,AR4,6.242714951,6.264371648,6.183325393
   END
 }
 
@@ -42,6 +47,6 @@ RSpec.describe ImportHistoricalEmissions do
   end
 
   it 'Creates new historical emission records' do
-    expect { subject }.to change { HistoricalEmissions::Record.count }.by(2)
+    expect { subject }.to change { HistoricalEmissions::Record.count }.by(3)
   end
 end

--- a/spec/services/import_historical_emissions_spec.rb
+++ b/spec/services/import_historical_emissions_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
 object_contents = {
-  'he_2/CW_HistoricalEmisisons_metadata_sectors.csv' => <<~END,
+  'he_2/CW_HistoricalEmissions_metadata_sectors.csv' => <<~END,
     Source,SourceType,Sector,SubsectorOf
     CAIT,,Total excluding LUCF,
     PIK,,Total including LUCF,
     UNFCCC,AI,Total GHG emissions without LULUCF,
   END
-  'he_2/CW_HistoricalEmisisons_sampledata_CAIT.csv' => <<~END,
+  'he_2/CW_HistoricalEmissions_sampledata_CAIT.csv' => <<~END,
     Country,Source,Sector,Gas,GWP,1990,1991,1992
     ABW,CAIT,Total excluding LUCF,All GHG,AR2,15.21284765,15.28643902,14.01053087,14.02811754
   END
-  'he_2/CW_HistoricalEmisisons_sampledata_PIK.csv' => <<~END,
+  'he_2/CW_HistoricalEmissions_sampledata_PIK.csv' => <<~END,
     Country,Source,Sector,Gas,GWP,1850,1851,1852
     ABW,PIK,Total including LUCF,CH4,AR2,0.00000469,0.00000475,0.00000483
   END
   'he_2/CW_HistoricalEmissions_sampledata_UNFCCC.csv' => <<~END,
     Country,Source,Sector,Gas,GWP,1990,1991,1992
-    AUS,UNFCCC,Total GHG emissions without LULUCF,Aggregate F-gases,AR4,6.242714951,6.264371648,6.183325393
+    ABW,UNFCCC,Total GHG emissions without LULUCF,Aggregate F-gases,AR4,6.242714951,6.264371648,6.183325393
   END
 }
 
@@ -47,6 +47,8 @@ RSpec.describe ImportHistoricalEmissions do
   end
 
   it 'Creates new historical emission records' do
-    expect { subject }.to change { HistoricalEmissions::Record.count }.by(3)
+    expect { subject }.to change {
+      HistoricalEmissions::Record.count
+    }.by(3)
   end
 end

--- a/spec/services/import_historical_emissions_spec.rb
+++ b/spec/services/import_historical_emissions_spec.rb
@@ -42,6 +42,6 @@ RSpec.describe ImportHistoricalEmissions do
   end
 
   it 'Creates new historical emission records' do
-    expect { subject }.to change { HistoricalEmission.count }.by(2)
+    expect { subject }.to change { HistoricalEmissions::Record.count }.by(2)
   end
 end


### PR DESCRIPTION
Add historical emissions endpoint: `/emissions`

The data behind this endpoint can be very large, so it is advised to always use filters. I believe I should also force the usage of some filters (or use defaults) because this endpoint could be a potential dos vector for the reasons mentioned above, but I'll need to know more about the kind of usage the FE will need.

This endpoint has the following filters available:
- location takes a comma-separated list of ISO country codes (3 character)
- source takes the id attribute of the `historical_emissions_data_sources` table
- gas takes the id attribute of the `historical_emissions_gases` table
- sector takes the id attribute of the `historical_emissions_sectors` table
- date_before will list only emissions for the year given and before
- date_after will list only emissions for the year given and after

example:

```
/emissions?location=PRT,ESP&source=1&gas=1&sector=1&date_before=2010&date_after=2000
```