### PR TITLE
Feature/changes to emissions meta endpoint

### DIFF
--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -4,6 +4,7 @@ module Api
       :data_sources,
       :sectors,
       :gases,
+      :gwps,
       :locations
     ) do
       alias_method :read_attribute_for_serialization, :send
@@ -22,6 +23,7 @@ module Api
             merged_records(grouped_records),
             ::HistoricalEmissions::Sector.all,
             ::HistoricalEmissions::Gas.all,
+            ::HistoricalEmissions::Gwp.all,
             Location.all
           ),
           serializer: Api::V1::HistoricalEmissions::MetadataSerializer
@@ -37,7 +39,8 @@ module Api
               data_source_id,
               ARRAY_AGG(DISTINCT sector_id) AS sector_ids,
               ARRAY_AGG(DISTINCT gas_id) AS gas_ids,
-              ARRAY_AGG(DISTINCT location_id) AS location_ids
+              ARRAY_AGG(DISTINCT location_id) AS location_ids,
+              ARRAY_AGG(DISTINCT gwp_id) AS gwp_ids
             SQL
           ).
           group('data_source_id').

--- a/app/models/historical_emissions/gwp.rb
+++ b/app/models/historical_emissions/gwp.rb
@@ -1,0 +1,6 @@
+module HistoricalEmissions
+  class Gwp < ApplicationRecord
+    has_many :records, class_name: 'HistoricalEmissions::Record'
+    validates :name, presence: true
+  end
+end

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -4,6 +4,7 @@ module HistoricalEmissions
     belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
     belongs_to :sector, class_name: 'HistoricalEmissions::Sector'
     belongs_to :gas, class_name: 'HistoricalEmissions::Gas'
+    belongs_to :gwp, class_name: 'HistoricalEmissions::Gwp'
 
     def self.find_by_params(params)
       records = ::HistoricalEmissions::Record.
@@ -11,7 +12,8 @@ module HistoricalEmissions
           :location,
           :data_source,
           :sector,
-          :gas
+          :gas,
+          :gwp
         )
 
       filters(records, params)
@@ -27,7 +29,8 @@ module HistoricalEmissions
       {
         historical_emissions_gases: :gas,
         historical_emissions_data_sources: :source,
-        historical_emissions_sectors: :sector
+        historical_emissions_sectors: :sector,
+        historical_emissions_gwps: :gwp
       }.each do |k, v|
         records = records.where(k => {id: params[v].split(',')}) if params[v]
       end

--- a/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/metadata_serializer.rb
@@ -2,29 +2,35 @@ module Api
   module V1
     module HistoricalEmissions
       class MetadataSerializer < ActiveModel::Serializer
-        attributes :data_sources, :sectors, :gases, :locations
+        attributes :data_source, :sector, :gas, :location, :gwp
 
-        def data_sources
+        def data_source
           object.data_sources.map do |g|
-            g.slice(:id, :name, :location_ids, :sector_ids, :gas_ids)
+            g.slice(:id, :name, :location_ids, :sector_ids, :gas_ids, :gwp_ids)
           end
         end
 
-        def sectors
+        def sector
           object.sectors.map do |g|
             g.slice(:id, :name)
           end
         end
 
-        def gases
+        def gas
           object.gases.map do |g|
             g.slice(:id, :name)
           end
         end
 
-        def locations
+        def location
           object.locations.map do |l|
-            l.slice(:id, :iso_code3)
+            l.slice(:id, :iso_code3, :wri_standard_name)
+          end
+        end
+
+        def gwp
+          object.gwps.map do |g|
+            g.slice(:id, :name)
           end
         end
       end

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -25,6 +25,10 @@ module Api
           object.sector.name
         end
 
+        def gwp
+          object.gwp.name
+        end
+
         def emissions
           date_before = @instance_options[:params]['date_before']&.to_i
           date_after = @instance_options[:params]['date_after']&.to_i

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -35,6 +35,7 @@ class ImportHistoricalEmissions
     HistoricalEmissions::Sector.delete_all
     HistoricalEmissions::Gas.delete_all
     HistoricalEmissions::Record.delete_all
+    HistoricalEmissions::Record.delete_all
   end
 
   def sector_attributes(row)
@@ -69,7 +70,7 @@ class ImportHistoricalEmissions
       data_source: HistoricalEmissions::DataSource.find_by(name: row[:source]),
       sector: HistoricalEmissions::Sector.find_by(name: row[:sector]),
       gas: HistoricalEmissions::Gas.find_or_create_by(name: row[:gas]),
-      gwp: row[:gwp],
+      gwp: HistoricalEmissions::Gwp.find_or_create_by(name: row[:gwp]),
       emissions: emissions(row)
     }
   end

--- a/db/migrate/20170928114300_create_historical_emissions_gwps.rb
+++ b/db/migrate/20170928114300_create_historical_emissions_gwps.rb
@@ -1,0 +1,8 @@
+class CreateHistoricalEmissionsGwps < ActiveRecord::Migration[5.1]
+  def change
+    create_table :historical_emissions_gwps do |t|
+      t.text :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170928114306_change_historical_emissions_records.rb
+++ b/db/migrate/20170928114306_change_historical_emissions_records.rb
@@ -1,0 +1,8 @@
+class ChangeHistoricalEmissionsRecords < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :historical_emissions_records, :gwp
+    add_reference :historical_emissions_records, :gwp, foreign_key: {
+      to_table: :historical_emissions_gwps
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170925144250) do
+ActiveRecord::Schema.define(version: 20170928114306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,15 +106,22 @@ ActiveRecord::Schema.define(version: 20170925144250) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "historical_emissions_gwps", force: :cascade do |t|
+    t.text "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "historical_emissions_records", force: :cascade do |t|
     t.bigint "location_id"
     t.bigint "data_source_id"
     t.bigint "sector_id"
     t.bigint "gas_id"
-    t.text "gwp"
     t.jsonb "emissions"
+    t.bigint "gwp_id"
     t.index ["data_source_id"], name: "index_historical_emissions_records_on_data_source_id"
     t.index ["gas_id"], name: "index_historical_emissions_records_on_gas_id"
+    t.index ["gwp_id"], name: "index_historical_emissions_records_on_gwp_id"
     t.index ["location_id"], name: "index_historical_emissions_records_on_location_id"
     t.index ["sector_id"], name: "index_historical_emissions_records_on_sector_id"
   end
@@ -226,6 +233,7 @@ ActiveRecord::Schema.define(version: 20170925144250) do
   add_foreign_key "cait_indc_values", "locations", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_gases", column: "gas_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "historical_emissions_gwps", column: "gwp_id"
   add_foreign_key "historical_emissions_records", "historical_emissions_sectors", column: "sector_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "locations", on_delete: :cascade
   add_foreign_key "historical_emissions_sectors", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade

--- a/spec/factories/historical_emissions_gwps.rb
+++ b/spec/factories/historical_emissions_gwps.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :historical_emissions_gwp,
+          class: 'HistoricalEmissions::Gwp' do
+    name 'MyText'
+  end
+end

--- a/spec/factories/historical_emissions_records.rb
+++ b/spec/factories/historical_emissions_records.rb
@@ -8,6 +8,8 @@ FactoryGirl.define do
                 factory: :historical_emissions_sector
     association :gas,
                 factory: :historical_emissions_gas
+    association :gwp,
+                factory: :historical_emissions_gwp
     emissions [{year: 1990, value: 9001}]
   end
 end

--- a/spec/models/historical_emissions/gwp_spec.rb
+++ b/spec/models/historical_emissions/gwp_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe HistoricalEmissions::Gwp, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryGirl.build(:historical_emissions_gwp, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+end


### PR DESCRIPTION
- change schema to keep `gwp` in a relation instead of text field
- change models and import process accordingly
- change meta endpoint to list `gwp` dependency under `data_source`
- change index endpoint to allow filtering by `gwp`
- please run `rake db:drop db:create db:migrate db:import` after the merge so that the db can be recreated properly.