### PR TITLE
Track analytics only in production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,6 +2,7 @@
 
 /* eslint global-require: 0 */
 
+const dotenv = require('dotenv').config(); // eslint-disable-line
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const CompressionPlugin = require('compression-webpack-plugin');
@@ -12,6 +13,8 @@ module.exports = merge(sharedConfig, {
   stats: 'normal',
 
   plugins: [
+    new webpack.EnvironmentPlugin(['GOOGLE_ANALYTICS_ID']),
+
     new webpack.optimize.UglifyJsPlugin({
       minimize: true,
       sourceMap: false,

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -31,6 +31,8 @@ spec:
             value: "3000"
           - name: RAILS_SERVE_STATIC_FILES
             value: "true"
+          - name: GOOGLE_ANALYTICS_ID
+            value: UA-1981881-51
           - name: PASSWORD_PROTECT
             value: "true"
           - name: AUTH_USERNAME

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "classnames": "2.2.5",
     "d3-format": "^1.2.0",
     "d3-scale": "1.0.6",
+    "dotenv": "^4.0.0",
     "history": "4.7.2",
     "lodash": "4.17.4",
     "react": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,6 +2391,10 @@ dot-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
 duplexer2@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
@@ -2910,6 +2914,10 @@ execall@^1.0.0:
   resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
   dependencies:
     clone-regexp "^1.0.0"
+
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -6481,6 +6489,12 @@ react-dom@16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-ga@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.3.5.tgz#7c3d0c530b2bbe64ceb1faa79be340685aa84a9a"
+  dependencies:
+    object-assign "^4.1.1"
+
 react-hot-loader@3.0.0-beta.7:
   version "3.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz#d5847b8165d731c4d5b30d86d5d4716227a0fa83"
@@ -6491,6 +6505,13 @@ react-hot-loader@3.0.0-beta.7:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.4.4"
+
+react-modal@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.0.0.tgz#2d8c4e0355b610f3df3fac0d60541a81bfc04324"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
 
 react-motion@0.5.1:
   version "0.5.1"


### PR DESCRIPTION
As we don't want to track events in development I've refactor a bit the GA logic and included the .env variable only in production.