### PR TITLE
Fix: allow change of breakby without resetting the sources selector

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -125,7 +125,7 @@ class GhgEmissionsContainer extends PureComponent {
       { name: 'breakBy', value: breakBy.value },
       { name: 'filter', value: '' }
     ];
-    this.updateUrlParam(params, true);
+    this.updateUrlParam(params);
   };
 
   handleVersionChange = version => {


### PR DESCRIPTION
Very quick fix to stop selectors resetting when changing breakBy value on the GHG emissions graph. We only want the filters to reset in this case and not the source so we dont send 'true' to the clear param for the update URL params helper.