### PR TITLE
Feature/fix ndcs endpoint filter

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -15,12 +15,11 @@ module Api
       private
 
       def indicators
-        indicators = ::CaitIndc::Indicator.
-          includes(
-            :labels,
-            :categories,
-            values: [:label, :location]
-          )
+        indicators = ::CaitIndc::Indicator.includes(
+          :labels,
+          :categories,
+          values: [:label, :location]
+        )
 
         if location_list
           indicators = indicators.where(
@@ -28,10 +27,11 @@ module Api
           )
         end
 
-        indicators = indicators.where(on_map: true) if params[:filter] == 'map'
-
-        indicators = indicators.where(summary_list: true) if
-          params[:filter] == 'summary'
+        if params[:filter]
+          indicators = indicators.where(
+            cait_indc_categories: {category_type: params[:filter]}
+          )
+        end
 
         indicators
       end

--- a/app/javascript/app/pages/ndc-country/ndc-country-actions.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-actions.js
@@ -9,7 +9,7 @@ const fetchCountryNDC = createThunkAction(
   'fetchCountryNDC',
   iso => dispatch => {
     dispatch(fetchCountryNDCInit());
-    fetch(`/api/v1/ndcs?location=${iso}&filter=summary`)
+    fetch(`/api/v1/ndcs?location=${iso}&filter=overview`)
       .then(response => {
         if (response.ok) return response.json();
         throw Error(response.statusText);

--- a/app/models/cait_indc/category.rb
+++ b/app/models/cait_indc/category.rb
@@ -4,5 +4,8 @@ module CaitIndc
                             join_table: :cait_indc_indicators_categories
     validates :name, presence: true
     validates :category_type, inclusion: {in: %w(map overview)}
+
+    scope :type_map, -> { where(category_type: 'map') }
+    scope :type_overview, -> { where(category_type: 'overview') }
   end
 end

--- a/app/services/import_cait_indc.rb
+++ b/app/services/import_cait_indc.rb
@@ -60,7 +60,6 @@ class ImportCaitIndc
       chart: chart(indicator),
       name: indicator[:long_name],
       slug: indicator[:column_name],
-      on_map: @map.any? { |m| m[:indicator] == indicator[:column_name] }
     }
   end
 

--- a/db/migrate/20170925143137_remove_cait_indc_indicators_on_map.rb
+++ b/db/migrate/20170925143137_remove_cait_indc_indicators_on_map.rb
@@ -1,0 +1,5 @@
+class RemoveCaitIndcIndicatorsOnMap < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :cait_indc_indicators, :on_map
+  end
+end

--- a/db/migrate/20170925144250_add_cait_indc_categories_category_type_index.rb
+++ b/db/migrate/20170925144250_add_cait_indc_categories_category_type_index.rb
@@ -1,0 +1,5 @@
+class AddCaitIndcCategoriesCategoryTypeIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :cait_indc_categories, :category_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921110036) do
+ActiveRecord::Schema.define(version: 20170925144250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20170921110036) do
     t.text "name", null: false
     t.text "slug", null: false
     t.text "category_type"
+    t.index ["category_type"], name: "index_cait_indc_categories_on_category_type"
   end
 
   create_table "cait_indc_charts", force: :cascade do |t|
@@ -51,7 +52,6 @@ ActiveRecord::Schema.define(version: 20170921110036) do
     t.bigint "chart_id"
     t.text "name", null: false
     t.text "slug", null: false
-    t.boolean "on_map", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["chart_id"], name: "index_cait_indc_indicators_on_chart_id"


### PR DESCRIPTION
There was an oversight when merging the last cait indc changes PR. A field that was used by the `filter` param of the `/ndcs` endpoint got removed, and an api call to `/ndcs?location=SOMELOCATION&filter=overview` was broken.

This PR fixes the backend to correctly filter NDCS by category type (category types are categories of indicators: `map` or `overview`, meaning the area of the site where the indicators will be displayed)