### PR TITLE
Fix bug happening in production

### DIFF
--- a/app/serializers/api/v1/ndc_sdg/meta_serializer.rb
+++ b/app/serializers/api/v1/ndc_sdg/meta_serializer.rb
@@ -2,9 +2,12 @@ module Api
   module V1
     module NdcSdg
       class MetaSerializer < ActiveModel::Serializer
-        has_many :sectors
-        has_many :targets
-        has_many :goals
+        has_many :sectors,
+                 serializer: Api::V1::NdcSdg::SectorSerializer
+        has_many :targets,
+                 serializer: Api::V1::NdcSdg::TargetSerializer
+        has_many :goals,
+                 serializer: Api::V1::NdcSdg::GoalSerializer
       end
     end
   end


### PR DESCRIPTION
Rails was not using the correct serializers for the
collections presented on the `/ndcs/sdgs` api endpoint.

This PR explicitly tells which serializers to be used in
the `has_many` relations of `NdcsSdgs` `MetaSerializer`.

To reproduce this weird behaviour locally, you can set
`config.eager_load = true` in `config/environments/development.rb`