### PR TITLE
Feature/allow ndc search by goals targets sectors

### DIFF
--- a/app/controllers/api/v1/ndc_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_texts_controller.rb
@@ -3,7 +3,13 @@ module Api
     class NdcTextsController < ApiController
       def index
         ndcs = Ndc.includes(:location)
-        ndcs = with_highlights(ndcs, false, false)
+        ndcs =
+          if params[:query]
+            with_highlights(ndcs, false, false)
+          else
+            ndcs
+          end
+
         render json: ndcs,
                each_serializer: Api::V1::NdcTextSearchResultSerializer,
                query: params[:query]

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -75,7 +75,7 @@ class Ndc < ApplicationRecord
 
     if params[:code]
       query_params[:locations] = {
-        iso_code3: params[:code]
+        iso_code3: params[:code].upcase
       }
     end
 

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -49,4 +49,40 @@ class Ndc < ApplicationRecord
     EOT
     update_all(sql)
   end
+
+  def self.linkage_texts(params)
+    query_params = {}
+
+    if params[:target]
+      query_params[:ndc_sdg_targets] = {
+        number: params[:target]
+      }
+    end
+
+    if params[:sector]
+      query_params[:ndc_sdg_ndc_target_sectors] = {
+        sector_id: params[:sector]
+      }
+    end
+
+    if params[:goal]
+      query_params[:ndc_sdg_goals] = {
+        number: params[:goal]
+      }
+    end
+
+    if params[:code]
+      query_params[:locations] = {
+        iso_code3: params[:code]
+      }
+    end
+
+    ::NdcSdg::NdcTarget.includes(
+      target: [:goal],
+      ndc_target_sectors: [:sector],
+      ndc: [:location]
+    ).where(query_params).
+      map(&:indc_text).
+      map(&:strip)
+  end
 end

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -74,7 +74,6 @@ class Ndc < ApplicationRecord
       ndc_target_sectors: [:sector],
       ndc: [:location]
     ).where(query_params).
-      map(&:indc_text).
-      map(&:strip)
+      map(&:indc_text)
   end
 end

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -6,6 +6,8 @@ class Ndc < ApplicationRecord
 
   validates :document_type, inclusion: {in: %w(ndc indc)}
 
+  attr_accessor :linkages
+
   PG_SEARCH_HIGHLIGHT_START = '<span class="highlight">'.freeze
   PG_SEARCH_HIGHLIGHT_END = '</span>'.freeze
   PG_SEARCH_HIGHLIGHT_FRAGMENT_DELIMITER = '[[FRAGMENT DELIMITER]]'.freeze

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -55,27 +55,17 @@ class Ndc < ApplicationRecord
   def self.linkage_texts(params)
     query_params = {}
 
-    if params[:target]
-      query_params[:ndc_sdg_targets] = {
-        number: params[:target]
-      }
-    end
+    filters = {
+      target: [:ndc_sdg_targets, :number, params[:target]],
+      sector: [:ndc_sdg_ndc_target_sectors, :sector_id, params[:sector]],
+      goal: [:ndc_sdg_goals, :number, params[:goal]],
+      code: [:locations, :iso_code3, params[:code].upcase]
+    }
 
-    if params[:sector]
-      query_params[:ndc_sdg_ndc_target_sectors] = {
-        sector_id: params[:sector]
-      }
-    end
-
-    if params[:goal]
-      query_params[:ndc_sdg_goals] = {
-        number: params[:goal]
-      }
-    end
-
-    if params[:code]
-      query_params[:locations] = {
-        iso_code3: params[:code].upcase
+    filters.each do |k, v|
+      next unless params[k]
+      query_params[v.first] = {
+        v.second => v.third
       }
     end
 

--- a/app/serializers/api/v1/ndc_text_serializer.rb
+++ b/app/serializers/api/v1/ndc_text_serializer.rb
@@ -10,6 +10,10 @@ module Api
         {self: text_api_v1_ndc_path(code: object.location.try(:iso_code3))}
       end
 
+      def linkages
+        object.linkages || []
+      end
+
       def html
         if highlights_present?
           object.pg_search_highlight.html_safe

--- a/app/serializers/api/v1/ndc_text_serializer.rb
+++ b/app/serializers/api/v1/ndc_text_serializer.rb
@@ -3,7 +3,7 @@ module Api
     class NdcTextSerializer < ActiveModel::Serializer
       include Rails.application.routes.url_helpers
 
-      attributes :id, :language, :document_type, :links, :html
+      attributes :id, :language, :document_type, :links, :linkages, :html
       belongs_to :location, serializer: Api::V1::LocationNanoSerializer
 
       def links

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -34,7 +34,7 @@ class ImportNdcSdgTargets
       ndc_target = NdcSdg::NdcTarget.find_or_create_by(
         ndc: ndc,
         target: target,
-        indc_text: row['INDC_text'],
+        indc_text: row['INDC_text'].strip,
         status: row['Status'],
         climate_response: row['Climate_response'],
         type_of_information: row['Type_of_information']

--- a/spec/controllers/api/v1/ndc_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_texts_controller_spec.rb
@@ -17,7 +17,7 @@ pulvinar, tempus augue. Hello sed egestas ipsum, et posuere tellus. \
 Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
   }
   let(:pol_html_linkage_text) {
-    "Nullam aliquam pretium risus laoreet."
+    'Nullam aliquam pretium risus laoreet.'
   }
   let(:pol_html_with_highlight) {
     pol_html.gsub(
@@ -93,22 +93,43 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
       expect(json_response.first['html']).to match(pol_html)
     end
     it 'returns NDC content with highlights when given a target number' do
-      get :show, params: {code: pol.iso_code3.downcase, target: pol_ndc_sdg_ndc_target.target.number}
+      get :show, params: {
+        code: pol.iso_code3.downcase,
+        target: pol_ndc_sdg_ndc_target.target.number
+      }
       json_response = JSON.parse(response.body)
-      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
-      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
+      expect(json_response.first['linkages']).to match_array(
+        [pol_html_linkage_text]
+      )
+      expect(json_response.first['html']).to include(
+        "<span class=\"highlight\">#{pol_html_linkage_text}</span>"
+      )
     end
     it 'returns NDC content with highlights when given a goal number' do
-      get :show, params: {code: pol.iso_code3.downcase, goal: pol_ndc_sdg_ndc_target.target.goal.number}
+      get :show, params: {
+        code: pol.iso_code3.downcase,
+        goal: pol_ndc_sdg_ndc_target.target.goal.number
+      }
       json_response = JSON.parse(response.body)
-      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
-      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
+      expect(json_response.first['linkages']).to match_array(
+        [pol_html_linkage_text]
+      )
+      expect(json_response.first['html']).to include(
+        "<span class=\"highlight\">#{pol_html_linkage_text}</span>"
+      )
     end
     it 'returns NDC content with highlights when given a sector id' do
-      get :show, params: {code: pol.iso_code3.downcase, sector: pol_ndc_sdg_ndc_target_sector.sector.id}
+      get :show, params: {
+        code: pol.iso_code3.downcase,
+        sector: pol_ndc_sdg_ndc_target_sector.sector.id
+      }
       json_response = JSON.parse(response.body)
-      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
-      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
+      expect(json_response.first['linkages']).to match_array(
+        [pol_html_linkage_text]
+      )
+      expect(json_response.first['html']).to include(
+        "<span class=\"highlight\">#{pol_html_linkage_text}</span>"
+      )
     end
   end
 end

--- a/spec/controllers/api/v1/ndc_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_texts_controller_spec.rb
@@ -16,6 +16,9 @@ Cras sollicitudin eleifend maximus. Etiam nec nulla viverra, suscipit diam\
 pulvinar, tempus augue. Hello sed egestas ipsum, et posuere tellus. \
 Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
   }
+  let(:pol_html_linkage_text) {
+    "Nullam aliquam pretium risus laoreet."
+  }
   let(:pol_html_with_highlight) {
     pol_html.gsub(
       'Hello',
@@ -28,6 +31,19 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
   }
   let!(:prt_ndc) {
     FactoryGirl.create(:ndc, location: prt, full_text: prt_html)
+  }
+  let!(:pol_ndc_sdg_ndc_target) {
+    FactoryGirl.create(
+      :ndc_sdg_ndc_target,
+      ndc: pol_ndc,
+      indc_text: pol_html_linkage_text
+    )
+  }
+  let!(:pol_ndc_sdg_ndc_target_sector) {
+    FactoryGirl.create(
+      :ndc_sdg_ndc_target_sector,
+      ndc_target: pol_ndc_sdg_ndc_target
+    )
   }
 
   before(:each) { Ndc.refresh_full_text_tsv }
@@ -75,6 +91,24 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
       get :show, params: {code: pol.iso_code3.downcase, query: 'goodbye'}
       json_response = JSON.parse(response.body)
       expect(json_response.first['html']).to match(pol_html)
+    end
+    it 'returns NDC content with highlights when given a target number' do
+      get :show, params: {code: pol.iso_code3.downcase, target: pol_ndc_sdg_ndc_target.target.number}
+      json_response = JSON.parse(response.body)
+      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
+      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
+    end
+    it 'returns NDC content with highlights when given a goal number' do
+      get :show, params: {code: pol.iso_code3.downcase, goal: pol_ndc_sdg_ndc_target.target.goal.number}
+      json_response = JSON.parse(response.body)
+      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
+      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
+    end
+    it 'returns NDC content with highlights when given a sector id' do
+      get :show, params: {code: pol.iso_code3.downcase, sector: pol_ndc_sdg_ndc_target_sector.sector.id}
+      json_response = JSON.parse(response.body)
+      expect(json_response.first['linkages']).to match_array([pol_html_linkage_text])
+      expect(json_response.first['html']).to include("<span class=\"highlight\">#{pol_html_linkage_text}</span>")
     end
   end
 end

--- a/spec/factories/ndc_sdg_goals.rb
+++ b/spec/factories/ndc_sdg_goals.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :ndc_sdg_goal, class: 'NdcSdg::Goal' do
-    number '1'
+    sequence :number { |n| ('00'..'99').to_a[n] }
     title 'End poverty in all its forms everywhere'
     cw_title 'No poverty'
     colour '#000000'

--- a/spec/factories/ndc_sdg_ndc_targets.rb
+++ b/spec/factories/ndc_sdg_ndc_targets.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :ndc_sdg_ndc_target, class: 'NdcSdg::NdcTarget' do
     ndc
-    association :target, factory: :ncd_sdg_target
+    association :target, factory: :ndc_sdg_target
     indc_text 'MyText'
     status 'MyText'
     climate_response 'MyText'

--- a/spec/factories/ndc_sdg_sectors.rb
+++ b/spec/factories/ndc_sdg_sectors.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :ndc_sdg_sector, class: 'NdcSdg::Sector' do
+    name 'MyText'
+  end
+end

--- a/spec/factories/ndc_sdg_targets.rb
+++ b/spec/factories/ndc_sdg_targets.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :ndc_sdg_target, class: 'NdcSdg::Target' do
     association :goal, factory: :ndc_sdg_goal
-    number '1.1'
+    sequence :number { |n| ('00'..'99').to_a[n] }
     title <<~EOT
       'By 2030, eradicate extreme poverty for all people everywhere, currently measured as people living on less than $1.25 a day'
     EOT


### PR DESCRIPTION
With these changes the `/ndcs/ISO/text`endpoint accepts the following query parameters:

- `goal` will highlight all the linkage texts related to the given goal *number*
- `target` will highlight all the linkage texts related to the given target *number*
- `sector` will highlight all the linkage texts related to the given sector *id*