### PR TITLE
Enforce usage of filter parameters

### DIFF
--- a/app/controllers/api/v1/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/historical_emissions_controller.rb
@@ -12,6 +12,14 @@ module Api
 
     class HistoricalEmissionsController < ApiController
       def index
+        unless valid_params(params)
+          render json: {
+            status: :bad_request,
+            error: 'Please specify `source` and at least one of `location`,'\
+                   '`sector` or `gas`'
+          }, status: :bad_request and return
+        end
+
         render json: ::HistoricalEmissions::Record.find_by_params(params),
                each_serializer: Api::V1::HistoricalEmissions::RecordSerializer,
                params: params
@@ -31,6 +39,12 @@ module Api
       end
 
       private
+
+      def valid_params(params)
+        params[:source] && (
+          params[:location] || params[:sector] || params[:gas]
+        )
+      end
 
       def grouped_records
         ::HistoricalEmissions::Record.

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -3,18 +3,42 @@ require 'rails_helper'
 describe Api::V1::HistoricalEmissionsController, type: :controller do
   context do
     let!(:some_historical_emissions_records) {
-      FactoryGirl.create_list(:historical_emissions_record, 3)
+      data_source = FactoryGirl.create(:historical_emissions_data_source)
+      sector = FactoryGirl.create(:historical_emissions_sector,
+                                  data_source: data_source)
+      gas = FactoryGirl.create(:historical_emissions_gas)
+      gwp = FactoryGirl.create(:historical_emissions_gwp)
+      FactoryGirl.create_list(
+        :historical_emissions_record,
+        3,
+        data_source: data_source,
+        sector: sector,
+        gas: gas,
+        gwp: gwp
+      )
     }
 
-    describe 'GET index' do
-      it 'returns a successful 200 response' do
-        get :index
+    describe 'GET meta' do
+      it 'returns endpoint metadata' do
+        get :meta
         expect(response).to be_success
+      end
+    end
+
+    describe 'GET index' do
+      it 'query without filter parameters returns 400 response' do
+        get :index
+        expect(response).to have_http_status(:bad_request)
       end
 
       it 'lists all historical emission records' do
-        get :index
+        params = {
+          source: ::HistoricalEmissions::DataSource.first.id,
+          gas: ::HistoricalEmissions::Gas.first.id
+        }
+        get :index, params: params
         parsed_body = JSON.parse(response.body)
+        expect(response).to be_success
         expect(parsed_body.length).to eq(3)
       end
     end


### PR DESCRIPTION
The endpoint will return an http 400 if not enough filters are given.

I've made sure that this is compatible with the current usage of the
endpoint in the historical emissions section, but this can change
in the future