### PR TITLE
Feature/changes for historical emissions endpoint

### DIFF
--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -17,7 +17,7 @@ module HistoricalEmissions
       filters(records, params)
     end
 
-    def self.filters(records, params)
+    private_class_method def self.filters(records, params)
       unless params[:location].blank?
         records = records.where(
           locations: {iso_code3: params[:location].split(',')}
@@ -29,12 +29,10 @@ module HistoricalEmissions
         historical_emissions_data_sources: :source,
         historical_emissions_sectors: :sector
       }.each do |k, v|
-        records = records.where(k => {id: params[v]}) if params[v]
+        records = records.where(k => {id: params[v].split(',')}) if params[v]
       end
 
       records
     end
-
-    private_class_method :filters
   end
 end

--- a/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
@@ -2,23 +2,29 @@ module Api
   module V1
     module HistoricalEmissions
       class MetadataSerializer < ActiveModel::Serializer
-        attributes :data_source, :sector, :gas
+        attributes :data_sources, :sectors, :gases, :locations
 
-        def data_source
+        def data_sources
           object.data_sources.map do |g|
+            g.slice(:id, :name, :location_ids, :sector_ids, :gas_ids)
+          end
+        end
+
+        def sectors
+          object.sectors.map do |g|
             g.slice(:id, :name)
           end
         end
 
-        def sector
-          object.sectors.map do |g|
-            g.slice(:id, :data_source_id, :name)
-          end
-        end
-
-        def gas
+        def gases
           object.gases.map do |g|
             g.slice(:id, :name)
+          end
+        end
+
+        def locations
+          object.locations.map do |l|
+            l.slice(:id, :iso_code3)
           end
         end
       end

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -7,6 +7,7 @@ module Api
         belongs_to :data_source, key: :source
         belongs_to :sector
         attribute :emissions
+        attribute :gwp
 
         def location
           object.location.iso_code3


### PR DESCRIPTION
This PR takes care of some specific: front-end needs:

- It now shows a relation between data sources and sectors, gases, and locations. These last now appear referenced under `data_sources` in the meta endpoint.

- It is now possible to search for multiple values in the sector, gas and data source parameters.

- A HE record attribute called `gwp` was omitted from the serializer, causing some confusion as wether some items were being repeated in the emissions endpoint.