### PR TITLE
Feature: NDC multi document search

### DIFF
--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { NavLink } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
+import qs from 'query-string';
 
 import styles from './anchor-nav-styles.scss';
 
@@ -21,6 +22,11 @@ const AnchorNav = props => {
             hash: link.hash
           }
         };
+        if (link.checkActiveQuery) {
+          linkProps.isActive = (match, location) =>
+            qs.parse(location.search)[link.checkActiveQuery] ===
+            link.activeQueryValue;
+        }
         if (useRoutes) {
           linkProps.exact = true;
           return <NavLink {...linkProps}>{link.label}</NavLink>;

--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -11,7 +11,7 @@ const AnchorNav = props => {
   const { links, useRoutes, className, query } = props;
   return (
     <nav className={cx(styles.anchorNav, className)}>
-      {links.map(link => {
+      {links.map((link, index) => {
         const linkProps = {
           key: link.label,
           className: styles.link,
@@ -25,7 +25,8 @@ const AnchorNav = props => {
         if (link.checkActiveQuery) {
           linkProps.isActive = (match, location) =>
             qs.parse(location.search)[link.checkActiveQuery] ===
-            link.activeQueryValue;
+              link.activeQueryValue ||
+            (index === 0 && !qs.parse(location.search)[link.checkActiveQuery]);
         }
         if (useRoutes) {
           linkProps.exact = true;

--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -22,11 +22,17 @@ const AnchorNav = props => {
             hash: link.hash
           }
         };
-        if (link.checkActiveQuery) {
-          linkProps.isActive = (match, location) =>
-            qs.parse(location.search)[link.checkActiveQuery] ===
-              link.activeQueryValue ||
-            (index === 0 && !qs.parse(location.search)[link.checkActiveQuery]);
+        if (link.activeQuery) {
+          linkProps.isActive = (match, location) => {
+            const activeSearchQuery = qs.parse(location.search)[
+              link.activeQuery.key
+            ];
+            const linkSearchQuery = link.activeQuery.value;
+            return (
+              activeSearchQuery === linkSearchQuery ||
+              (index === 0 && !activeSearchQuery)
+            );
+          };
         }
         if (useRoutes) {
           linkProps.exact = true;

--- a/app/javascript/app/components/button-group/button-group-styles.scss
+++ b/app/javascript/app/components/button-group/button-group-styles.scss
@@ -17,10 +17,7 @@
   padding: 0;
   min-width: 45px;
   width: 100%;
-
-  &:last-child {
-    border-right: solid 1px rgba(202, 204, 208, 0.85);
-  }
+  box-shadow: none;
 }
 
 .first {

--- a/app/javascript/app/components/footer/footer-styles.scss
+++ b/app/javascript/app/components/footer/footer-styles.scss
@@ -1,5 +1,9 @@
 @import '~styles/layout.scss';
 
+.footer {
+  padding-top: 20px;
+}
+
 .gray {
   background-color: $light-gray;
 }

--- a/app/javascript/app/components/footer/footer-styles.scss
+++ b/app/javascript/app/components/footer/footer-styles.scss
@@ -1,9 +1,5 @@
 @import '~styles/layout.scss';
 
-.footer {
-  padding-top: 20px;
-}
-
 .gray {
   background-color: $light-gray;
 }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -62,7 +62,6 @@ class GhgEmissions extends PureComponent {
           <MultiSelect
             label={breakSelected.label}
             groups={breakSelected.value === 'location' ? groups : null}
-            placeholderText={`Select ${breakSelected.value}s`}
             values={filtersSelected}
             options={filters}
             onMultiValueChange={handleFilterChange}

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -166,9 +166,10 @@ export const getFilterOptions = createSelector(
     if (breakByValue === 'location') {
       const countries = filteredSelected.map(d => ({
         ...d,
+        value: d.iso,
         groupId: 'countries'
       }));
-      return sortLabelByAlpha(uniqBy(countries.concat(regions), 'value'));
+      return sortLabelByAlpha(uniqBy(countries.concat(regions), 'iso'));
     }
     return sortLabelByAlpha(filteredSelected);
   }
@@ -183,13 +184,12 @@ export const getFiltersSelected = createSelector(
     if (breakBy.value === 'location' && !selected) {
       const selectedValues = TOP_EMITTERS;
       selectedFilters = filters.filter(
-        filter => selectedValues.indexOf(filter.iso) > -1
+        filter => selectedValues.indexOf(filter.value) > -1
       );
     } else {
       const selectedValues = selected.split(',');
-      const selectedValuesNum = selectedValues.map(d => parseInt(d, 10));
       selectedFilters = filters.filter(
-        filter => selectedValuesNum.indexOf(filter.value) > -1
+        filter => selectedValues.indexOf(`${filter.value}`) > -1
       );
     }
     return selectedFilters;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -133,7 +133,12 @@ class GhgEmissionsContainer extends PureComponent {
   };
 
   handleFilterChange = filters => {
-    const filtersParam = filters.map(filter => filter.value);
+    const filtersParam = filters.map(
+      filter =>
+        (this.props.breakSelected.value === 'location'
+          ? filter.iso
+          : filter.value)
+    );
     this.updateUrlParam({ name: 'filter', value: filtersParam.toString() });
   };
 

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -18,36 +18,35 @@ class Multiselect extends Component {
     };
   }
 
+  getSelectorValue() {
+    const { values, options } = this.props;
+    const { search } = this.state;
+    const hasValues = values && values.length;
+    if (hasValues && !search) {
+      return values.length === options.length ? (
+        <span>All selected</span>
+      ) : (
+        <span>{`${values.length} selected`}</span>
+      );
+    }
+    return null;
+  }
+
   render() {
     const {
-      values,
-      options,
       selectedClassName,
-      placeholderText,
       handleChange,
       filterOptions,
       label
     } = this.props;
-    const { search } = this.state;
     return (
       <div className={styles.multiSelectWrapper}>
         {label && <span className={styles.label}>{label}</span>}
         <div className={cx(theme.dropdown, styles.multiSelect)}>
-          <div className={styles.values}>
-            {placeholderText &&
-            !values.length && <span>{placeholderText}</span>}
-            {!search &&
-            values.length &&
-            values.length === options.length && <span>All selected</span>}
-            {!search &&
-              values.length &&
-              values.length !== options.length &&
-              `${values.length} selected`}
-          </div>
+          <div className={styles.values}>{this.getSelectorValue()}</div>
           <MultiSelect
             filterOptions={filterOptions}
-            renderValue={value =>
-              (values.length > 1 ? <span /> : <span>{value}</span>)}
+            renderValue={() => <span />}
             renderOption={option => {
               const className = option.isSelected ? selectedClassName : '';
               return (
@@ -79,7 +78,6 @@ Multiselect.propTypes = {
   options: Proptypes.array.isRequired,
   selectedClassName: Proptypes.string,
   onMultiValueChange: Proptypes.func,
-  placeholderText: Proptypes.string,
   filterOptions: Proptypes.func,
   handleChange: Proptypes.func,
   label: Proptypes.string

--- a/app/javascript/app/components/result-card/result-card-component.jsx
+++ b/app/javascript/app/components/result-card/result-card-component.jsx
@@ -10,29 +10,38 @@ import styles from './result-card-styles.scss';
 
 const ResultCard = props => {
   const { result, query } = props;
+  console.log(result);
   return (
     <div className={styles.resultCard}>
       <div className={styles.header}>
-        <h4 className={styles.title}>{result.location.name}</h4>
-        <span className={styles.count}>{result.matches.length}</span>
+        <h4 className={styles.title}>{result.label}</h4>
+        {result.results.length === 1 &&
+          <span className={styles.count}>{result.results[0].matches.length}</span>
+        }
       </div>
-      {result.matches &&
-        result.matches.map(match => (
-          <NavLink
-            key={match.fragment}
-            to={`/ndcs/country/${result.location
-              .iso_code3}/full?search=${query}&idx=${match.idx}`}
-            className={styles.match}
-          >
-            <div
-              className={styles.text}
-              id={match.idx}
-              dangerouslySetInnerHTML={{ __html: match.fragment }} // eslint-disable-line
-            />
-            <Button className={styles.link} color="white" square>
-              <Icon icon={iconLink} className={styles.iconLink} />
-            </Button>
-          </NavLink>
+      {result.results &&
+        result.results.map(r => (
+          <div key={`${r.location}-${r.documentType}`}>
+            <h4 className={styles.title}>{r.documentType}({r.language})</h4>
+            {r.matches &&
+              r.matches.map(match => (
+                <NavLink
+                  key={match.fragment}
+                  to={`/ndcs/country/${result.location}/full?search=${query}&idx=${match.idx}`}
+                  className={styles.match}
+                >
+                  <div
+                    className={styles.text}
+                    id={match.idx}
+                    dangerouslySetInnerHTML={{ __html: match.fragment }} // eslint-disable-line
+                  />
+                  <Button className={styles.link} color="white" square>
+                    <Icon icon={iconLink} className={styles.iconLink} />
+                  </Button>
+                </NavLink>
+              ))
+            }
+          </div>
         ))}
     </div>
   );

--- a/app/javascript/app/components/result-card/result-card-component.jsx
+++ b/app/javascript/app/components/result-card/result-card-component.jsx
@@ -10,38 +10,29 @@ import styles from './result-card-styles.scss';
 
 const ResultCard = props => {
   const { result, query } = props;
-  console.log(result);
   return (
     <div className={styles.resultCard}>
       <div className={styles.header}>
-        <h4 className={styles.title}>{result.label}</h4>
-        {result.results.length === 1 &&
-          <span className={styles.count}>{result.results[0].matches.length}</span>
-        }
+        <h4 className={styles.title}>{result.location.name}</h4>
+        <span className={styles.count}>{result.matches.length}</span>
       </div>
-      {result.results &&
-        result.results.map(r => (
-          <div key={`${r.location}-${r.documentType}`}>
-            <h4 className={styles.title}>{r.documentType}({r.language})</h4>
-            {r.matches &&
-              r.matches.map(match => (
-                <NavLink
-                  key={match.fragment}
-                  to={`/ndcs/country/${result.location}/full?search=${query}&idx=${match.idx}`}
-                  className={styles.match}
-                >
-                  <div
-                    className={styles.text}
-                    id={match.idx}
-                    dangerouslySetInnerHTML={{ __html: match.fragment }} // eslint-disable-line
-                  />
-                  <Button className={styles.link} color="white" square>
-                    <Icon icon={iconLink} className={styles.iconLink} />
-                  </Button>
-                </NavLink>
-              ))
-            }
-          </div>
+      {result.matches &&
+        result.matches.map(match => (
+          <NavLink
+            key={match.fragment}
+            to={`/ndcs/country/${result.location
+              .iso_code3}/full?search=${query}&idx=${match.idx}&document=${result.document_type}`}
+            className={styles.match}
+          >
+            <div
+              className={styles.text}
+              id={match.idx}
+              dangerouslySetInnerHTML={{ __html: match.fragment }} // eslint-disable-line
+            />
+            <Button className={styles.link} color="white" square>
+              <Icon icon={iconLink} className={styles.iconLink} />
+            </Button>
+          </NavLink>
         ))}
     </div>
   );

--- a/app/javascript/app/components/result-card/result-card-styles.scss
+++ b/app/javascript/app/components/result-card/result-card-styles.scss
@@ -11,13 +11,15 @@
   padding-right: 25px;
   position: relative;
 
-  &::after {
-    position: absolute;
-    content: '';
-    border-bottom: solid 1px #e5e5eb;
-    bottom: 0;
-    right: 0;
-    width: 200%;
+  &:not(:last-child) {
+    &::after {
+      position: absolute;
+      content: '';
+      border-bottom: solid 1px #e5e5eb;
+      bottom: 0;
+      right: 0;
+      width: 200%;
+    }
   }
 }
 

--- a/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
+++ b/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
@@ -13,7 +13,7 @@ class ScrollToHighlightIndex extends PureComponent {
     window.scrollTo({
       behavior: 'smooth',
       left: 0,
-      top: e.offsetTop
+      top: e.offsetTop - 100
     });
   };
 

--- a/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
+++ b/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
@@ -1,0 +1,30 @@
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+class ScrollToHighlightIndex extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  componentDidMount() {
+    setTimeout(this.handleScroll(), 1500);
+  }
+
+  handleScroll = () => {
+    const { idx, targetElementsSelector } = this.props;
+    const e = document.querySelectorAll(targetElementsSelector)[idx];
+    window.scrollTo({
+      behavior: 'smooth',
+      left: 0,
+      top: e.offsetTop
+    });
+  };
+
+  render() {
+    return null;
+  }
+}
+
+ScrollToHighlightIndex.propTypes = {
+  idx: PropTypes.string,
+  targetElementsSelector: PropTypes.string
+};
+
+export default ScrollToHighlightIndex;

--- a/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
+++ b/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 class ScrollToHighlightIndex extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   componentDidMount() {
-    setTimeout(this.handleScroll(), 1500);
+    setTimeout(this.handleScroll, 150);
   }
 
   handleScroll = () => {

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-component.jsx
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-component.jsx
@@ -25,7 +25,7 @@ class NDCCountry extends PureComponent {
       loading
     } = this.props;
     return (
-      <div>
+      <div className={styles.wrapper}>
         <Header route={route}>
           <div className={cx(layout.content, styles.header)}>
             <div className={styles.title}>

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-actions.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-actions.js
@@ -4,9 +4,6 @@ import { createThunkAction } from 'utils/redux';
 const fetchCountryNDCFullInit = createAction('fetchCountryNDCFullInit');
 const fetchCountryNDCFullReady = createAction('fetchCountryNDCFullReady');
 const fetchCountryNDCFullFailed = createAction('fetchCountryNDCFullFailed');
-const changeSelectedCountryNDCFull = createAction(
-  'changeSelectedCountryNDCFull'
-);
 
 const fetchCountryNDCFull = createThunkAction(
   'fetchCountryNDCFull',
@@ -34,6 +31,5 @@ export default {
   fetchCountryNDCFull,
   fetchCountryNDCFullInit,
   fetchCountryNDCFullReady,
-  fetchCountryNDCFullFailed,
-  changeSelectedCountryNDCFull
+  fetchCountryNDCFullFailed
 };

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -48,15 +48,14 @@ class NDCCountryFull extends PureComponent {
           </div>
         </Header>
         <div className={cx(layout.content, styles.actions)}>
-          {contentOptions.length > 1 && (
-            <Dropdown
-              label="Document"
-              options={contentOptions}
-              value={contentOptionSelected}
-              onValueChange={onSelectChange}
-              hideResetButton
-            />
-          )}
+          <Dropdown
+            label="Document"
+            options={contentOptions}
+            value={contentOptionSelected}
+            onValueChange={onSelectChange}
+            hideResetButton
+            disabled={contentOptions.length === 1}
+          />
           <Search
             theme={darkSearch}
             className={styles.search}

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -9,6 +9,7 @@ import Search from 'components/search';
 import cx from 'classnames';
 import NoContent from 'components/no-content';
 import isEmpty from 'lodash/isEmpty';
+import ScrollToHighlightIndex from 'components/scroll-to-highlight-index';
 
 import darkSearch from 'styles/themes/search/search-dark.scss';
 import layout from 'styles/layout.scss';
@@ -17,9 +18,32 @@ import contentStyles from 'styles/themes/content.scss';
 import styles from './ndc-country-full-styles.scss';
 
 class NDCCountryFull extends PureComponent {
+  getPageContent() {
+    const { content, loaded, idx } = this.props;
+    const hasContent = !isEmpty(content);
+    if (hasContent) {
+      return (
+        <div className={cx(layout.content, styles.bodyContent)}>
+          {!isEmpty(content) && (
+            <div
+              className={cx(contentStyles.content, styles.innerContent)}
+              dangerouslySetInnerHTML={{ __html: content.html }} // eslint-disable-line
+            />
+          )}
+          {idx && (
+            <ScrollToHighlightIndex
+              idx={idx}
+              targetElementsSelector={'.highlight'}
+            />
+          )}
+        </div>
+      );
+    }
+    return loaded ? <NoContent message="No content available" /> : null;
+  }
+
   render() {
     const {
-      loading,
       country,
       match,
       onSearchChange,
@@ -47,34 +71,27 @@ class NDCCountryFull extends PureComponent {
             </div>
           </div>
         </Header>
-        <div className={cx(layout.content, styles.actions)}>
-          <Dropdown
-            label="Document"
-            options={contentOptions}
-            value={contentOptionSelected}
-            onValueChange={onSelectChange}
-            hideResetButton
-            disabled={contentOptions.length === 1}
-          />
-          <Search
-            theme={darkSearch}
-            className={styles.search}
-            placeholder="Search"
-            input={search}
-            onChange={onSearchChange}
-            disabled={isEmpty(content)}
-          />
-        </div>
-        {isEmpty(content) &&
-        !loading && <NoContent message="No content available" />}
-        <div className={cx(layout.content, styles.bodyContent)}>
-          {!isEmpty(content) && (
-            <div
-              className={cx(contentStyles.content, styles.innerContent)}
-              dangerouslySetInnerHTML={{ __html: content.html }} // eslint-disable-line
+        <div className={styles.actionsWrapper}>
+          <div className={cx(layout.content, styles.actions)}>
+            <Dropdown
+              label="Document"
+              options={contentOptions}
+              value={contentOptionSelected}
+              onValueChange={onSelectChange}
+              hideResetButton
+              disabled={contentOptions.length === 1}
             />
-          )}
+            <Search
+              theme={darkSearch}
+              className={styles.search}
+              placeholder="Search"
+              input={search}
+              onChange={onSearchChange}
+              disabled={isEmpty(content)}
+            />
+          </div>
         </div>
+        {this.getPageContent()}
       </div>
     );
   }
@@ -90,7 +107,8 @@ NDCCountryFull.propTypes = {
   contentOptions: PropTypes.array,
   onSelectChange: PropTypes.func,
   contentOptionSelected: PropTypes.object,
-  loading: PropTypes.bool
+  loaded: PropTypes.bool,
+  idx: PropTypes.string
 };
 
 export default NDCCountryFull;

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -10,9 +10,9 @@ import cx from 'classnames';
 import NoContent from 'components/no-content';
 import isEmpty from 'lodash/isEmpty';
 
+import darkSearch from 'styles/themes/search/search-dark.scss';
 import layout from 'styles/layout.scss';
 import backIcon from 'assets/icons/back.svg';
-import lightSearch from 'styles/themes/search/search-light.scss';
 import contentStyles from 'styles/themes/content.scss';
 import styles from './ndc-country-full-styles.scss';
 
@@ -27,9 +27,9 @@ class NDCCountryFull extends PureComponent {
       onSelectChange,
       content,
       contentOptions,
+      contentOptionSelected,
       route
     } = this.props;
-
     return (
       <div>
         <Header route={route}>
@@ -43,36 +43,29 @@ class NDCCountryFull extends PureComponent {
               >
                 <Icon className={styles.backIcon} icon={backIcon} />
               </Button>
-              <Intro title={`${country.wri_standard_name} Full Content`} />
-            </div>
-            <div
-              className={
-                contentOptions.length > 1 ? (
-                  styles.twoFoldReversed
-                ) : (
-                  styles.oneFold
-                )
-              }
-            >
-              {contentOptions.length > 1 && (
-                <Dropdown
-                  white
-                  options={contentOptions}
-                  value={content}
-                  onValueChange={onSelectChange}
-                  hideResetButton
-                />
-              )}
-              <Search
-                theme={lightSearch}
-                placeholder="Search"
-                input={search}
-                onChange={onSearchChange}
-                disabled={isEmpty(content)}
-              />
+              <Intro title={`${country.wri_standard_name} - Full Content`} />
             </div>
           </div>
         </Header>
+        <div className={cx(layout.content, styles.actions)}>
+          {contentOptions.length > 1 && (
+            <Dropdown
+              label="Document"
+              options={contentOptions}
+              value={contentOptionSelected}
+              onValueChange={onSelectChange}
+              hideResetButton
+            />
+          )}
+          <Search
+            theme={darkSearch}
+            className={styles.search}
+            placeholder="Search"
+            input={search}
+            onChange={onSearchChange}
+            disabled={isEmpty(content)}
+          />
+        </div>
         {isEmpty(content) &&
         !loading && <NoContent message="No content available" />}
         <div className={cx(layout.content, styles.bodyContent)}>
@@ -97,6 +90,7 @@ NDCCountryFull.propTypes = {
   content: PropTypes.object,
   contentOptions: PropTypes.array,
   onSelectChange: PropTypes.func,
+  contentOptionSelected: PropTypes.object,
   loading: PropTypes.bool
 };
 

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
@@ -10,7 +10,7 @@ const setLoading = (loading, state) => ({ ...state, loading });
 const setLoaded = (loaded, state) => ({ ...state, loaded });
 
 export default {
-  fetchCountryNDCFullInit: state => setLoading(true, state),
+  fetchCountryNDCFullInit: state => setLoaded(false, setLoading(true, state)),
   fetchCountryNDCFullReady: (state, { payload }) => {
     if (isEmpty(payload)) {
       return setLoaded(true, setLoading(false, state));

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
@@ -36,12 +36,5 @@ export default {
       }
     };
     return setLoaded(true, setLoading(false, newState));
-  },
-  changeSelectedCountryNDCFull: (state, { payload }) => {
-    const newState = {
-      ...state,
-      selected: payload
-    };
-    return newState;
   }
 };

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -14,7 +14,7 @@ export const getSelectedContent = createSelector(
   (selected, content) => {
     if (!content || !content.length) return null;
     if (!selected) return content[0];
-    return content.find(item => item.id === parseInt(selected, 10));
+    return content.find(item => item.document_type === selected, 10);
   }
 );
 
@@ -23,7 +23,7 @@ const getLabel = item =>
 
 export const getContentOptions = createSelector(getContent, content =>
   (content || []).map(item => ({
-    value: item.id,
+    value: item.document_type,
     label: getLabel(item)
   }))
 );
@@ -32,7 +32,7 @@ export const getContentOptionSelected = createSelector(
   [getSelected, getContentOptions],
   (selected, options) => {
     if (!selected) return options[0];
-    return options.find(option => option.value === parseInt(selected, 10));
+    return options.find(option => option.value === selected);
   }
 );
 

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -30,8 +30,10 @@ export const getContentOptions = createSelector(getContent, content =>
 
 export const getContentOptionSelected = createSelector(
   [getSelected, getContentOptions],
-  (selected, options) =>
-    options.find(option => option.value === parseInt(selected, 10))
+  (selected, options) => {
+    if (!selected) return options[0];
+    return options.find(option => option.value === parseInt(selected, 10));
+  }
 );
 
 export default {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -1,10 +1,8 @@
 import { createSelector } from 'reselect';
-import isEmpty from 'lodash/isEmpty';
 
 const getCountries = state => state.countries.data;
-const getSelected = state => state.countryNDCFull.selected;
-
-export const getContent = (state, iso) => state.countryNDCFull.data[iso];
+const getSelected = state => state.document || null;
+const getContent = state => state.content || null;
 
 export const getCountry = createSelector(
   [getCountries, (countries, iso) => iso],
@@ -14,13 +12,9 @@ export const getCountry = createSelector(
 export const getSelectedContent = createSelector(
   [getSelected, getContent],
   (selected, content) => {
-    if (isEmpty(content)) {
-      return null;
-    }
-
-    return content.length > 1
-      ? content.find(item => item.id === selected)
-      : content[0];
+    if (!content || !content.length) return null;
+    if (!selected) return content[0];
+    return content.find(item => item.id === parseInt(selected, 10));
   }
 );
 
@@ -32,6 +26,12 @@ export const getContentOptions = createSelector(getContent, content =>
     value: item.id,
     label: getLabel(item)
   }))
+);
+
+export const getContentOptionSelected = createSelector(
+  [getSelected, getContentOptions],
+  (selected, options) =>
+    options.find(option => option.value === parseInt(selected, 10))
 );
 
 export default {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -23,7 +23,7 @@
 }
 
 .actionsWrapper {
-  border-bottom: solid 1px $border-color;  
+  border-bottom: solid 1px $border-color;
 }
 
 .actions {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -22,11 +22,14 @@
   height: 60px;
 }
 
+.actionsWrapper {
+  border-bottom: solid 1px $border-color;  
+}
+
 .actions {
   @extend %grid;
 
   grid-template-columns: 3fr 4fr 5fr;
-  border-bottom: solid 1px $border-color;
   padding-top: 30px;
   padding-bottom: 40px;
 }

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -12,10 +12,6 @@
   grid-template-columns: 5fr 7fr;
 }
 
-.oneFold {
-
-}
-
 .backButton {
   margin-right: 20px;
 }
@@ -24,6 +20,20 @@
   fill: $white;
   width: 60px;
   height: 60px;
+}
+
+.actions {
+  @extend %grid;
+
+  grid-template-columns: 3fr 4fr 5fr;
+  border-bottom: solid 1px $border-color;
+  padding-top: 30px;
+  padding-bottom: 40px;
+}
+
+.search {
+  grid-column-start: 3;
+  align-self: flex-end;
 }
 
 .title {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
@@ -3,14 +3,15 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import Proptypes from 'prop-types';
 import qs from 'query-string';
+import { getLocationParamUpdated } from 'utils/navigation';
 
 import NDCCountryFullComponent from './ndc-country-full-component';
 import actions from './ndc-country-full-actions';
 import {
   getCountry,
-  getContent,
   getSelectedContent,
-  getContentOptions
+  getContentOptions,
+  getContentOptionSelected
 } from './ndc-country-full-selectors';
 
 export { default as component } from './ndc-country-full-component';
@@ -21,13 +22,17 @@ export { default as actions } from './ndc-country-full-actions';
 const mapStateToProps = (state, { match }) => {
   const search = qs.parse(location.search);
   const { iso } = match.params;
-
+  const contentData = {
+    content: state.countryNDCFull.data[iso],
+    document: search.document,
+    iso
+  };
   return {
-    fetched: getContent(state, iso),
     loading: state.countryNDCFull.loading,
     country: getCountry(state, iso),
-    content: getSelectedContent(state, iso),
-    contentOptions: getContentOptions(state, iso),
+    content: getSelectedContent(contentData),
+    contentOptions: getContentOptions(contentData),
+    contentOptionSelected: getContentOptionSelected(contentData),
     search: search.search
   };
 };
@@ -55,9 +60,13 @@ class NDCCountryFullContainer extends PureComponent {
     fetchCountryNDCFull(iso, query);
   };
 
-  onSelectChange = args => {
-    const { changeSelectedCountryNDCFull } = this.props;
-    changeSelectedCountryNDCFull(args.value);
+  onSelectChange = selected => {
+    this.updateUrlParam({ name: 'document', value: selected.value });
+  };
+
+  updateUrlParam = (params, clear) => {
+    const { history, location } = this.props;
+    history.replace(getLocationParamUpdated(location, params, clear));
   };
 
   render() {
@@ -75,8 +84,7 @@ NDCCountryFullContainer.propTypes = {
   location: Proptypes.object.isRequired,
   fetched: Proptypes.array,
   loading: Proptypes.bool,
-  fetchCountryNDCFull: Proptypes.func,
-  changeSelectedCountryNDCFull: Proptypes.func
+  fetchCountryNDCFull: Proptypes.func
 };
 
 export default withRouter(

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
@@ -29,11 +29,13 @@ const mapStateToProps = (state, { match }) => {
   };
   return {
     loading: state.countryNDCFull.loading,
+    loaded: state.countryNDCFull.loaded,
     country: getCountry(state, iso),
     content: getSelectedContent(contentData),
     contentOptions: getContentOptions(contentData),
     contentOptionSelected: getContentOptionSelected(contentData),
-    search: search.search
+    search: search.search,
+    idx: search.idx
   };
 };
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -61,7 +61,11 @@ class NDCCountry extends PureComponent {
             </div>
           </div>
         </Header>
-        <Accordion data={ndcsData} loading={loading} />
+        <Accordion
+          className={styles.accordion}
+          data={ndcsData}
+          loading={loading}
+        />
       </div>
     );
   }

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -27,3 +27,7 @@
   justify-content: flex-start;
   align-items: flex-start;
 }
+
+.accordion {
+  margin-bottom: 40px;
+}

--- a/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
+++ b/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Sticky from 'react-stickynode';
 
+import AnchorNav from 'components/anchor-nav';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import ResultCard from 'components/result-card';
@@ -17,8 +18,14 @@ import styles from './ndc-search-styles.scss';
 
 class SearchPage extends PureComponent {
   render() {
-    const { results, query, onSearchChange, route } = this.props;
-    console.log(results);
+    const {
+      results,
+      query,
+      onSearchChange,
+      route,
+      docOptions,
+      anchorLinks
+    } = this.props;
     return (
       <div>
         <Header route={route}>
@@ -32,6 +39,9 @@ class SearchPage extends PureComponent {
                 onChange={onSearchChange}
               />
             </div>
+            {docOptions.length > 1 && (
+              <AnchorNav useRoutes links={anchorLinks} />
+            )}
           </div>
         </Header>
         <div className={cx(layout.content, styles.contentCols)}>
@@ -42,7 +52,7 @@ class SearchPage extends PureComponent {
             {results &&
               results.map(result => (
                 <ResultCard
-                  key={result.location}
+                  key={result.location.iso_code3}
                   result={result}
                   query={query}
                 />
@@ -61,7 +71,9 @@ SearchPage.propTypes = {
   route: PropTypes.object.isRequired,
   query: PropTypes.string,
   results: PropTypes.array,
-  onSearchChange: PropTypes.func.isRequired
+  onSearchChange: PropTypes.func.isRequired,
+  docOptions: PropTypes.array,
+  anchorLinks: PropTypes.array.isRequired
 };
 
 SearchPage.defaultProps = {

--- a/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
+++ b/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
@@ -19,6 +19,7 @@ import styles from './ndc-search-styles.scss';
 class SearchPage extends PureComponent {
   render() {
     const {
+      loading,
       results,
       query,
       onSearchChange,
@@ -46,9 +47,8 @@ class SearchPage extends PureComponent {
         </Header>
         <div className={cx(layout.content, styles.contentCols)}>
           <div className={styles.resultsList}>
-            {!results.length && (
-              <NoContent message="No results for this search" />
-            )}
+            {!results.length &&
+            !loading && <NoContent message="No results for this search" />}
             {results &&
               results.map(result => (
                 <ResultCard
@@ -68,6 +68,7 @@ class SearchPage extends PureComponent {
 }
 
 SearchPage.propTypes = {
+  loading: PropTypes.bool,
   route: PropTypes.object.isRequired,
   query: PropTypes.string,
   results: PropTypes.array,

--- a/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
+++ b/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
@@ -18,6 +18,7 @@ import styles from './ndc-search-styles.scss';
 class SearchPage extends PureComponent {
   render() {
     const { results, query, onSearchChange, route } = this.props;
+    console.log(results);
     return (
       <div>
         <Header route={route}>
@@ -41,7 +42,7 @@ class SearchPage extends PureComponent {
             {results &&
               results.map(result => (
                 <ResultCard
-                  key={result.location.iso_code3}
+                  key={result.location}
                   result={result}
                   query={query}
                 />

--- a/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
@@ -35,7 +35,12 @@ export const filterSearchResults = createSelector(
 
 export const getSearchResultsSorted = createSelector(
   filterSearchResults,
-  results => results.sort((a, b) => a.matches.length > b.matches.length)
+  results =>
+    results.sort((a, b) => {
+      if (a.matches.length > b.matches.length) return -1;
+      if (a.matches.length < b.matches.length) return 1;
+      return 0;
+    })
 );
 
 export const getAnchorLinks = createSelector(

--- a/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
@@ -1,10 +1,31 @@
 import { createSelector } from 'reselect';
+import groupBy from 'lodash/groupBy';
 
-const getResultsData = state => state.results;
+const getResultsData = state => state.results || null;
 
-export const getSearchResults = createSelector(getResultsData, results =>
-  results.sort((a, b) => a.matches.length < b.matches.length)
+export const groupSearchResults = createSelector(getResultsData, results => {
+  if (!results) return null;
+  return groupBy(results.map(d => ({
+    location: d.location.iso_code3,
+    label: d.location.name,
+    documentType: d.document_type,
+    language: d.language,
+    matches: d.matches
+  })), 'location');
+});
+
+export const getSearchResults = createSelector(groupSearchResults,
+  results => {
+    if (!results) return [];
+    const mappedResults = Object.keys(results).map(d => ({
+      label: results[d][0].label,
+      location: results[d][0].location,
+      results: results[d]
+    }));
+    return mappedResults.sort((a, b) => a.results[0].matches.length < b.results[0].matches.length);
+  }
 );
+
 
 export default {
   getSearchResults

--- a/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
@@ -50,8 +50,10 @@ export const getAnchorLinks = createSelector(
       label: d.label,
       path: `${location.pathname}`,
       search: `?document=${d.value}&query=${query}`,
-      checkActiveQuery: 'document',
-      activeQueryValue: d.value
+      activeQuery: {
+        key: 'document',
+        value: d.value
+      }
     }))
 );
 

--- a/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
+++ b/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
@@ -15,4 +15,5 @@
 
 .resultsList {
   border-right: solid 1px #e5e5eb;
+  margin-bottom: -20px;
 }

--- a/app/javascript/app/pages/ndc-search/ndc-search.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search.js
@@ -6,20 +6,30 @@ import qs from 'query-string';
 
 import actions from './ndc-search-actions';
 import SearchComponent from './ndc-search-component';
-import { getSearchResults } from './ndc-search-selectors';
+import {
+  getSearchResultsSorted,
+  getDocumentOptions,
+  getDocumentSelected,
+  getAnchorLinks
+} from './ndc-search-selectors';
 
 export { default as component } from './ndc-search-component';
 export { default as styles } from './ndc-search-styles';
 
 const mapStateToProps = (state, { location }) => {
-  const { query } = qs.parse(location.search);
+  const { query, document } = qs.parse(location.search);
   const stateWithQuery = {
     query,
+    document,
+    location,
     results: state.ndcSearch.data
   };
   return {
     query,
-    results: getSearchResults(stateWithQuery)
+    results: getSearchResultsSorted(stateWithQuery),
+    docOptions: getDocumentOptions(stateWithQuery),
+    docSelected: getDocumentSelected(stateWithQuery),
+    anchorLinks: getAnchorLinks(stateWithQuery)
   };
 };
 

--- a/app/javascript/app/pages/ndc-search/ndc-search.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search.js
@@ -26,6 +26,7 @@ const mapStateToProps = (state, { location }) => {
   };
   return {
     query,
+    loading: state.ndcSearch.loading,
     results: getSearchResultsSorted(stateWithQuery),
     docOptions: getDocumentOptions(stateWithQuery),
     docSelected: getDocumentSelected(stateWithQuery),

--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -125,7 +125,8 @@ export default [
       {
         path: '/ndc-search',
         exact: true,
-        component: NDCSearch
+        component: NDCSearch,
+        headerImage: 'ndc'
       },
       {
         path: '/stories',


### PR DESCRIPTION
This PR primarily addresses the issues occurring when searching the ``/ndcs/text?query=something`` endpoint. As there are at least two types of document for NPL (indc and ndc) we receive duplicate results in the return. Not only does rendering this in React make is cry like a 5 year old on cake, we also had no pleasant way of displaying this result separation either in the design or in the code. So... we decided to add the age old, tried and tested, tabs (dynamically set based on the results) to handle this rendering. Now (if needed) you can switch between document types for your search. This gives a heap of benefits:
- Document type held in URL param. Now this can be used to filter on both ``/ndcs/country/ISO/full`` searches and the global search functions
- All params are persistent between views from updated links so we show to correct document when moving between views
- NEW FEATURE: Scroll to idx param in page if passed in the URL

Other fixes:
- Sorting of results more thorougly
- Only show 'No results' when not fetching

![oct-11-2017 17-40-35](https://user-images.githubusercontent.com/20288774/31451050-57431526-aeab-11e7-883d-2a776349e589.gif)

BONUS ROUND: I noticed that when navigating to the ``/ghg-emissions`` view from a country page the ``regions`` selector was not handling countries or regions using ``iso``. So I changed that. Now this page is a turbo charged, param receiving, data machine. 🛥  💨 