### PR TITLE
Move map selectors on ndcs to top

### DIFF
--- a/app/javascript/app/components/button-group/button-group-styles.scss
+++ b/app/javascript/app/components/button-group/button-group-styles.scss
@@ -1,7 +1,6 @@
 @import '~styles/settings';
 
 .buttonGroup {
-  background-color: $white;
   border-radius: 4px;
   float: left;
   display: flex;

--- a/app/javascript/app/components/button/button-styles.scss
+++ b/app/javascript/app/components/button/button-styles.scss
@@ -1,7 +1,6 @@
 @import '~styles/settings';
 
 .button {
-  background-color: $white;
   height: 45px;
   padding: 0 15px;
   display: flex;

--- a/app/javascript/app/components/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/ndcs-map/ndcs-map-component.jsx
@@ -12,6 +12,24 @@ const getHtmlTooltip = content => ({ __html: content });
 
 const NDCMap = props => (
   <div className={styles.wrapper}>
+    <div className={styles.col4}>
+      <Dropdown
+        label="Category"
+        paceholder="Select a category"
+        options={props.categories}
+        onValueChange={props.handleCategoryChange}
+        value={props.selectedCategory}
+        hideResetButton
+      />
+      <Dropdown
+        label="Indicator"
+        options={props.indicators}
+        onValueChange={props.handleIndicatorChange}
+        value={props.selectedIndicator}
+        hideResetButton
+      />
+      <ButtonGroup className={styles.buttons} />
+    </div>
     <Map
       cache={false}
       paths={props.paths}
@@ -31,26 +49,6 @@ const NDCMap = props => (
         buckets={props.selectedIndicator.legendBuckets}
       />
     )}
-    <div className={styles.col4}>
-      <Dropdown
-        label="Category"
-        paceholder="Select a category"
-        options={props.categories}
-        onValueChange={props.handleCategoryChange}
-        value={props.selectedCategory}
-        hideResetButton
-        dropdownDirection={-1}
-      />
-      <Dropdown
-        label="Indicator"
-        options={props.indicators}
-        onValueChange={props.handleIndicatorChange}
-        value={props.selectedIndicator}
-        hideResetButton
-        dropdownDirection={-1}
-      />
-      <ButtonGroup className={styles.buttons} />
-    </div>
   </div>
 );
 

--- a/app/javascript/app/components/ndcs-map/ndcs-map-styles.scss
+++ b/app/javascript/app/components/ndcs-map/ndcs-map-styles.scss
@@ -15,7 +15,7 @@
 .legend {
   position: absolute;
   left: 0;
-  bottom: 100px;
+  bottom: 0;
 }
 
 .buttons {


### PR DESCRIPTION
Simple PR to move selectors on the NDCs content map above the map and fix some button styles.