### PR TITLE
Fix hash links in anchor nav

### DIFF
--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -7,7 +7,7 @@ import { HashLink } from 'react-router-hash-link';
 import styles from './anchor-nav-styles.scss';
 
 const AnchorNav = props => {
-  const { links, useRoutes, className, query } = props;
+  const { links, useRoutes, className } = props;
   return (
     <nav className={cx(styles.anchorNav, className)}>
       {links.map(link => {
@@ -16,8 +16,9 @@ const AnchorNav = props => {
           className: styles.link,
           activeClassName: styles.linkActive,
           to: {
-            search: query,
-            pathname: link.path
+            search: link.search,
+            pathname: link.path,
+            hash: link.hash
           }
         };
         if (useRoutes) {
@@ -33,7 +34,6 @@ const AnchorNav = props => {
 };
 
 AnchorNav.propTypes = {
-  query: PropTypes.string,
   links: PropTypes.array,
   useRoutes: PropTypes.bool.isRequired,
   className: PropTypes.string

--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -7,7 +7,7 @@ import { HashLink } from 'react-router-hash-link';
 import styles from './anchor-nav-styles.scss';
 
 const AnchorNav = props => {
-  const { links, useRoutes, className } = props;
+  const { links, useRoutes, className, query } = props;
   return (
     <nav className={cx(styles.anchorNav, className)}>
       {links.map(link => {
@@ -16,7 +16,7 @@ const AnchorNav = props => {
           className: styles.link,
           activeClassName: styles.linkActive,
           to: {
-            search: link.search,
+            search: link.search || query,
             pathname: link.path,
             hash: link.hash
           }
@@ -36,12 +36,14 @@ const AnchorNav = props => {
 AnchorNav.propTypes = {
   links: PropTypes.array,
   useRoutes: PropTypes.bool.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  query: PropTypes.string
 };
 
 AnchorNav.defaultProps = {
   links: [],
-  useRoutes: false
+  useRoutes: false,
+  query: ''
 };
 
 export default AnchorNav;

--- a/app/javascript/app/pages/country/country-selectors.js
+++ b/app/javascript/app/pages/country/country-selectors.js
@@ -29,8 +29,9 @@ export const getAnchorLinks = createSelector(
   (sections, iso) =>
     sections.filter(section => section.anchor).map(section => ({
       label: section.label,
-      path: `/countries/${iso}#${section.hash}`,
-      hash: section.hash
+      path: `/countries/${iso}`,
+      hash: section.hash,
+      search: location.search
     }))
 );
 

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -16,7 +16,8 @@ export function getLocationParamUpdated(location, params = [], clear = false) {
     };
   return {
     pathname: location.pathname,
-    search: qs.stringify(newSearch)
+    search: qs.stringify(newSearch),
+    hash: location.hash
   };
 }
 


### PR DESCRIPTION
We had a problem where when clicking the anchor link it was appending duplicates, and ignoring search queries. Now it doesn't.