### PR TITLE
Add relation to location in ndc_target entity

### DIFF
--- a/app/controllers/api/v1/ndc_sdgs_controller.rb
+++ b/app/controllers/api/v1/ndc_sdgs_controller.rb
@@ -14,6 +14,23 @@ module Api
         render json: @ndc,
                serializer: Api::V1::NdcSdg::NdcSerializer
       end
+
+      # Temporary hack to render NDC-SDG linkages for countries
+      # that do not have full NDCs imported
+      def show_by_location
+        @location = Location
+          .includes(:ndc_targets)
+          .where(iso_code3: params[:code].upcase)
+          .first
+        unless @location.ndc_targets.length > 0
+          render json: {
+            error: 'NDC not found',
+            status: 404
+          }, status: :not_found and return
+        end
+        render json: @location,
+               serializer: Api::V1::NdcSdg::LocationSerializer
+      end
     end
   end
 end

--- a/app/controllers/api/v1/ndc_sdgs_controller.rb
+++ b/app/controllers/api/v1/ndc_sdgs_controller.rb
@@ -18,11 +18,11 @@ module Api
       # Temporary hack to render NDC-SDG linkages for countries
       # that do not have full NDCs imported
       def show_by_location
-        @location = Location
-          .includes(:ndc_targets)
-          .where(iso_code3: params[:code].upcase)
-          .first
-        unless @location.ndc_targets.length > 0
+        @location = Location.
+          includes(:ndc_targets).
+          where(iso_code3: params[:code].upcase).
+          first
+        if @location.ndc_targets.length.empty?
           render json: {
             error: 'NDC not found',
             status: 404

--- a/app/controllers/api/v1/ndc_sdgs_controller.rb
+++ b/app/controllers/api/v1/ndc_sdgs_controller.rb
@@ -22,7 +22,7 @@ module Api
           includes(:ndc_targets).
           where(iso_code3: params[:code].upcase).
           first
-        if @location.ndc_targets.length.empty?
+        if @location.ndc_targets.empty?
           render json: {
             error: 'NDC not found',
             status: 404

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,6 +9,8 @@ class Location < ApplicationRecord
   has_many :indicators,
            class_name: 'CaitIndc::Indicator',
            through: :values
+  has_many :ndc_targets,
+           class_name: 'NdcSdg::NdcTarget'
 
   validates :iso_code3, presence: true, uniqueness: true
   validates :iso_code2, presence: true, uniqueness: true, if: proc { |l|

--- a/app/models/ndc_sdg/ndc_target.rb
+++ b/app/models/ndc_sdg/ndc_target.rb
@@ -1,6 +1,7 @@
 module NdcSdg
   class NdcTarget < ApplicationRecord
-    belongs_to :ndc
+    belongs_to :ndc, optional: true
+    belongs_to :location
     belongs_to :target, class_name: 'NdcSdg::Target'
     has_many :ndc_target_sectors,
              class_name: 'NdcSdg::NdcTargetSector',

--- a/app/serializers/api/v1/ndc_sdg/location_serializer.rb
+++ b/app/serializers/api/v1/ndc_sdg/location_serializer.rb
@@ -1,0 +1,58 @@
+module Api
+  module V1
+    module NdcSdg
+      class LocationSerializer < ActiveModel::Serializer
+        include Rails.application.routes.url_helpers
+
+        attributes :iso_code3, :links, :sectors, :sdgs
+
+        def links
+          {self: sdgs_api_v1_ndc_path(code: object.iso_code3)}
+        end
+
+        def sectors
+          ary = ::NdcSdg::Sector.order(:name).select(:id, :name)
+          Hash[ary.map { |s| [s.id, {name: s.name}] }]
+        end
+
+        def sdgs
+          result = {}
+          ndc_targets = object.ndc_targets.includes(:ndc_target_sectors)
+          ::NdcSdg::Goal.eager_load(:targets).
+            order('ndc_sdg_goals.number::INT, ndc_sdg_targets.number').
+            each do |goal|
+            result[goal.number] = goal_properties(goal, ndc_targets)
+          end
+          result
+        end
+
+        def goal_properties(goal, ndc_targets)
+          goal_properties = {
+            title: goal.cw_title,
+            colour: goal.colour,
+            targets: {}
+          }
+          goal.targets.each do |target|
+            goal_properties[:targets][target.number] = target_properties(
+              target, ndc_targets
+            )
+          end
+          goal_properties
+        end
+
+        def target_properties(target, ndc_targets)
+          target_properties = {
+            title: target.title
+          }
+          ndc_target = ndc_targets.select { |o| o.target_id == target.id }.
+            first
+          if ndc_target
+            sector_ids = ndc_target.ndc_target_sectors.map(&:sector_id)
+            target_properties[:sectors] = sector_ids
+          end
+          target_properties
+        end
+      end
+    end
+  end
+end

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -28,12 +28,14 @@ class ImportNdcSdgTargets
 
   def import_ndc_sdg_targets(content)
     CSV.parse(content, headers: true).each.with_index(2) do |row|
+      location = location(row)
       ndc = ndc(row)
       target = target(row)
-      next unless ndc && target
+      next unless location && target
       ndc_target = NdcSdg::NdcTarget.find_or_create_by(
         ndc: ndc,
         target: target,
+        location: location,
         indc_text: row['INDC_text'],
         status: row['Status'],
         climate_response: row['Climate_response'],
@@ -55,9 +57,13 @@ class ImportNdcSdgTargets
     end
   end
 
-  def ndc(row)
+  def location(row)
     iso_code3 = row['iso_code3'] && row['iso_code3'].strip.upcase
-    location = iso_code3 && Location.find_by_iso_code3(iso_code3)
+    iso_code3 && Location.find_by_iso_code3(iso_code3)
+  end
+
+  def ndc(row)
+    location = location(row)
     unless location
       Rails.logger.error "Location not found #{row}"
       return nil

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -29,11 +29,10 @@ class ImportNdcSdgTargets
   def import_ndc_sdg_targets(content)
     CSV.parse(content, headers: true).each.with_index(2) do |row|
       location = location(row)
-      ndc = ndc(row)
       target = target(row)
       next unless location && target
       ndc_target = NdcSdg::NdcTarget.find_or_create_by(
-        ndc: ndc,
+        ndc: ndc(row),
         target: target,
         location: location,
         indc_text: row['INDC_text'],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       resources :ndcs, param: :code, only: [:index, :show] do
         get :text, on: :member, controller: :ndc_texts, action: :show
         get :text, on: :collection, controller: :ndc_texts, action: :index
-        get :sdgs, on: :member, controller: :ndc_sdgs, action: :show
+        get :sdgs, on: :member, controller: :ndc_sdgs, action: :show_by_location
       end
       resources :adaptations, only: [:index]
 

--- a/db/migrate/20171009163704_add_location_id_to_ndc_sdg_ndc_targets.rb
+++ b/db/migrate/20171009163704_add_location_id_to_ndc_sdg_ndc_targets.rb
@@ -1,0 +1,5 @@
+class AddLocationIdToNdcSdgNdcTargets < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :ndc_sdg_ndc_targets, :location, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005141114) do
+ActiveRecord::Schema.define(version: 20171009163704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,6 +192,8 @@ ActiveRecord::Schema.define(version: 20171005141114) do
     t.text "type_of_information"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "location_id"
+    t.index ["location_id"], name: "index_ndc_sdg_ndc_targets_on_location_id"
     t.index ["ndc_id"], name: "index_ndc_sdg_ndc_targets_on_ndc_id"
     t.index ["target_id"], name: "index_ndc_sdg_ndc_targets_on_target_id"
   end
@@ -245,6 +247,7 @@ ActiveRecord::Schema.define(version: 20171005141114) do
   add_foreign_key "location_members", "locations", on_delete: :cascade
   add_foreign_key "ndc_sdg_ndc_target_sectors", "ndc_sdg_ndc_targets", column: "ndc_target_id"
   add_foreign_key "ndc_sdg_ndc_target_sectors", "ndc_sdg_sectors", column: "sector_id"
+  add_foreign_key "ndc_sdg_ndc_targets", "locations"
   add_foreign_key "ndc_sdg_ndc_targets", "ndc_sdg_targets", column: "target_id"
   add_foreign_key "ndc_sdg_ndc_targets", "ndcs"
   add_foreign_key "ndc_sdg_targets", "ndc_sdg_goals", column: "goal_id"


### PR DESCRIPTION
This will allow the API to show linkage data for locations
that do not yet have a full ndc imported. This is an ugly temporary hack
and should be reverted as soon as possible!

This change requires an update to the db and a re-import of linkage data. Please
remember to:

```
rails db:migrate
rails ndc_sdg_targets:import
```