### PR TITLE
Prevent api routes falling into the FE catch-all

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,12 @@
 module Api
   module V1
     class ApiController < ActionController::API
+      def not_found
+        render json: {
+          code: 404,
+          status: "#{request.params[:endpoint]} not found"
+        }, status: :not_found
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
         get :sdgs, on: :member, controller: :ndc_sdgs, action: :show
       end
       resources :adaptations, only: [:index]
+
+      get '(*endpoint)', controller: :api, action: :not_found
     end
   end
 


### PR DESCRIPTION
I created a controller method and another catch-all route inside the API namespace to achieve this