### PR TITLE
Feature: multiselect for ghgs

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -47,6 +47,7 @@ class ChartLine extends PureComponent {
               dataKey={column.value}
               dot={false}
               stroke={config.theme[column.value].stroke || ''}
+              strokeWidth={2}
             />
           ))}
         </LineChart>

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -2,8 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  AreaChart,
-  Area,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -13,14 +13,14 @@ import {
 import TooltipChart from 'components/charts/tooltip-chart';
 import { format } from 'd3-format';
 
-class ChartStackedArea extends PureComponent {
+class ChartLine extends PureComponent {
   render() {
     const { config, data } = this.props;
     return (
       <ResponsiveContainer height={500}>
-        <AreaChart
+        <LineChart
           data={data}
-          margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+          margin={{ top: 0, right: 0, left: -20, bottom: 0 }}
         >
           <XAxis
             dataKey="x"
@@ -28,7 +28,7 @@ class ChartStackedArea extends PureComponent {
           />
           <YAxis
             axisLine={false}
-            tickFormatter={tick => format('.1s')(tick)}
+            tickFormatter={tick => `${format('.1s')(tick)}t`}
             tickLine={false}
             tick={{ stroke: '#8f8fa1', strokeWidth: 0.5, fontSize: '13px' }}
           />
@@ -41,22 +41,22 @@ class ChartStackedArea extends PureComponent {
             )}
           />
           {config.columns.y.map(column => (
-            <Area
+            <Line
               key={column.value}
               dataKey={column.value}
               dot={false}
               stroke={config.theme[column.value].stroke || ''}
             />
           ))}
-        </AreaChart>
+        </LineChart>
       </ResponsiveContainer>
     );
   }
 }
 
-ChartStackedArea.propTypes = {
+ChartLine.propTypes = {
   config: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired
 };
 
-export default ChartStackedArea;
+export default ChartLine;

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -31,6 +31,7 @@ class ChartLine extends PureComponent {
             tickFormatter={tick => `${format('.1s')(tick)}t`}
             tickLine={false}
             tick={{ stroke: '#8f8fa1', strokeWidth: 0.5, fontSize: '13px' }}
+            domain={['auto', 'auto']}
           />
           <CartesianGrid vertical={false} />
           <Tooltip

--- a/app/javascript/app/components/charts/line/line-styles.scss
+++ b/app/javascript/app/components/charts/line/line-styles.scss
@@ -1,0 +1,1 @@
+@import '~styles/layout.scss';

--- a/app/javascript/app/components/charts/line/line.js
+++ b/app/javascript/app/components/charts/line/line.js
@@ -1,0 +1,3 @@
+import Component from './line-component';
+
+export default Component;

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -27,22 +27,30 @@ class TooltipChart extends PureComponent {
         )}
         {content.payload &&
           content.payload.length > 0 &&
-          content.payload.map(y => (
-            <div key={y.dataKey} className={styles.label}>
-              <div className={styles.legend}>
-                <span
-                  className={styles.labelDot}
-                  style={{ backgroundColor: config.theme[y.dataKey].stroke }}
-                />
-                <p className={styles.labelName}>
-                  {config.tooltip[y.dataKey].label}
-                </p>
-              </div>
-              <p className={styles.labelValue}>
-                {y.payload ? `${format('.3s')(y.payload[y.dataKey])}t` : ''}
-              </p>
-            </div>
-          ))}
+          content.payload.map(
+            y =>
+              (y.payload ? (
+                <div
+                  key={`${y.dataKey}-${y.payload[y.dataKey]}`}
+                  className={styles.label}
+                >
+                  <div className={styles.legend}>
+                    <span
+                      className={styles.labelDot}
+                      style={{
+                        backgroundColor: config.theme[y.dataKey].stroke
+                      }}
+                    />
+                    <p className={styles.labelName}>
+                      {config.tooltip[y.dataKey].label}
+                    </p>
+                  </div>
+                  <p className={styles.labelValue}>
+                    {y.payload ? `${format('.3s')(y.payload[y.dataKey])}t` : ''}
+                  </p>
+                </div>
+              ) : null)
+          )}
       </div>
     );
   }

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -11,16 +11,15 @@ class TooltipChart extends PureComponent {
     keys.forEach(key => {
       total += data.payload[key.value];
     });
-    return format('.3s')(total);
+    return `${format('.3s')(total)}t`;
   };
 
   render() {
-    const { config, content } = this.props;
-    const needsTotal = content.payload && content.payload.length > 1;
+    const { config, content, showTotal } = this.props;
     return (
       <div className={styles.tooltip}>
         <span className={styles.unit}>{config.axes.yLeft.unit}</span>
-        {needsTotal && (
+        {showTotal && (
           <div className={cx(styles.label, styles.labelTotal)}>
             <p>TOTAL</p>
             <p>{this.getTotal(config.columns.y, content.payload[0])}</p>
@@ -33,14 +32,14 @@ class TooltipChart extends PureComponent {
               <div className={styles.legend}>
                 <span
                   className={styles.labelDot}
-                  style={{ backgroundColor: config.theme[y.dataKey].fill }}
+                  style={{ backgroundColor: config.theme[y.dataKey].stroke }}
                 />
                 <p className={styles.labelName}>
                   {config.tooltip[y.dataKey].label}
                 </p>
               </div>
               <p className={styles.labelValue}>
-                {y.payload ? format('.3s')(y.payload[y.dataKey]) : ''}
+                {y.payload ? `${format('.3s')(y.payload[y.dataKey])}t` : ''}
               </p>
             </div>
           ))}
@@ -51,7 +50,8 @@ class TooltipChart extends PureComponent {
 
 TooltipChart.propTypes = {
   content: Proptypes.object,
-  config: Proptypes.object
+  config: Proptypes.object,
+  showTotal: Proptypes.bool
 };
 
 export default TooltipChart;

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -30,10 +30,7 @@ class TooltipChart extends PureComponent {
           content.payload.map(
             y =>
               (y.payload ? (
-                <div
-                  key={`${y.dataKey}-${y.payload[y.dataKey]}`}
-                  className={styles.label}
-                >
+                <div key={`${y.dataKey}`} className={styles.label}>
                   <div className={styles.legend}>
                     <span
                       className={styles.labelDot}

--- a/app/javascript/app/components/dropdown/dropdown-styles.scss
+++ b/app/javascript/app/components/dropdown/dropdown-styles.scss
@@ -17,6 +17,7 @@
   height: 45px;
   border-radius: 4px;
   position: relative;
+  z-index: 10;
 
   .Select-control {
     height: 100%;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
@@ -26,7 +26,8 @@ const fetchGhgEmissionsMeta = createThunkAction(
               dataParsed[key] = data[key].map(item => {
                 let newItem = {
                   value: item.id,
-                  label: upperFirst(item.name)
+                  label:
+                    key === 'locations' ? item.iso_code3 : upperFirst(item.name)
                 };
                 if (key === 'data_sources') {
                   newItem = {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
@@ -31,6 +31,12 @@ const fetchGhgEmissionsMeta = createThunkAction(
                       ? item.wri_standard_name
                       : upperFirst(item.name)
                 };
+                if (key === 'location') {
+                  newItem = {
+                    ...newItem,
+                    iso: item.iso_code3
+                  };
+                }
                 if (key === 'data_source') {
                   newItem = {
                     ...newItem,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
@@ -23,23 +23,21 @@ const fetchGhgEmissionsMeta = createThunkAction(
           if (data) {
             const dataParsed = {};
             Object.keys(data).forEach(key => {
-              if (key === 'data_sources') {
-                dataParsed[key] = data[key].map(item => {
-                  let newitem = {
-                    value: item.id,
-                    label: upperFirst(item.name)
+              dataParsed[key] = data[key].map(item => {
+                let newItem = {
+                  value: item.id,
+                  label: upperFirst(item.name)
+                };
+                if (key === 'data_sources') {
+                  newItem = {
+                    ...newItem,
+                    location: item.location_ids,
+                    sector: item.sector_ids,
+                    gas: item.gas_ids
                   };
-                  if (key === 'data_sources') {
-                    newitem = {
-                      ...item,
-                      location: item.location_ids,
-                      sector: item.sector_ids,
-                      gas: item.gas_ids
-                    };
-                  }
-                  return newitem;
-                });
-              }
+                }
+                return newItem;
+              });
             }, this);
             dispatch(fetchGhgEmissionsMetaReady(dataParsed));
           } else {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
@@ -23,10 +23,23 @@ const fetchGhgEmissionsMeta = createThunkAction(
           if (data) {
             const dataParsed = {};
             Object.keys(data).forEach(key => {
-              dataParsed[key] = data[key].map(item => ({
-                value: item.id,
-                label: upperFirst(item.name)
-              }));
+              if (key === 'data_sources') {
+                dataParsed[key] = data[key].map(item => {
+                  let newitem = {
+                    value: item.id,
+                    label: upperFirst(item.name)
+                  };
+                  if (key === 'data_sources') {
+                    newitem = {
+                      ...item,
+                      location: item.location_ids,
+                      sector: item.sector_ids,
+                      gas: item.gas_ids
+                    };
+                  }
+                  return newitem;
+                });
+              }
             }, this);
             dispatch(fetchGhgEmissionsMetaReady(dataParsed));
           } else {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-actions.js
@@ -27,14 +27,17 @@ const fetchGhgEmissionsMeta = createThunkAction(
                 let newItem = {
                   value: item.id,
                   label:
-                    key === 'locations' ? item.iso_code3 : upperFirst(item.name)
+                    key === 'location'
+                      ? item.wri_standard_name
+                      : upperFirst(item.name)
                 };
-                if (key === 'data_sources') {
+                if (key === 'data_source') {
                   newItem = {
                     ...newItem,
                     location: item.location_ids,
                     sector: item.sector_ids,
-                    gas: item.gas_ids
+                    gas: item.gas_ids,
+                    gwp: item.gwp_ids
                   };
                 }
                 return newItem;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -21,31 +21,13 @@ class GhgEmissions extends PureComponent {
       breakSelected,
       handleBreakByChange,
       filters,
-      filterSelected,
+      filtersSelected,
       handleFilterChange
     } = this.props;
     return (
       <div>
-        <h2
-          className={styles.title}
-        >{`Global Historical Emissions - ${filterSelected.label}`}</h2>
+        <h2 className={styles.title}>Global Historical Emissions</h2>
         <RegionsProvider />
-        <ChartStackedArea config={config} data={data} />
-        <div className={styles.tags}>
-          {config.columns.y &&
-            config.columns.y.map(column => (
-              <Tag
-                key={column.value}
-                data={{
-                  color: 'red',
-                  name: column.label
-                }}
-                onRemove={() => {
-                  console.info('please remove me');
-                }}
-              />
-            ))}
-        </div>
         <div className={styles.col4}>
           <Dropdown
             label="Category"
@@ -65,10 +47,27 @@ class GhgEmissions extends PureComponent {
             label={breakSelected.label}
             options={filters}
             onChange={handleFilterChange}
-            value={filterSelected}
+            value={filtersSelected}
             clearable={false}
+            multi
           />
           <ButtonGroup className={styles.colEnd} />
+        </div>
+        <ChartStackedArea config={config} data={data} />
+        <div className={styles.tags}>
+          {config.columns.y &&
+            config.columns.y.map(column => (
+              <Tag
+                key={column.value}
+                data={{
+                  color: 'red',
+                  name: column.label
+                }}
+                onRemove={() => {
+                  console.info('please remove me');
+                }}
+              />
+            ))}
         </div>
       </div>
     );
@@ -85,7 +84,7 @@ GhgEmissions.propTypes = {
   breakSelected: PropTypes.object.isRequired,
   handleBreakByChange: PropTypes.func.isRequired,
   filters: PropTypes.array.isRequired,
-  filterSelected: PropTypes.object.isRequired,
+  filtersSelected: PropTypes.array.isRequired,
   handleFilterChange: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import RegionsProvider from 'providers/regions-provider';
-import ChartStackedArea from 'components/charts/stacked-area';
+import ChartLine from 'components/charts/line';
 import Dropdown from 'components/dropdown';
 import ButtonGroup from 'components/button-group';
 import Tag from 'components/tag';
@@ -22,7 +22,8 @@ class GhgEmissions extends PureComponent {
       handleBreakByChange,
       filters,
       filtersSelected,
-      handleFilterChange
+      handleFilterChange,
+      colors
     } = this.props;
     return (
       <div>
@@ -30,7 +31,7 @@ class GhgEmissions extends PureComponent {
         <RegionsProvider />
         <div className={styles.col4}>
           <Dropdown
-            label="Category"
+            label="Source"
             options={sources}
             onChange={handleSourceChange}
             value={sourceSelected}
@@ -53,15 +54,16 @@ class GhgEmissions extends PureComponent {
           />
           <ButtonGroup className={styles.colEnd} />
         </div>
-        <ChartStackedArea config={config} data={data} />
+        <ChartLine config={config} data={data} />
         <div className={styles.tags}>
-          {config.columns.y &&
-            config.columns.y.map(column => (
+          {filtersSelected &&
+            filtersSelected.map((filter, index) => (
               <Tag
-                key={column.value}
+                className={styles.tag}
+                key={`tag-${filter.value}`}
                 data={{
-                  color: 'red',
-                  name: column.label
+                  color: colors[index],
+                  name: filter.label
                 }}
                 onRemove={() => {
                   console.info('please remove me');
@@ -85,7 +87,8 @@ GhgEmissions.propTypes = {
   handleBreakByChange: PropTypes.func.isRequired,
   filters: PropTypes.array.isRequired,
   filtersSelected: PropTypes.array.isRequired,
-  handleFilterChange: PropTypes.func.isRequired
+  handleFilterChange: PropTypes.func.isRequired,
+  colors: PropTypes.array
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -17,6 +17,9 @@ class GhgEmissions extends PureComponent {
       sources,
       sourceSelected,
       handleSourceChange,
+      versions,
+      versionSelected,
+      handleVersionChange,
       breaksBy,
       breakSelected,
       handleBreakByChange,
@@ -38,6 +41,14 @@ class GhgEmissions extends PureComponent {
             clearable={false}
           />
           <Dropdown
+            label="IPCCVersion"
+            options={versions}
+            onChange={handleVersionChange}
+            value={versionSelected}
+            clearable={false}
+            disabled={versions.length === 1}
+          />
+          <Dropdown
             label="BreakBy"
             options={breaksBy}
             onChange={handleBreakByChange}
@@ -56,22 +67,19 @@ class GhgEmissions extends PureComponent {
         </div>
         <ChartLine config={config} data={data} />
         <div className={styles.tags}>
-          {filtersSelected &&
-            filtersSelected.map(
-              filter =>
-                (config.theme[filter.column] ? (
-                  <Tag
-                    className={styles.tag}
-                    key={`${filter.value}`}
-                    data={{
-                      color: config.theme[filter.column].stroke,
-                      label: filter.label,
-                      id: filter.value
-                    }}
-                    onRemove={handleRemoveTag}
-                  />
-                ) : null)
-            )}
+          {config.columns &&
+            config.columns.y.map(column => (
+              <Tag
+                className={styles.tag}
+                key={`${column.label}`}
+                data={{
+                  color: config.theme[column.value].stroke,
+                  label: column.label,
+                  id: column.value
+                }}
+                onRemove={handleRemoveTag}
+              />
+            ))}
         </div>
       </div>
     );
@@ -81,6 +89,9 @@ class GhgEmissions extends PureComponent {
 GhgEmissions.propTypes = {
   data: PropTypes.array.isRequired,
   config: PropTypes.object.isRequired,
+  versions: PropTypes.array.isRequired,
+  versionSelected: PropTypes.object.isRequired,
+  handleVersionChange: PropTypes.func.isRequired,
   sources: PropTypes.array.isRequired,
   sourceSelected: PropTypes.object.isRequired,
   handleSourceChange: PropTypes.func.isRequired,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -41,7 +41,7 @@ class GhgEmissions extends PureComponent {
             clearable={false}
           />
           <Dropdown
-            label="IPCCVersion"
+            label="IPCC Version"
             options={versions}
             onChange={handleVersionChange}
             value={versionSelected}
@@ -71,7 +71,7 @@ class GhgEmissions extends PureComponent {
             config.columns.y.map(column => (
               <Tag
                 className={styles.tag}
-                key={`${column.label}`}
+                key={`${column.value}`}
                 data={{
                   color: config.theme[column.value].stroke,
                   label: column.label,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -23,7 +23,7 @@ class GhgEmissions extends PureComponent {
       filters,
       filtersSelected,
       handleFilterChange,
-      colors
+      handleRemoveTag
     } = this.props;
     return (
       <div>
@@ -57,19 +57,21 @@ class GhgEmissions extends PureComponent {
         <ChartLine config={config} data={data} />
         <div className={styles.tags}>
           {filtersSelected &&
-            filtersSelected.map((filter, index) => (
-              <Tag
-                className={styles.tag}
-                key={`tag-${filter.value}`}
-                data={{
-                  color: colors[index],
-                  name: filter.label
-                }}
-                onRemove={() => {
-                  console.info('please remove me');
-                }}
-              />
-            ))}
+            filtersSelected.map(
+              filter =>
+                (config.theme[filter.column] ? (
+                  <Tag
+                    className={styles.tag}
+                    key={`${filter.value}`}
+                    data={{
+                      color: config.theme[filter.column].stroke,
+                      label: filter.label,
+                      id: filter.value
+                    }}
+                    onRemove={handleRemoveTag}
+                  />
+                ) : null)
+            )}
         </div>
       </div>
     );
@@ -85,10 +87,10 @@ GhgEmissions.propTypes = {
   breaksBy: PropTypes.array.isRequired,
   breakSelected: PropTypes.object.isRequired,
   handleBreakByChange: PropTypes.func.isRequired,
+  handleRemoveTag: PropTypes.func.isRequired,
   filters: PropTypes.array.isRequired,
   filtersSelected: PropTypes.array.isRequired,
-  handleFilterChange: PropTypes.func.isRequired,
-  colors: PropTypes.array
+  handleFilterChange: PropTypes.func.isRequired
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -17,8 +17,6 @@ const getData = state =>
   (state.data ? state.data.filter(d => d.gwp === 'AR2') : []);
 
 // constants needed for data parsing
-const DATA_LIMIT = 10;
-
 const colors = [
   '#2D9290',
   '#B25BD0',
@@ -160,16 +158,14 @@ export const getFiltersSelected = createSelector(
       const selectedValues = selected
         ? selected.split(',')
         : sortedFilters.map(filter => filter.value);
-      selectedValues.forEach((filter, index) => {
-        if (index < DATA_LIMIT) {
-          const filterData = sortedFilters.find(
-            filterOption => filterOption.value === parseInt(filter, 10)
-          );
-          selectedFilters.push({
-            ...filterData,
-            column: getYColumnValue(filterData.label)
-          });
-        }
+      selectedValues.forEach(filter => {
+        const filterData = sortedFilters.find(
+          filterOption => filterOption.value === parseInt(filter, 10)
+        );
+        selectedFilters.push({
+          ...filterData,
+          column: getYColumnValue(filterData.label)
+        });
       });
       return selectedFilters;
     }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -184,7 +184,6 @@ export const getChartData = createSelector(
     const dataParsed = xValues.map(x => {
       const yItems = {};
       data.forEach(d => {
-        // console.log(d);
         if (activeFiltersLabels.indexOf(d[breakBy.value]) > -1) {
           const yKey = getYColumnValue(d[breakBy.value]);
           const yData = d.emissions.find(e => e.year === x);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -11,6 +11,19 @@ const getBreakSelection = state => state.search.breakBy || null;
 const getFilterSelection = state => state.search.filter || null;
 const getMetaFiltered = meta => omit(meta, 'data_source');
 
+const lineColors = [
+  '#2D9290',
+  '#B25BD0',
+  '#7EA759',
+  '#FF0D3A',
+  '#687AB7',
+  '#BC6332',
+  '#F97DA1',
+  '#00971D',
+  '#F1933B',
+  '#938126'
+];
+
 const parseRegions = regions =>
   regions.map(region => ({
     label: region.wri_standard_name,
@@ -103,7 +116,7 @@ export const getFiltersSelected = createSelector(
         });
         return selectedFilters;
       }
-      return [filters[0]];
+      return filters;
     }
     return [];
   }
@@ -122,7 +135,7 @@ export const getChartData = createSelector(
       data.forEach(d => {
         const yKey = getYColumnValue(d[breakBy.value]);
         const yData = d.emissions.find(e => e.year === x);
-        yItems[yKey] = yData.value;
+        yItems[yKey] = yData.value * 1000000;
       });
       const item = {
         x,
@@ -143,15 +156,18 @@ const axesConfig = {
   },
   yLeft: {
     name: 'Emissions',
-    unit: 'MtCO2e',
+    unit: 'CO2e',
     format: 'number'
   }
 };
 
 function getThemeConfig(columns) {
   const theme = {};
-  columns.forEach(column => {
-    theme[column.value] = { fill: '#302463' };
+  columns.forEach((column, index) => {
+    theme[column.value] = {
+      stroke: lineColors[index],
+      strokeWidth: 5
+    };
   });
   return theme;
 }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import uniqBy from 'lodash/uniqBy';
 import {
   getYColumnValue,
   getThemeConfig,
@@ -207,15 +208,16 @@ export const getChartConfig = createSelector(
       label: d[breakBy.value],
       value: getYColumnValue(d[breakBy.value])
     }));
-    const theme = getThemeConfig(yColumns, COLORS);
-    const tooltip = getTooltipConfig(yColumns);
+    const yColumnsChecked = uniqBy(yColumns, 'value');
+    const theme = getThemeConfig(yColumnsChecked, COLORS);
+    const tooltip = getTooltipConfig(yColumnsChecked);
     return {
       axes: AXES_CONFIG,
       theme,
       tooltip,
       columns: {
         x: [{ label: 'year', value: 'x' }],
-        y: yColumns
+        y: yColumnsChecked
       }
     };
   }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -170,8 +170,7 @@ export const filterData = createSelector(
   [getData, getVersionSelected, getFiltersSelected, getBreakSelected],
   (data, version, filters, breakBy) => {
     if (!data || !data.length || !filters || !filters.length) return [];
-    const filterKey = breakBy.value === 'location' ? 'iso' : 'label';
-    const filterValues = filters.map(filter => filter[filterKey]);
+    const filterValues = filters.map(filter => filter.label);
     return data.filter(
       d =>
         d.gwp === version.label && filterValues.indexOf(d[breakBy.value]) > -1

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -88,17 +88,24 @@ export const getFilterOptions = createSelector(
   (breakSelected, filters) => filters[breakSelected.value] || []
 );
 
-export const getFilterSelected = createSelector(
+export const getFiltersSelected = createSelector(
   [getFilterOptions, getFilterSelection],
   (filters, selected) => {
     if (filters.length > 0) {
       if (selected) {
-        const filtered = filters.filter(filter => filter.value == selected); // eslint-disable-line eqeqeq
-        return filtered.length > 0 ? filtered[0] : filters[0];
+        const selectedFilters = [];
+        selected.split(',').forEach(filter => {
+          selectedFilters.push(
+            filters.find(
+              filterOption => filterOption.value === parseInt(filter, 10)
+            )
+          );
+        });
+        return selectedFilters;
       }
-      return filters[0];
+      return [filters[0]];
     }
-    return {};
+    return [];
   }
 );
 
@@ -188,5 +195,5 @@ export default {
   getBreaksByOptions,
   getBreakSelected,
   getFilterOptions,
-  getFilterSelected
+  getFiltersSelected
 };

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -3,7 +3,7 @@
 .col4 {
   @extend %grid;
 
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   align-items: end;
   margin-bottom: 40px;
 }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -21,6 +21,13 @@
 }
 
 .tags {
+  display: flex;
+  flex-wrap: wrap;
   margin-top: 10px;
   margin-bottom: 15px;
+}
+
+.tag {
+  margin-right: 10px;
+  margin-bottom: 10px;
 }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-utils.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-utils.js
@@ -1,0 +1,36 @@
+import upperFirst from 'lodash/upperFirst';
+import camelCase from 'lodash/camelCase';
+
+export const parseRegions = regions =>
+  regions.map(region => ({
+    label: region.wri_standard_name,
+    value: region.iso_code3
+  }));
+
+export const sortLabelByAlpha = array =>
+  array.sort((a, b) => {
+    if (a.label < b.label) return -1;
+    if (a.label > b.label) return 1;
+    return 0;
+  });
+
+export const getYColumnValue = column => `y${upperFirst(camelCase(column))}`;
+
+export const getThemeConfig = (columns, colors) => {
+  const theme = {};
+  columns.forEach((column, index) => {
+    theme[column.value] = {
+      stroke: colors[index % 10],
+      strokeWidth: 5
+    };
+  });
+  return theme;
+};
+
+export const getTooltipConfig = columns => {
+  const tooltip = {};
+  columns.forEach(column => {
+    tooltip[column.value] = { label: column.label };
+  });
+  return tooltip;
+};

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -20,6 +20,19 @@ import {
 import GhgEmissionsComponent from './ghg-emissions-component';
 import actions from './ghg-emissions-actions';
 
+const lineColors = [
+  '#2D9290',
+  '#B25BD0',
+  '#7EA759',
+  '#FF0D3A',
+  '#687AB7',
+  '#BC6332',
+  '#F97DA1',
+  '#00971D',
+  '#F1933B',
+  '#938126'
+];
+
 const mapStateToProps = (state, { location }) => {
   const { meta, data } = state.ghgEmissions;
   const { data: regions } = state.regions;
@@ -38,7 +51,8 @@ const mapStateToProps = (state, { location }) => {
     breaksBy: getBreaksByOptions(ghg),
     breakSelected: getBreakSelected(ghg),
     filters: getFilterOptions(ghg),
-    filtersSelected: getFiltersSelected(ghg)
+    filtersSelected: getFiltersSelected(ghg),
+    colors: lineColors
   };
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -97,11 +97,11 @@ class GhgEmissionsContainer extends PureComponent {
   }
 
   handleSourceChange = category => {
-    this.updateUrlParam({ name: 'source', value: category.value });
+    this.updateUrlParam({ name: 'source', value: category.value, clear: true });
   };
 
   handleBreakByChange = breakBy => {
-    this.updateUrlParam({ name: 'breakBy', value: breakBy.value });
+    this.updateUrlParam({ name: 'breakBy', value: breakBy.value, clear: true });
   };
 
   handleVersionChange = version => {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import isEqual from 'lodash/isEqual';
 
 import {
   getChartData,
@@ -13,7 +14,7 @@ import {
   getBreaksByOptions,
   getBreakSelected,
   getFilterOptions,
-  getFilterSelected
+  getFiltersSelected
 } from './ghg-emissions-selectors';
 
 import GhgEmissionsComponent from './ghg-emissions-component';
@@ -37,23 +38,23 @@ const mapStateToProps = (state, { location }) => {
     breaksBy: getBreaksByOptions(ghg),
     breakSelected: getBreakSelected(ghg),
     filters: getFilterOptions(ghg),
-    filterSelected: getFilterSelected(ghg)
+    filtersSelected: getFiltersSelected(ghg)
   };
 };
 
 function needsRequestData(props, nextProps) {
-  const { sourceSelected, breakSelected, filterSelected } = nextProps;
+  const { sourceSelected, breakSelected, filtersSelected } = nextProps;
   const hasValues =
-    sourceSelected.value && breakSelected.value && filterSelected.value;
+    sourceSelected.value && breakSelected.value && filtersSelected;
   const hasChanged =
     sourceSelected.value !== props.sourceSelected.value ||
     breakSelected.value !== props.breakSelected.value ||
-    filterSelected.value !== props.filterSelected.value;
+    !isEqual(filtersSelected, props.filtersSelected);
   return hasValues && hasChanged;
 }
 
 function getFiltersParsed(props) {
-  const { sourceSelected, breakSelected, filterSelected } = props;
+  const { sourceSelected, breakSelected, filtersSelected } = props;
   const filter = {};
   // we need to request default value for other indicators
   switch (breakSelected.value) {
@@ -75,7 +76,7 @@ function getFiltersParsed(props) {
   return {
     ...filter,
     source: sourceSelected.value,
-    [breakSelected.value]: filterSelected.value
+    [breakSelected.value]: filtersSelected.value
   };
 }
 
@@ -101,8 +102,9 @@ class GhgEmissionsContainer extends PureComponent {
     this.updateUrlParam({ name: 'breakBy', value: breakBy.value });
   };
 
-  handleFilterChange = filter => {
-    this.updateUrlParam({ name: 'filter', value: filter.value });
+  handleFilterChange = filters => {
+    const filtersParam = filters.map(filter => filter.value);
+    this.updateUrlParam({ name: 'filter', value: filtersParam.toString() });
   };
 
   updateUrlParam(param) {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
-import isEqual from 'lodash/isEqual';
 
 import {
   getChartData,
@@ -48,8 +47,7 @@ function needsRequestData(props, nextProps) {
     sourceSelected.value && breakSelected.value && filtersSelected;
   const hasChanged =
     sourceSelected.value !== props.sourceSelected.value ||
-    breakSelected.value !== props.breakSelected.value ||
-    !isEqual(filtersSelected, props.filtersSelected);
+    breakSelected.value !== props.breakSelected.value;
   return hasValues && hasChanged;
 }
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import isEqual from 'lodash/isEqual';
 
 import {
   getChartData,
@@ -47,7 +48,8 @@ function needsRequestData(props, nextProps) {
     sourceSelected.value && breakSelected.value && filtersSelected;
   const hasChanged =
     sourceSelected.value !== props.sourceSelected.value ||
-    breakSelected.value !== props.breakSelected.value;
+    breakSelected.value !== props.breakSelected.value ||
+    !isEqual(filtersSelected.value, props.filtersSelected.value);
   return hasValues && hasChanged;
 }
 
@@ -63,6 +65,7 @@ function getFiltersParsed(props) {
     case 'location':
       filter.gas = 1;
       filter.sector = 1;
+      filter.location = 'WORLD';
       break;
     case 'sector':
       filter.gas = 1;
@@ -71,10 +74,13 @@ function getFiltersParsed(props) {
     default:
       break;
   }
+  const filtersSelectedValues = filtersSelected.map(
+    d => (breakSelected.value === 'location' ? d.label : d.value)
+  );
   return {
     ...filter,
     source: sourceSelected.value,
-    [breakSelected.value]: filtersSelected.value
+    [breakSelected.value]: filtersSelectedValues.toString()
   };
 }
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
-import isEqual from 'lodash/isEqual';
 
 import {
   getChartData,
@@ -52,50 +51,26 @@ function needsRequestData(props, nextProps) {
     sourceSelected.value && breakSelected.value && filtersSelected;
   const hasChanged =
     sourceSelected.value !== props.sourceSelected.value ||
-    breakSelected.value !== props.breakSelected.value ||
-    !isEqual(filtersSelected.value, props.filtersSelected.value);
+    breakSelected.value !== props.breakSelected.value;
   return hasValues && hasChanged;
 }
 
-const TOP_EMITTERS = [
-  'CHN',
-  'USA',
-  'EU28',
-  'IND',
-  'RUS',
-  'JPN',
-  'BRA',
-  'IDN',
-  'CAN',
-  'MEX'
-];
-
 function getFiltersParsed(props) {
-  const { sourceSelected, breakSelected, filtersSelected, location } = props;
-  const search = qs.parse(location.search);
+  const { sourceSelected, breakSelected } = props;
   const filter = {};
-  // we need to request default value for other indicators
-  const filtersSelectedValues = filtersSelected.map(
-    d => (breakSelected.value === 'location' ? d.label : d.value)
-  );
 
   switch (breakSelected.value) {
     case 'gas':
       filter.location = 'WORLD';
       filter.sector = 1;
-      filter.gas = filtersSelectedValues.toString();
       break;
     case 'location':
       filter.gas = 1;
       filter.sector = 1;
-      filter.location = search.filter
-        ? filtersSelectedValues.toString()
-        : TOP_EMITTERS.toString();
       break;
     case 'sector':
       filter.gas = 1;
       filter.location = 'WORLD';
-      filter.sector = filtersSelectedValues.toString();
       break;
     default:
       break;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -20,19 +20,6 @@ import {
 import GhgEmissionsComponent from './ghg-emissions-component';
 import actions from './ghg-emissions-actions';
 
-const lineColors = [
-  '#2D9290',
-  '#B25BD0',
-  '#7EA759',
-  '#FF0D3A',
-  '#687AB7',
-  '#BC6332',
-  '#F97DA1',
-  '#00971D',
-  '#F1933B',
-  '#938126'
-];
-
 const mapStateToProps = (state, { location }) => {
   const { meta, data } = state.ghgEmissions;
   const { data: regions } = state.regions;
@@ -51,8 +38,7 @@ const mapStateToProps = (state, { location }) => {
     breaksBy: getBreaksByOptions(ghg),
     breakSelected: getBreakSelected(ghg),
     filters: getFilterOptions(ghg),
-    filtersSelected: getFiltersSelected(ghg),
-    colors: lineColors
+    filtersSelected: getFiltersSelected(ghg)
   };
 };
 
@@ -113,7 +99,7 @@ class GhgEmissionsContainer extends PureComponent {
   };
 
   handleBreakByChange = breakBy => {
-    this.updateUrlParam({ name: 'breakBy', value: breakBy.value });
+    this.updateUrlParam({ name: 'breakBy', value: breakBy.value, clear: true });
   };
 
   handleFilterChange = filters => {
@@ -126,12 +112,24 @@ class GhgEmissionsContainer extends PureComponent {
     history.replace(getLocationParamUpdated(location, param));
   }
 
+  handleRemoveTag = tagData => {
+    const { filtersSelected } = this.props;
+    const newFilters = [];
+    filtersSelected.forEach(filter => {
+      if (filter.label !== tagData.label) {
+        newFilters.push(filter.value);
+      }
+    });
+    this.updateUrlParam({ name: 'filter', value: newFilters.toString() });
+  };
+
   render() {
     return createElement(GhgEmissionsComponent, {
       ...this.props,
       handleSourceChange: this.handleSourceChange,
       handleBreakByChange: this.handleBreakByChange,
-      handleFilterChange: this.handleFilterChange
+      handleFilterChange: this.handleFilterChange,
+      handleRemoveTag: this.handleRemoveTag
     });
   }
 }
@@ -140,7 +138,8 @@ GhgEmissionsContainer.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   fetchGhgEmissionsMeta: PropTypes.func.isRequired,
-  fetchGhgEmissionsData: PropTypes.func.isRequired
+  fetchGhgEmissionsData: PropTypes.func.isRequired,
+  filtersSelected: PropTypes.array
 };
 
 export { default as component } from './ghg-emissions-component';

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -53,34 +53,53 @@ function needsRequestData(props, nextProps) {
   return hasValues && hasChanged;
 }
 
+const TOP_EMITTERS = [
+  'CHN',
+  'USA',
+  'EU28',
+  'IND',
+  'RUS',
+  'JPN',
+  'BRA',
+  'IDN',
+  'CAN',
+  'MEX'
+];
+
 function getFiltersParsed(props) {
-  const { sourceSelected, breakSelected, filtersSelected } = props;
+  const { sourceSelected, breakSelected, filtersSelected, location } = props;
+  const search = qs.parse(location.search);
   const filter = {};
   // we need to request default value for other indicators
+  const filtersSelectedValues = filtersSelected.map(
+    d => (breakSelected.value === 'location' ? d.label : d.value)
+  );
+
   switch (breakSelected.value) {
     case 'gas':
       filter.location = 'WORLD';
       filter.sector = 1;
+      filter.gas = filtersSelectedValues.toString();
       break;
     case 'location':
       filter.gas = 1;
       filter.sector = 1;
-      filter.location = 'WORLD';
+      filter.location = search.filter
+        ? filtersSelectedValues.toString()
+        : TOP_EMITTERS.toString();
       break;
     case 'sector':
       filter.gas = 1;
       filter.location = 'WORLD';
+      filter.sector = filtersSelectedValues.toString();
       break;
     default:
       break;
   }
-  const filtersSelectedValues = filtersSelected.map(
-    d => (breakSelected.value === 'location' ? d.label : d.value)
-  );
+
   return {
     ...filter,
-    source: sourceSelected.value,
-    [breakSelected.value]: filtersSelectedValues.toString()
+    source: sourceSelected.value
   };
 }
 
@@ -99,11 +118,11 @@ class GhgEmissionsContainer extends PureComponent {
   }
 
   handleSourceChange = category => {
-    this.updateUrlParam({ name: 'source', value: category.value, clear: true });
+    this.updateUrlParam({ name: 'source', value: category.value });
   };
 
   handleBreakByChange = breakBy => {
-    this.updateUrlParam({ name: 'breakBy', value: breakBy.value, clear: true });
+    this.updateUrlParam({ name: 'breakBy', value: breakBy.value });
   };
 
   handleFilterChange = filters => {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -97,20 +97,26 @@ class GhgEmissionsContainer extends PureComponent {
   }
 
   handleSourceChange = category => {
-    this.updateUrlParam({ name: 'source', value: category.value, clear: true });
+    this.updateUrlParam([{ name: 'source', value: category.value }], true);
   };
 
   handleBreakByChange = breakBy => {
-    this.updateUrlParam({ name: 'breakBy', value: breakBy.value, clear: true });
+    this.updateUrlParam(
+      [
+        { name: 'breakBy', value: breakBy.value },
+        { name: 'filter', value: '' }
+      ],
+      true
+    );
   };
 
   handleVersionChange = version => {
-    this.updateUrlParam({ name: 'version', value: version.value });
+    this.updateUrlParam([{ name: 'version', value: version.value }]);
   };
 
   handleFilterChange = filters => {
     const filtersParam = filters.map(filter => filter.value);
-    this.updateUrlParam({ name: 'filter', value: filtersParam.toString() });
+    this.updateUrlParam([{ name: 'filter', value: filtersParam.toString() }]);
   };
 
   updateUrlParam(param) {
@@ -126,7 +132,7 @@ class GhgEmissionsContainer extends PureComponent {
         newFilters.push(filter.value);
       }
     });
-    this.updateUrlParam({ name: 'filter', value: newFilters.toString() });
+    this.updateUrlParam([{ name: 'filter', value: newFilters.toString() }]);
   };
 
   render() {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -11,6 +11,8 @@ import {
   getChartConfig,
   getSourceOptions,
   getSourceSelected,
+  getVersionOptions,
+  getVersionSelected,
   getBreaksByOptions,
   getBreakSelected,
   getFilterOptions,
@@ -35,6 +37,8 @@ const mapStateToProps = (state, { location }) => {
     config: getChartConfig(ghg),
     sources: getSourceOptions(ghg),
     sourceSelected: getSourceSelected(ghg),
+    versions: getVersionOptions(ghg),
+    versionSelected: getVersionSelected(ghg),
     breaksBy: getBreaksByOptions(ghg),
     breakSelected: getBreakSelected(ghg),
     filters: getFilterOptions(ghg),
@@ -125,6 +129,10 @@ class GhgEmissionsContainer extends PureComponent {
     this.updateUrlParam({ name: 'breakBy', value: breakBy.value });
   };
 
+  handleVersionChange = version => {
+    this.updateUrlParam({ name: 'version', value: version.value });
+  };
+
   handleFilterChange = filters => {
     const filtersParam = filters.map(filter => filter.value);
     this.updateUrlParam({ name: 'filter', value: filtersParam.toString() });
@@ -150,6 +158,7 @@ class GhgEmissionsContainer extends PureComponent {
     return createElement(GhgEmissionsComponent, {
       ...this.props,
       handleSourceChange: this.handleSourceChange,
+      handleVersionChange: this.handleVersionChange,
       handleBreakByChange: this.handleBreakByChange,
       handleFilterChange: this.handleFilterChange,
       handleRemoveTag: this.handleRemoveTag

--- a/app/javascript/app/components/tag/tag-component.jsx
+++ b/app/javascript/app/components/tag/tag-component.jsx
@@ -12,8 +12,8 @@ class Tag extends PureComponent {
     return (
       <div className={cx(styles.tag, className)}>
         <span className={styles.dot} style={{ backgroundColor: data.color }} />
-        <p>{data.name}</p>
-        <button className={styles.closeButton} onClick={onRemove}>
+        <p>{data.label}</p>
+        <button className={styles.closeButton} onClick={() => onRemove(data)}>
           <Icon icon={closeIcon} className={styles.icon} />
         </button>
       </div>

--- a/app/javascript/app/components/tag/tag-component.jsx
+++ b/app/javascript/app/components/tag/tag-component.jsx
@@ -1,15 +1,16 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import Icon from 'components/icon';
+import cx from 'classnames';
 
 import closeIcon from 'assets/icons/legend-close.svg';
 import styles from './tag-styles.scss';
 
 class Tag extends PureComponent {
   render() {
-    const { data, onRemove } = this.props;
+    const { data, onRemove, className } = this.props;
     return (
-      <div className={styles.tag}>
+      <div className={cx(styles.tag, className)}>
         <span className={styles.dot} style={{ backgroundColor: data.color }} />
         <p>{data.name}</p>
         <button className={styles.closeButton} onClick={onRemove}>
@@ -22,7 +23,8 @@ class Tag extends PureComponent {
 
 Tag.propTypes = {
   data: Proptypes.object,
-  onRemove: Proptypes.func
+  onRemove: Proptypes.func,
+  className: Proptypes.string
 };
 
 export default Tag;

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -1,15 +1,16 @@
 import qs from 'query-string';
 
-export function getLocationParamUpdated(
-  location,
-  { name, value, clear = false }
-) {
+export function getLocationParamUpdated(location, params, clear) {
   const search = qs.parse(location.search);
+  const newFilters = {};
+  params.forEach(param => {
+    newFilters[param.name] = param.value;
+  });
   const newSearch = clear
-    ? { [name]: value }
+    ? { ...newFilters }
     : {
       ...search,
-      [name]: value
+      ...newFilters
     };
   return {
     pathname: location.pathname,

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -10,7 +10,7 @@ module Api
         attribute :gwp
 
         def location
-          object.location.iso_code3
+          object.location.wri_standard_name
         end
 
         def gas


### PR DESCRIPTION
This is mixed PR, covering the implementation of rendering the fetched data from the API into the GHG emissions graph. 
- Add a new selector for navigating between the version of the data (IPCC, ```gwp```)
- Fetch and parse correct data based on updated selectors (now all data for each break value is fetched and then filtered in the selector (see filterData selector)
- Function within selectors file are now held in ./...-utils to make life easier for us all
- Add a default "TOP_EMITTERS" constant to the selectors for 'location' to allow for setting limit in initial countries
- Abstract the parsing of the data for the graph to a single filter point => this allows for the graph to render independently of the selectors so that the legend and graph operate as true components.
- Change the graph to a line chart, keeping the StackedArea component for later :).

![sep-28-2017 19-02-35](https://user-images.githubusercontent.com/20288774/30979969-a8645c3e-a47f-11e7-9595-8e309e49941e.gif)

Other:
- Small changes to the config for the graph: domain of axes, formatting of the tooltip value and 

Note: the endpoint for /emissions/meta has changed structure. As a result there is a big difference in the selectors for the data

TODO: 
- Fix bug with duplicate keys in legend/tooltip
- Sort the order of Legend, Tooltip, Selector
- Limit the amount of data that cant be selected into the graph giving the user feedback
- Add a checkbox multi-select to the Filters dropdown
- Styles