### PR TITLE
Add label index field to data model and endpoint

### DIFF
--- a/app/javascript/app/components/footer/footer-component.jsx
+++ b/app/javascript/app/components/footer/footer-component.jsx
@@ -17,17 +17,18 @@ class Footer extends PureComponent {
   render() {
     const { routes } = this.props;
     const { pathname } = this.props.location;
+    const isNdcs = pathname === '/ndcs' || pathname === '/ndcs/table';
     const isHomePage = pathname === '/';
     const isAboutPage = pathname.includes('about');
     const className = cx(
       styles.footer,
-      { [styles.gray]: isHomePage },
+      { [styles.gray]: isHomePage || isNdcs },
       { [styles.border]: isAboutPage }
     );
     return (
       <footer className={className}>
         {!isAboutPage && (
-          <Initiators className={layout.content} gray={isHomePage} />
+          <Initiators className={layout.content} gray={isHomePage || isNdcs} />
         )}
         <div className={cx(layout.content, styles.nav)}>
           <Nav routes={routes} hideLogo hideActive />

--- a/app/javascript/app/components/map-legend/map-legend-component.jsx
+++ b/app/javascript/app/components/map-legend/map-legend-component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { getColorByIndex } from 'utils/map';
 
 import styles from './map-legend-styles.scss';
 
@@ -13,7 +14,9 @@ const MapLegend = ({ title, buckets, className }) => (
           <li className={styles.buckets} key={key}>
             <span
               className={styles.bucketIcon}
-              style={{ backgroundColor: buckets[key].color }}
+              style={{
+                backgroundColor: getColorByIndex(buckets, buckets[key].index)
+              }}
             />
             <span className={styles.bucketTxt}>{buckets[key].name}</span>
           </li>

--- a/app/javascript/app/components/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs-map/ndcs-map-selectors.js
@@ -76,20 +76,22 @@ export const getSelectedIndicator = createSelector(
 const countryStyles = {
   default: {
     fill: '#ECEFF1',
-    fillOpacity: 0.3,
-    stroke: '#396d90',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
     strokeWidth: 1,
     outline: 'none'
   },
   hover: {
     fill: '#ECEFF1',
-    stroke: '#396d90',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
     strokeWidth: 1,
     outline: 'none'
   },
   pressed: {
     fill: '#ECEFF1',
-    stroke: '#396d90',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
     strokeWidth: 1,
     outline: 'none'
   }

--- a/app/javascript/app/components/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs-map/ndcs-map-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { getColorByIndex } from 'utils/map';
 import uniqBy from 'lodash/uniqBy';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
@@ -102,7 +103,6 @@ export const getPathsWithStyles = createSelector(
       const defaultStyles = { ...path, style: countryStyles };
 
       if (!locations) return defaultStyles;
-
       const isEuropeanCountry = europeanCountries.includes(path.id);
       const countryData = isEuropeanCountry
         ? locations[europeSlug]
@@ -110,7 +110,7 @@ export const getPathsWithStyles = createSelector(
 
       if (countryData) {
         const legendData = legendBuckets[countryData.label_id];
-        const color = legendData && legendData.color;
+        const color = getColorByIndex(legendBuckets, legendData.index);
         const style = {
           ...countryStyles,
           default: {

--- a/app/javascript/app/pages/ndcs/ndcs-component.jsx
+++ b/app/javascript/app/pages/ndcs/ndcs-component.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { renderRoutes } from 'react-router-config';
 import Proptypes from 'prop-types';
-import cx from 'classnames';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import AutocompleteSearch from 'components/autocomplete-search';
@@ -21,8 +20,8 @@ const NDC = ({ anchorLinks, query, route }) => (
         <AnchorNav useRoutes links={anchorLinks} query={query} />
       </div>
     </Header>
-    <div className={cx(layout.content, styles.wrapper)}>
-      {renderRoutes(route.routes)}
+    <div className={styles.wrapper}>
+      <div className={layout.content}>{renderRoutes(route.routes)}</div>
     </div>
   </div>
 );

--- a/app/javascript/app/pages/ndcs/ndcs-styles.scss
+++ b/app/javascript/app/pages/ndcs/ndcs-styles.scss
@@ -4,6 +4,7 @@
 .wrapper {
   padding-top: $gutter-padding;
   padding-bottom: $gutter-padding;
+  background-color: $light-gray;
 }
 
 .cols {

--- a/app/javascript/app/utils/map.js
+++ b/app/javascript/app/utils/map.js
@@ -42,7 +42,7 @@ const buckets = [
 
 export function getColorByIndex(data, index) {
   const length = Object.keys(data).length;
-  return buckets[length][index] || '#E5E5EB';
+  return buckets[length - 2][index - 1] || '#E5E5EB';
 }
 
 export default {

--- a/app/javascript/app/utils/map.js
+++ b/app/javascript/app/utils/map.js
@@ -1,0 +1,50 @@
+const buckets = [
+  ['#EEBC8F', '#25597C'],
+  ['#EEBC8F', '#FEE08D', '#25597C'],
+  ['#EEBC8F', '#FEE08D', '#5081A6', '#25597C'],
+  ['#EEBC8F', '#FEE08D', '#ACBBBF', '#5081A6', '#25597C'],
+  ['#EEBC8F', '#F6CE8E', '#FEE08D', '#90B1CB', '#5081A6', '#25597C'],
+  ['#EEBC8F', '#F6CE8E', '#FEE08D', '#90B1CB', '#7199B8', '#5081A6', '#25597C'],
+  [
+    '#EEBC8F',
+    '#F6CE8E',
+    '#FEE08D',
+    '#ACBBBF',
+    '#90B1CB',
+    '#7199B8',
+    '#5081A6',
+    '#25597C'
+  ],
+  [
+    '#EEBC8F',
+    '#F6CE8E',
+    '#FEE08D',
+    '#E3D2A0',
+    '#ACBBBF',
+    '#90B1CB',
+    '#7199B8',
+    '#5081A6',
+    '#25597C'
+  ],
+  [
+    '#EEBC8F',
+    '#F6CE8E',
+    '#FEE08D',
+    '#E3D2A0',
+    '#C5C5B2',
+    '#ACBBBF',
+    '#90B1CB',
+    '#7199B8',
+    '#5081A6',
+    '#25597C'
+  ]
+];
+
+export function getColorByIndex(data, index) {
+  const length = Object.keys(data).length;
+  return buckets[length][index] || '#E5E5EB';
+}
+
+export default {
+  getColorByIndex
+};

--- a/app/serializers/api/v1/cait_indc/label_serializer.rb
+++ b/app/serializers/api/v1/cait_indc/label_serializer.rb
@@ -3,6 +3,7 @@ module Api
     module CaitIndc
       class LabelSerializer < ActiveModel::Serializer
         attributes :name
+        attributes :index
       end
     end
   end

--- a/db/migrate/20171009153610_add_label_index_to_cait_indc_label.rb
+++ b/db/migrate/20171009153610_add_label_index_to_cait_indc_label.rb
@@ -1,0 +1,5 @@
+class AddLabelIndexToCaitIndcLabel < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cait_indc_labels, :index, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005141114) do
+ActiveRecord::Schema.define(version: 20171009153610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20171005141114) do
     t.text "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "index"
     t.index ["indicator_id"], name: "index_cait_indc_labels_on_indicator_id"
   end
 


### PR DESCRIPTION
This change adds an `index` field to the ndc label properties. This field will be used as an index to a color array, so that the labels can be colorful again.
This field is set on the import process itself, so you'll need to re-import cait indc data.

tl;dr before trying this out please run:
```
rails db:migrate
rails cait_indc:import
```