### PR TITLE
Fix/suggestive search from params

### DIFF
--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
@@ -41,12 +41,12 @@ class NdcsAutocompleteSearch extends PureComponent {
             />
           )}
           renderGroupTitle={(index, group) =>
-            group.groupId !== 'search' && (
+            group.groupId !== 'query' && (
               <div className="simple-group-title">{group.title}</div>
             )}
           renderOption={option => (
             <div
-              className={`simple-option ${option.groupId === 'search'
+              className={`simple-option ${option.groupId === 'query'
                 ? '-search'
                 : ''}`}
             >

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
@@ -6,7 +6,7 @@ const getSectors = state => state.sectors || null;
 const getTargets = state => state.targets || null;
 const getGoals = state => state.goals || null;
 const getQuery = state => state.query || null;
-const getQueryValues = state => state.search || null;
+const getSearch = state => state.search || null;
 
 export const getQueryUpper = state => deburrUpper(state.query);
 
@@ -53,21 +53,16 @@ export const getSearchList = createSelector(
 );
 
 export const getOptionSelected = createSelector(
-  [getSearchList, getQueryValues],
-  (options, queryValues) => {
-    if (!options || !queryValues) return null;
-    if (queryValues.query) {
+  [getSearchList, getSearch],
+  (options, search) => {
+    if (!options || !search) return null;
+    if (search.searchBy === 'query') {
       return {
-        label: queryValues.query,
-        value: queryValues.query
+        label: search.query,
+        value: search.query
       };
     }
-    return options.find(
-      option =>
-        option.value === queryValues.sector ||
-        option.value === queryValues.goal ||
-        option.value === queryValues.target
-    );
+    return options.find(option => option.value === search.query);
   }
 );
 

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
@@ -5,8 +5,8 @@ import upperFirst from 'lodash/upperFirst';
 const getSectors = state => state.sectors || null;
 const getTargets = state => state.targets || null;
 const getGoals = state => state.goals || null;
-const getQuery = state => state.query;
-const getQueryValues = state => state.queryParams || null;
+const getQuery = state => state.query || null;
+const getQueryValues = state => state.search || null;
 
 export const getQueryUpper = state => deburrUpper(state.query);
 
@@ -45,7 +45,7 @@ export const getSearchList = createSelector(
       searchOptions.push({
         label: `Search for "${query}" in the document`,
         value: query,
-        groupId: 'search'
+        groupId: 'query'
       });
     }
     return searchOptions.concat(sectors, goals, targets);
@@ -56,10 +56,10 @@ export const getOptionSelected = createSelector(
   [getSearchList, getQueryValues],
   (options, queryValues) => {
     if (!options || !queryValues) return null;
-    if (queryValues.search) {
+    if (queryValues.query) {
       return {
-        label: queryValues.search,
-        value: queryValues.search
+        label: queryValues.query,
+        value: queryValues.query
       };
     }
     return options.find(

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search.js
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search.js
@@ -65,7 +65,10 @@ class NdcsAutocompleteSearchContainer extends PureComponent {
   handleValueClick = option => {
     if (option) {
       this.props.onSearchChange(option);
-      this.updateUrlParam({ name: option.groupId, value: option.value }, true);
+      this.updateUrlParam([
+        { name: 'searchBy', value: option.groupId },
+        { name: 'query', value: option.value }
+      ]);
     }
   };
 

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search.js
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search.js
@@ -21,8 +21,8 @@ export { default as actions } from './ndcs-autocomplete-search-actions';
 
 const groups = [
   {
-    groupId: 'search',
-    title: 'Search'
+    groupId: 'query',
+    title: 'Query'
   },
   {
     groupId: 'sector',
@@ -46,7 +46,7 @@ const mapStateToProps = (state, props) => {
     sectors: state.ndcsSdgsMeta.data.sectors,
     targets: state.ndcsSdgsMeta.data.targets,
     goals: state.ndcsSdgsMeta.data.goals,
-    queryParams: qs.parse(location.search, { ignoreQueryPrefix: true })
+    search: qs.parse(location.search)
   };
   return {
     query: getQueryUpper(ndcsAutocompleteSearch),
@@ -57,14 +57,16 @@ const mapStateToProps = (state, props) => {
 };
 
 class NdcsAutocompleteSearchContainer extends PureComponent {
-  componentDidMount() {
+  componentWillMount() {
     const search = qs.parse(this.props.location.search).search || '';
     this.props.setNdcsAutocompleteSearch(search);
   }
 
   handleValueClick = option => {
-    this.props.onSearchChange(option);
-    this.updateUrlParam({ name: option.groupId, value: option.value }, true);
+    if (option) {
+      this.props.onSearchChange(option);
+      this.updateUrlParam({ name: option.groupId, value: option.value }, true);
+    }
   };
 
   updateUrlParam(params, clear) {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-actions.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-actions.js
@@ -8,10 +8,8 @@ const fetchCountryNDCFullFailed = createAction('fetchCountryNDCFullFailed');
 const fetchCountryNDCFull = createThunkAction(
   'fetchCountryNDCFull',
   (iso, search) => dispatch => {
-    const url = search
-      ? `/api/v1/ndcs/${iso}/text?${Object.keys(search)[0]}=${search[
-        Object.keys(search)[0]
-      ]}`
+    const url = search.searchBy
+      ? `/api/v1/ndcs/${iso}/text?${search.searchBy}=${search.query}`
       : `/api/v1/ndcs/${iso}/text`;
     dispatch(fetchCountryNDCFullInit());
     fetch(url)

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -44,7 +44,7 @@ class NDCCountryFull extends PureComponent {
     const {
       country,
       match,
-      onSelectChange,
+      onDocumentChange,
       contentOptions,
       contentOptionSelected,
       route,
@@ -73,7 +73,7 @@ class NDCCountryFull extends PureComponent {
               label="Document"
               options={contentOptions}
               value={contentOptionSelected}
-              onValueChange={onSelectChange}
+              onValueChange={onDocumentChange}
               hideResetButton
               disabled={contentOptions.length === 1}
             />
@@ -95,7 +95,7 @@ NDCCountryFull.propTypes = {
   country: PropTypes.object.isRequired,
   content: PropTypes.object,
   contentOptions: PropTypes.array,
-  onSelectChange: PropTypes.func,
+  onDocumentChange: PropTypes.func,
   contentOptionSelected: PropTypes.object,
   loaded: PropTypes.bool,
   idx: PropTypes.string,

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
@@ -51,7 +51,7 @@ class NDCCountryFullContainer extends PureComponent {
   onSearchChange = option => {
     const { match, fetchCountryNDCFull } = this.props;
     const { iso } = match.params;
-    if (option.groupId) {
+    if (option && option.groupId) {
       const optionValues = {
         [option.groupId]: option.value
       };
@@ -59,7 +59,7 @@ class NDCCountryFullContainer extends PureComponent {
     }
   };
 
-  onSelectChange = selected => {
+  onDocumentChange = selected => {
     this.updateUrlParam({ name: 'document', value: selected.value });
   };
 
@@ -72,7 +72,7 @@ class NDCCountryFullContainer extends PureComponent {
     return createElement(NDCCountryFullComponent, {
       ...this.props,
       onSearchChange: this.onSearchChange,
-      onSelectChange: this.onSelectChange
+      onDocumentChange: this.onDocumentChange
     });
   }
 }

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full.js
@@ -53,7 +53,8 @@ class NDCCountryFullContainer extends PureComponent {
     const { iso } = match.params;
     if (option && option.groupId) {
       const optionValues = {
-        [option.groupId]: option.value
+        searchBy: option.groupId,
+        query: option.value
       };
       fetchCountryNDCFull(iso, optionValues);
     }

--- a/app/javascript/app/styles/themes/dropdown/react-selectize.scss
+++ b/app/javascript/app/styles/themes/dropdown/react-selectize.scss
@@ -51,8 +51,9 @@ $height: 45px;
             background: none;
             border: none;
             outline: none;
-            font-size: 1em;
-            padding: 7px 0;
+            font-size: $font-size;
+            font-family: $font-family-1;
+            padding: 6px 0;
             vertical-align: middle;
             width: 0;
             position: absolute;
@@ -385,6 +386,10 @@ $height: 45px;
 
   .react-selectize-toggle-button-container {
     transform: rotate(0deg) !important;
+  }
+
+  .dropdown-menu {
+    border: solid 1px $border-color !important;
   }
 
   .open {


### PR DESCRIPTION
We had a problem where searching in the ndcs full content removed the params of the document, preventing multi-search and persistence. This was not cool. Super uncool. Now it is cooler than ever 😎 .

To fix this it needed a small refactor of how params were handled in the url and the selectors, but as a result the component is much more reusable.