### PR TITLE
Feature/ndc sdg linkages meta to component

### DIFF
--- a/app/javascript/app/actions.js
+++ b/app/javascript/app/actions.js
@@ -1,5 +1,6 @@
 import { actions as countriesProvider } from 'providers/countries-provider';
 import { actions as regionsProvider } from 'providers/regions-provider';
+import { actions as ndcsSdgsMetaProvider } from 'providers/ndcs-sdgs-meta-provider';
 import { actions as geoLocationProvider } from 'providers/geolocation-provider';
 import { actions as ghgEmissionsMetaProvider } from 'providers/ghg-emissions-meta-provider';
 import { actions as countrySelect } from 'components/countries-select';
@@ -19,6 +20,7 @@ import { actions as ndcSearchActions } from 'pages/ndc-search';
 export default {
   ...countriesProvider,
   ...regionsProvider,
+  ...ndcsSdgsMetaProvider,
   ...geoLocationProvider,
   ...ghgEmissionsMetaProvider,
   ...stories,

--- a/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 
+import NdcsSdgsMetaProvider from 'providers/ndcs-sdgs-meta-provider';
 import SDGCard from 'components/sdg-card';
 import ReactTooltip from 'react-tooltip';
 import NoContent from 'components/no-content';
@@ -13,7 +14,10 @@ import styles from './country-ndc-sdg-linkages-styles.scss';
 
 class CountrySDGLinkages extends PureComponent {
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.sdgs, this.props.sdgs)) {
+    if (
+      !isEqual(prevProps.sdgs, this.props.sdgs) ||
+      !isEqual(prevProps.targetsMeta, this.props.targetsMeta)
+    ) {
       ReactTooltip.rebuild();
     }
   }
@@ -27,7 +31,8 @@ class CountrySDGLinkages extends PureComponent {
       handleSectorChange,
       loading,
       setTooltipData,
-      tooltipData
+      tooltipData,
+      targetsMeta
     } = this.props;
     return (
       <div className={styles.wrapper}>
@@ -44,11 +49,13 @@ class CountrySDGLinkages extends PureComponent {
               />
             </div>
           </div>
+          <NdcsSdgsMetaProvider />
           {!isEmpty(sdgs) && (
             <div>
               <div className={styles.sdgs}>
                 {sdgs.map(sdg => (
                   <SDGCard
+                    targetsMeta={targetsMeta}
                     activeSector={activeSector}
                     key={sdg.title}
                     sdgData={sdg}
@@ -66,17 +73,21 @@ class CountrySDGLinkages extends PureComponent {
                       <b>{tooltipData.targetKey}: </b>
                       {tooltipData.title}
                     </p>
-                    {tooltipData.sectors && (
+                    {targetsMeta[tooltipData.targetKey] && (
                       <p className={styles.sectors}>
                         <b>Sectors: </b>
-                        {tooltipData.sectors.map((sector, index) => (
+                        {targetsMeta[
+                          tooltipData.targetKey
+                        ].sectors.map((sector, index) => (
                           <span key={`${tooltipData.targetKey}-${sector}`}>
                             {sectors[sector].name}
-                            {index === tooltipData.sectors.length - 1 ? (
-                              ''
-                            ) : (
-                              ', '
-                            )}
+                            {index ===
+                            targetsMeta[tooltipData.targetKey].sectors.length -
+                              1 ? (
+                                ''
+                              ) : (
+                                ', '
+                              )}
                           </span>
                         ))}
                       </p>
@@ -102,7 +113,8 @@ CountrySDGLinkages.propTypes = {
   activeSector: Proptypes.object,
   loading: Proptypes.bool,
   setTooltipData: Proptypes.func,
-  tooltipData: Proptypes.object
+  tooltipData: Proptypes.object,
+  targetsMeta: Proptypes.object
 };
 
 export default CountrySDGLinkages;

--- a/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-selectors.js
+++ b/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-selectors.js
@@ -16,6 +16,23 @@ const getActiveSectorId = state => {
   return state.activeSector;
 };
 
+const getNdcsSdgsTargets = state => {
+  if (!state.data) return null;
+  return state.data.targets;
+};
+
+export const parsedNdcsSdgs = createSelector(getNdcsSdgsTargets, targets => {
+  if (!targets) return {};
+  const mappedTargets = {};
+  targets.forEach(target => {
+    mappedTargets[target.number] = {
+      title: target.title,
+      sectors: target.sectors
+    };
+  });
+  return mappedTargets;
+});
+
 export const mapSDGs = createSelector(getSDGs, sdgs => {
   if (!sdgs) return [];
   const sdgIds = Object.keys(sdgs);
@@ -74,5 +91,6 @@ export const filterSDGs = createSelector([mapSDGs], sdgs => {
 export default {
   getSectorOptionsSorted,
   filterSDGs,
-  getSectorSelected
+  getSectorSelected,
+  parsedNdcsSdgs
 };

--- a/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
+++ b/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
@@ -9,7 +9,8 @@ import actions from './country-ndc-sdg-linkages-actions';
 import {
   getSectorOptionsSorted,
   filterSDGs,
-  getSectorSelected
+  getSectorSelected,
+  parsedNdcsSdgs
 } from './country-ndc-sdg-linkages-selectors';
 
 export { default as component } from './country-ndc-sdg-linkages-component';
@@ -19,7 +20,7 @@ export { default as reducers } from './country-ndc-sdg-linkages-reducers';
 export { default as actions } from './country-ndc-sdg-linkages-actions';
 
 const mapStateToProps = (state, { match, location }) => {
-  const { countrySDGLinkages } = state;
+  const { countrySDGLinkages, ndcsSdgsMeta } = state;
   const { iso } = match.params;
   const search = qs.parse(location.search);
   const sdgsData = {
@@ -35,6 +36,7 @@ const mapStateToProps = (state, { match, location }) => {
       : {},
     sectorOptions: getSectorOptionsSorted(sdgsData),
     sdgs: filterSDGs(sdgsData),
+    targetsMeta: parsedNdcsSdgs(ndcsSdgsMeta),
     loading: countrySDGLinkages.loading
   };
 };

--- a/app/javascript/app/components/sdg-card/sdg-card-component.jsx
+++ b/app/javascript/app/components/sdg-card/sdg-card-component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import isEmpty from 'lodash/isEmpty';
 
 import Icon from 'components/icon';
 
@@ -16,7 +17,8 @@ class SDGCard extends PureComponent {
       setTooltipData,
       className,
       activeSector,
-      icons
+      icons,
+      targetsMeta
     } = this.props;
     const cardStyle = cx(styles.card, square ? styles.square : null, className);
     return (
@@ -26,6 +28,7 @@ class SDGCard extends PureComponent {
           : ''} ${sdgData.title}`}</h4>
         <div className={styles.dots}>
           {indicators &&
+            !isEmpty(targetsMeta) &&
             sdgData &&
             sdgData.targets.map(target => (
               <span
@@ -36,9 +39,9 @@ class SDGCard extends PureComponent {
                 className={cx(
                   styles.dot,
                   activeSector &&
-                  (!target.sectors ||
-                    target.sectors.indexOf(parseInt(activeSector.value, 10)) ===
-                      -1)
+                  targetsMeta[target.targetKey].sectors.indexOf(
+                    parseInt(activeSector.value, 10)
+                  ) === -1
                     ? styles.small
                     : ''
                 )}
@@ -63,7 +66,8 @@ SDGCard.propTypes = {
   tooltipId: PropTypes.string,
   setTooltipData: PropTypes.func,
   className: PropTypes.string,
-  activeSector: PropTypes.object
+  activeSector: PropTypes.object,
+  targetsMeta: PropTypes.object
 };
 
 export default SDGCard;

--- a/app/javascript/app/data/initial-state.js
+++ b/app/javascript/app/data/initial-state.js
@@ -13,12 +13,14 @@ import { initialState as NDCCompare } from 'pages/ndc-compare';
 import { initialState as ndcSearch } from 'pages/ndc-search';
 import { initialState as countries } from 'providers/countries-provider';
 import { initialState as regions } from 'providers/regions-provider';
+import { initialState as ndcsSdgsMeta } from 'providers/ndcs-sdgs-meta-provider';
 import { initialState as geoLocation } from 'providers/geolocation-provider';
 import { initialState as ghgEmissionsMeta } from 'providers/ghg-emissions-meta-provider';
 
 export default {
   countries,
   regions,
+  ndcsSdgsMeta,
   stories,
   geoLocation,
   map,

--- a/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider-actions.js
+++ b/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider-actions.js
@@ -1,0 +1,33 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import isEmpty from 'lodash/isEmpty';
+
+const getNdcsSdgsMetaInit = createAction('getNdcsSdgsMetaInit');
+const getNdcsSdgsMetaReady = createAction('getNdcsSdgsMetaReady');
+
+const getNdcsSdgsMeta = createThunkAction(
+  'getNdcsSdgsMeta',
+  () => (dispatch, state) => {
+    const { ndcsSdgsMeta } = state();
+    if (ndcsSdgsMeta && isEmpty(ndcsSdgsMeta.data)) {
+      dispatch(getNdcsSdgsMetaInit());
+      fetch('/api/v1/ndcs/sdgs')
+        .then(response => {
+          if (response.ok) return response.json();
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          dispatch(getNdcsSdgsMetaReady(data));
+        })
+        .catch(error => {
+          console.info(error);
+        });
+    }
+  }
+);
+
+export default {
+  getNdcsSdgsMeta,
+  getNdcsSdgsMetaInit,
+  getNdcsSdgsMetaReady
+};

--- a/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider-reducers.js
+++ b/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider-reducers.js
@@ -1,0 +1,14 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  data: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+
+export default {
+  getNdcsSdgsMetaInit: state => setLoading(true, state),
+  getNdcsSdgsMetaReady: (state, { payload }) =>
+    setLoaded(true, setLoading(false, { ...state, data: payload }))
+};

--- a/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider.js
+++ b/app/javascript/app/providers/ndcs-sdgs-meta-provider/ndcs-sdgs-meta-provider.js
@@ -1,0 +1,26 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './ndcs-sdgs-meta-provider-actions';
+
+export { initialState } from './ndcs-sdgs-meta-provider-reducers';
+export { default as reducers } from './ndcs-sdgs-meta-provider-reducers';
+export { default as actions } from './ndcs-sdgs-meta-provider-actions';
+
+class NdcsSdgsMetaProvider extends PureComponent {
+  componentDidMount() {
+    const { getNdcsSdgsMeta } = this.props;
+    getNdcsSdgsMeta();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+NdcsSdgsMetaProvider.propTypes = {
+  getNdcsSdgsMeta: PropTypes.func.isRequired
+};
+
+export default connect(null, actions)(NdcsSdgsMetaProvider);

--- a/app/javascript/app/providers/regions-provider/regions-provider-reducers.js
+++ b/app/javascript/app/providers/regions-provider/regions-provider-reducers.js
@@ -4,11 +4,11 @@ export const initialState = {
   data: []
 };
 
-const setLoading = (loading, state) => ({ ...state, loading });
-const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setLoading = (state, loading) => ({ ...state, loading });
+const setLoaded = (state, loaded) => ({ ...state, loaded });
 
 export default {
-  getRegionsInit: state => setLoading(true, state),
+  getRegionsInit: state => setLoading(state, true),
   getRegionsReady: (state, { payload }) =>
-    setLoaded(true, setLoading(false, { ...state, data: payload }))
+    setLoaded(setLoading({ ...state, data: payload }, false), true)
 };

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -3,6 +3,7 @@ import { handleActions } from 'app/utils/redux';
 
 import { reducers as countriesReducers } from 'providers/countries-provider';
 import { reducers as regionsReducers } from 'providers/regions-provider';
+import { reducers as ndcsSdgsMetaReducers } from 'providers/ndcs-sdgs-meta-provider';
 import { reducers as ghgEmissionsMetaReducers } from 'providers/ghg-emissions-meta-provider';
 import { reducers as geoLocationReducers } from 'providers/geolocation-provider';
 import { reducers as autocompleteSearchReducers } from 'components/autocomplete-search';
@@ -55,6 +56,12 @@ export default combineReducers({
     initialState
   ),
   regions: handleActions('regions', allActions, regionsReducers, initialState),
+  ndcsSdgsMeta: handleActions(
+    'ndcsSdgsMeta',
+    allActions,
+    ndcsSdgsMetaReducers,
+    initialState
+  ),
   geoLocation: handleActions(
     'geoLocation',
     allActions,


### PR DESCRIPTION
We had the problem of displaying the relationship between the SDG targets and the sectors that they are related to irrespective of country. Using the new endpoint ```/ndcs/sdgs``` to fetch the meta data for this relationship, the component for NDC SDG linkages now changes the size of the dots per target based on the targets overall relationship to the selected Sector, and not at the target specific level.