### PR TITLE
Feature/import wri metadata

### DIFF
--- a/app/controllers/api/v1/metadata_controller.rb
+++ b/app/controllers/api/v1/metadata_controller.rb
@@ -2,47 +2,24 @@ module Api
   module V1
     class MetadataController < ApiController
       def index
-        render json: [{
-          slug: 'cait_historical_emissions',
-          title: 'CAIT Historical Emissions',
-          link: 'http://cait.wri.org/historical/',
-          sourceOrganization: 'WRI',
-          summary:
-            'Historical Country-level and sectoral GHG emission data
-            (1850-2014)',
-          description:
-            'As of Oct 2017, CAIT Historical Emission data contains
-            sector-level greenhouse gas (GHG) emissions data for
-            185 countries and the European Union (EU) for the
-            period 1990-2014, including emissions of the six major GHGs
-            from most major sources and sinks. It also contains historical
-            country-level carbon dioxide (CO2) emissions data going back to
-            1850, and energy sub-sector CO2 emissions data going back to
-            1971. See http://cait.wri.org/docs/CAIT2.0_CountryGHG_Methods.pdf
-            for details regarding data source and methodology.'
-        }]
+        metadata = ::WriMetadata::Source.includes(values: :property)
+        render json: metadata,
+               each_serializer: Api::V1::WriMetadata::SourceSerializer
       end
 
       def show
-        render json: {
-          slug: 'cait_historical_emissions',
-          title: 'CAIT Historical Emissions',
-          link: 'http://cait.wri.org/historical/',
-          sourceOrganization: 'WRI',
-          summary:
-            'Historical Country-level and sectoral GHG emission data
-            (1850-2014)',
-          description:
-            'As of Oct 2017, CAIT Historical Emission data contains
-            sector-level greenhouse gas (GHG) emissions data for 185
-            countries and the European Union (EU) for the period 1990-2014,
-            including emissions of the six major GHGs from most major
-            sources and sinks. It also contains historical country-level
-            carbon dioxide (CO2) emissions data going back to 1850, and
-            energy sub-sector CO2 emissions data going back to 1971.
-            See http://cait.wri.org/docs/CAIT2.0_CountryGHG_Methods.pdf for
-            details regarding data source and methodology.'
-        }
+        metadata = ::WriMetadata::Source.
+          includes(values: :property).
+          where(name: params[:slug]).
+          first
+        render json: metadata,
+               serializer: Api::V1::WriMetadata::SourceSerializer
+      end
+
+      def acronyms
+        acronyms = ::WriMetadata::Acronym.all
+        render json: acronyms,
+               each_serializer: Api::V1::WriMetadata::AcronymSerializer
       end
     end
   end

--- a/app/models/wri_metadata.rb
+++ b/app/models/wri_metadata.rb
@@ -1,0 +1,5 @@
+module WriMetadata
+  def self.table_name_prefix
+    'wri_metadata_'
+  end
+end

--- a/app/models/wri_metadata/acronym.rb
+++ b/app/models/wri_metadata/acronym.rb
@@ -1,4 +1,6 @@
 module WriMetadata
   class Acronym < ApplicationRecord
+    validates :acronym, presence: true, uniqueness: true
+    validates :definition, presence: true
   end
 end

--- a/app/models/wri_metadata/acronym.rb
+++ b/app/models/wri_metadata/acronym.rb
@@ -1,0 +1,4 @@
+module WriMetadata
+  class Acronym < ApplicationRecord
+  end
+end

--- a/app/models/wri_metadata/property.rb
+++ b/app/models/wri_metadata/property.rb
@@ -1,5 +1,8 @@
 module WriMetadata
   class Property < ApplicationRecord
     has_many :values, class_name: 'WriMetadata::Value'
+
+    validates :slug, presence: true, uniqueness: true
+    validates :name, presence: true
   end
 end

--- a/app/models/wri_metadata/property.rb
+++ b/app/models/wri_metadata/property.rb
@@ -1,0 +1,5 @@
+module WriMetadata
+  class Property < ApplicationRecord
+    has_many :values, class_name: 'WriMetadata::Value'
+  end
+end

--- a/app/models/wri_metadata/source.rb
+++ b/app/models/wri_metadata/source.rb
@@ -1,0 +1,5 @@
+module WriMetadata
+  class Source < ApplicationRecord
+    has_many :values, class_name: 'WriMetadata::Value'
+  end
+end

--- a/app/models/wri_metadata/source.rb
+++ b/app/models/wri_metadata/source.rb
@@ -1,5 +1,13 @@
 module WriMetadata
   class Source < ApplicationRecord
     has_many :values, class_name: 'WriMetadata::Value'
+
+    def value_by_property(property)
+      self.values.
+        find do |value|
+          value.property.slug == property.to_s
+        end.
+        value
+    end
   end
 end

--- a/app/models/wri_metadata/source.rb
+++ b/app/models/wri_metadata/source.rb
@@ -5,9 +5,9 @@ module WriMetadata
     validates :name, presence: true
 
     def value_by_property(property)
-      self.values.
+      values.
         find do |v|
-         v.property.slug == property.to_s
+          v.property.slug == property.to_s
         end
     end
   end

--- a/app/models/wri_metadata/source.rb
+++ b/app/models/wri_metadata/source.rb
@@ -2,6 +2,8 @@ module WriMetadata
   class Source < ApplicationRecord
     has_many :values, class_name: 'WriMetadata::Value'
 
+    validates :name, presence: true
+
     def value_by_property(property)
       self.values.
         find do |value|

--- a/app/models/wri_metadata/source.rb
+++ b/app/models/wri_metadata/source.rb
@@ -6,10 +6,9 @@ module WriMetadata
 
     def value_by_property(property)
       self.values.
-        find do |value|
-          value.property.slug == property.to_s
-        end.
-        value
+        find do |v|
+         v.property.slug == property.to_s
+        end
     end
   end
 end

--- a/app/models/wri_metadata/value.rb
+++ b/app/models/wri_metadata/value.rb
@@ -1,0 +1,6 @@
+module WriMetadata
+  class Value < ApplicationRecord
+    belongs_to :source, class_name: 'WriMetadata::Source'
+    belongs_to :property, class_name: 'WriMetadata::Property'
+  end
+end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -6,6 +6,7 @@ module Api
         attribute :source
         attribute :name
         attribute :slug
+        attribute :description, if: -> { object.description }
         attribute :category_ids, if: -> { object.category_ids.length.positive? }
         attribute :labels
         attribute :locations

--- a/app/serializers/api/v1/wri_metadata/acronym_serializer.rb
+++ b/app/serializers/api/v1/wri_metadata/acronym_serializer.rb
@@ -8,4 +8,3 @@ module Api
     end
   end
 end
-

--- a/app/serializers/api/v1/wri_metadata/acronym_serializer.rb
+++ b/app/serializers/api/v1/wri_metadata/acronym_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    module WriMetadata
+      class AcronymSerializer < ActiveModel::Serializer
+        attribute :acronym
+        attribute :definition
+      end
+    end
+  end
+end
+

--- a/app/serializers/api/v1/wri_metadata/source_serializer.rb
+++ b/app/serializers/api/v1/wri_metadata/source_serializer.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     module WriMetadata
       class SourceSerializer < ActiveModel::Serializer
+        attribute :name, key: :source
         attribute :title
         attribute :subtitle
         attribute :technical_title
@@ -19,10 +20,19 @@ module Api
         attribute :published_language
         attribute :published_title
 
-        def read_attribute_for_serialization(attribute)
-          object.value_by_property(attribute)
+        def source
+          object.name
         end
 
+        def read_attribute_for_serialization(attribute)
+          value = object.value_by_property(attribute)
+
+          if value.nil? && object.methods.include?(attribute)
+            object.send(attribute)
+          elsif !value.nil?
+            value.value
+          end
+        end
       end
     end
   end

--- a/app/serializers/api/v1/wri_metadata/source_serializer.rb
+++ b/app/serializers/api/v1/wri_metadata/source_serializer.rb
@@ -1,0 +1,51 @@
+module Api
+  module V1
+    module WriMetadata
+      class SourceSerializer < ActiveModel::Serializer
+        attribute :name, key: :slug
+        attribute :title
+        attribute :link
+        attribute :organization, key: :sourceOrganization
+        attribute :summary
+        attribute :description
+
+        def title
+          select_by_property('title_75_character_limit')
+        end
+
+        def link
+          select_by_property('learn_more_link')
+        end
+
+        def organization
+          select_by_property('source_organization')
+        end
+
+        def summary
+          select_by_property(
+            'functionsummary_tagline_description'\
+            '_of_what_data_says_150_character_limit'
+          )
+        end
+
+        def description
+          select_by_property(
+            'description_recap_data_name_source_'\
+            'organization_objectives_data_type_methodology'
+          )
+        end
+
+        private
+
+        def select_by_property(property)
+          object.values.
+            select do |value|
+              value.property.name == property
+            end.
+            first.
+            value
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/wri_metadata/source_serializer.rb
+++ b/app/serializers/api/v1/wri_metadata/source_serializer.rb
@@ -2,49 +2,27 @@ module Api
   module V1
     module WriMetadata
       class SourceSerializer < ActiveModel::Serializer
-        attribute :name, key: :slug
         attribute :title
-        attribute :link
-        attribute :organization, key: :sourceOrganization
+        attribute :subtitle
+        attribute :technical_title
+        attribute :source_organization
+        attribute :learn_more_link
         attribute :summary
         attribute :description
+        attribute :cautions
+        attribute :geographic_coverage
+        attribute :date_of_content
+        attribute :frequency_of_updates
+        attribute :summary_of_licenses
+        attribute :terms_of_service_link
+        attribute :citation
+        attribute :published_language
+        attribute :published_title
 
-        def title
-          select_by_property('title_75_character_limit')
+        def read_attribute_for_serialization(attribute)
+          object.value_by_property(attribute)
         end
 
-        def link
-          select_by_property('learn_more_link')
-        end
-
-        def organization
-          select_by_property('source_organization')
-        end
-
-        def summary
-          select_by_property(
-            'functionsummary_tagline_description'\
-            '_of_what_data_says_150_character_limit'
-          )
-        end
-
-        def description
-          select_by_property(
-            'description_recap_data_name_source_'\
-            'organization_objectives_data_type_methodology'
-          )
-        end
-
-        private
-
-        def select_by_property(property)
-          object.values.
-            select do |value|
-              value.property.name == property
-            end.
-            first.
-            value
-        end
       end
     end
   end

--- a/app/services/import_wri_metadata.rb
+++ b/app/services/import_wri_metadata.rb
@@ -1,7 +1,8 @@
 class ImportWriMetadata
   WRI_ACRONYMS_FILEPATH = 'metadata/Acronyms.csv'.freeze
   WRI_METADATA_FILEPATH = 'metadata/metadata_sources.csv'.freeze
-  WRI_DESCRIPTIONS_FILEPATH = 'metadata/metadata_sources_descriptions.csv'.freeze
+  WRI_DESCRIPTIONS_FILEPATH = 'metadata/metadata_sources_descriptions.csv'.
+    freeze
 
   def call
     cleanup
@@ -27,9 +28,8 @@ class ImportWriMetadata
     @acronyms = S3CSVReader.read(WRI_ACRONYMS_FILEPATH)
     @metadata = S3CSVReader.read(WRI_METADATA_FILEPATH)
     @descriptions_index = S3CSVReader.read(WRI_DESCRIPTIONS_FILEPATH).
-      reduce({}) do |memo, current|
+      each_with_object({}) do |current, memo|
         memo[current[:id].to_sym] = current[:description]
-        memo
       end
     @sources_index = {}
     @properties_index = {}

--- a/app/services/import_wri_metadata.rb
+++ b/app/services/import_wri_metadata.rb
@@ -1,0 +1,71 @@
+class ImportWriMetadata
+  WRI_ACRONYMS_FILEPATH = 'metadata/Acronyms.csv'.freeze
+  WRI_METADATA_FILEPATH = 'metadata/metadata_sources.csv'.freeze
+
+  def call
+    cleanup
+
+    load_csvs
+
+    import_acronyms
+    import_sources
+    import_properties
+    import_values
+  end
+
+  private
+
+  def cleanup
+    WriMetadata::Acronym.delete_all
+    WriMetadata::Value.delete_all
+    WriMetadata::Source.delete_all
+    WriMetadata::Property.delete_all
+  end
+
+  def load_csvs
+    @acronyms = S3CSVReader.read(WRI_ACRONYMS_FILEPATH)
+    @metadata = S3CSVReader.read(WRI_METADATA_FILEPATH)
+    @sources_index = {}
+    @properties_index = {}
+  end
+
+  def import_acronyms
+    @acronyms.each do |r|
+      WriMetadata::Acronym.create(
+        acronym: r[:acronym].strip,
+        definition: r[:definition].strip
+      )
+    end
+  end
+
+  def import_sources
+    sources = @metadata.map { |r| r[:dataset] }.uniq
+    sources.each do |s|
+      @sources_index[s] = WriMetadata::Source.create!(
+        name: s
+      )
+    end
+  end
+
+  def import_properties
+    properties = @metadata.first.to_h.except(:dataset).keys
+    properties.each do |a|
+      @properties_index[a] = WriMetadata::Property.create!(
+        name: a
+      )
+    end
+  end
+
+  def import_values
+    @metadata.each do |row|
+      source = @sources_index[row[:dataset]]
+      row.to_h.except(:dataset).each do |property, value|
+        WriMetadata::Value.create!(
+          source: source,
+          property: @properties_index[property],
+          value: value
+        )
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
           action: :content_overview
       end
       resources :adaptations, only: [:index]
-      resources :metadata, only: [:index, :show]
+      resources :metadata, param: :slug, only: [:index, :show] do
+        get :acronyms, on: :collection, controller: :metadata, action: :acronyms
+      end
 
       get '(*endpoint)', controller: :api, action: :route_not_found
     end

--- a/db/migrate/20171016112825_create_wri_metadata_acronyms.rb
+++ b/db/migrate/20171016112825_create_wri_metadata_acronyms.rb
@@ -5,5 +5,7 @@ class CreateWriMetadataAcronyms < ActiveRecord::Migration[5.1]
       t.text :definition
       t.timestamps
     end
+
+    add_index :wri_metadata_acronyms, :acronym, unique: true
   end
 end

--- a/db/migrate/20171016112825_create_wri_metadata_acronyms.rb
+++ b/db/migrate/20171016112825_create_wri_metadata_acronyms.rb
@@ -1,0 +1,9 @@
+class CreateWriMetadataAcronyms < ActiveRecord::Migration[5.1]
+  def change
+    create_table :wri_metadata_acronyms do |t|
+      t.text :acronym
+      t.text :definition
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171016113108_create_wri_metadata_sources.rb
+++ b/db/migrate/20171016113108_create_wri_metadata_sources.rb
@@ -1,0 +1,8 @@
+class CreateWriMetadataSources < ActiveRecord::Migration[5.1]
+  def change
+    create_table :wri_metadata_sources do |t|
+      t.text :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171016113116_create_wri_metadata_properties.rb
+++ b/db/migrate/20171016113116_create_wri_metadata_properties.rb
@@ -1,0 +1,8 @@
+class CreateWriMetadataProperties < ActiveRecord::Migration[5.1]
+  def change
+    create_table :wri_metadata_properties do |t|
+      t.text :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171016113116_create_wri_metadata_properties.rb
+++ b/db/migrate/20171016113116_create_wri_metadata_properties.rb
@@ -1,6 +1,7 @@
 class CreateWriMetadataProperties < ActiveRecord::Migration[5.1]
   def change
     create_table :wri_metadata_properties do |t|
+      t.text :slug
       t.text :name
       t.timestamps
     end

--- a/db/migrate/20171016113116_create_wri_metadata_properties.rb
+++ b/db/migrate/20171016113116_create_wri_metadata_properties.rb
@@ -5,5 +5,7 @@ class CreateWriMetadataProperties < ActiveRecord::Migration[5.1]
       t.text :name
       t.timestamps
     end
+
+    add_index :wri_metadata_properties, :slug, unique: true
   end
 end

--- a/db/migrate/20171016113522_create_wri_metadata_value.rb
+++ b/db/migrate/20171016113522_create_wri_metadata_value.rb
@@ -1,0 +1,10 @@
+class CreateWriMetadataValue < ActiveRecord::Migration[5.1]
+  def change
+    create_table :wri_metadata_values do |t|
+      t.references :source, foreign_key: {to_table: :wri_metadata_sources, on_delete: :cascade}
+      t.references :property, foreign_key: {to_table: :wri_metadata_properties, on_delete: :cascade}
+      t.text :value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171016113522_create_wri_metadata_value.rb
+++ b/db/migrate/20171016113522_create_wri_metadata_value.rb
@@ -6,5 +6,8 @@ class CreateWriMetadataValue < ActiveRecord::Migration[5.1]
       t.text :value
       t.timestamps
     end
+
+   add_index :wri_metadata_values, [:source_id, :property_id],
+             unique: true, name: 'source_id_property_id_index'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,6 +283,7 @@ ActiveRecord::Schema.define(version: 20171016113522) do
   end
 
   create_table "wri_metadata_properties", force: :cascade do |t|
+    t.text "slug"
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -280,6 +280,7 @@ ActiveRecord::Schema.define(version: 20171016113522) do
     t.text "definition"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["acronym"], name: "index_wri_metadata_acronyms_on_acronym", unique: true
   end
 
   create_table "wri_metadata_properties", force: :cascade do |t|
@@ -287,6 +288,7 @@ ActiveRecord::Schema.define(version: 20171016113522) do
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_wri_metadata_properties_on_slug", unique: true
   end
 
   create_table "wri_metadata_sources", force: :cascade do |t|
@@ -302,6 +304,7 @@ ActiveRecord::Schema.define(version: 20171016113522) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["property_id"], name: "index_wri_metadata_values_on_property_id"
+    t.index ["source_id", "property_id"], name: "source_id_property_id_index", unique: true
     t.index ["source_id"], name: "index_wri_metadata_values_on_source_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171011134822) do
+ActiveRecord::Schema.define(version: 20171016113522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -275,6 +275,35 @@ ActiveRecord::Schema.define(version: 20171011134822) do
     t.index ["sector_id"], name: "index_wb_indc_values_on_sector_id"
   end
 
+  create_table "wri_metadata_acronyms", force: :cascade do |t|
+    t.text "acronym"
+    t.text "definition"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "wri_metadata_properties", force: :cascade do |t|
+    t.text "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "wri_metadata_sources", force: :cascade do |t|
+    t.text "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "wri_metadata_values", force: :cascade do |t|
+    t.bigint "source_id"
+    t.bigint "property_id"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["property_id"], name: "index_wri_metadata_values_on_property_id"
+    t.index ["source_id"], name: "index_wri_metadata_values_on_source_id"
+  end
+
   add_foreign_key "adaptation_values", "adaptation_variables", column: "variable_id", on_delete: :cascade
   add_foreign_key "adaptation_values", "locations", on_delete: :cascade
   add_foreign_key "cait_indc_indicators", "cait_indc_charts", column: "chart_id", on_delete: :cascade
@@ -307,6 +336,8 @@ ActiveRecord::Schema.define(version: 20171011134822) do
   add_foreign_key "wb_indc_values", "locations", on_delete: :cascade
   add_foreign_key "wb_indc_values", "wb_indc_indicators", column: "indicator_id", on_delete: :cascade
   add_foreign_key "wb_indc_values", "wb_indc_sectors", column: "sector_id", on_delete: :cascade
+  add_foreign_key "wri_metadata_values", "wri_metadata_properties", column: "property_id", on_delete: :cascade
+  add_foreign_key "wri_metadata_values", "wri_metadata_sources", column: "source_id", on_delete: :cascade
 
   create_view "indc_indicators", materialized: true,  sql_definition: <<-SQL
       SELECT ('cait'::text || cait_indc_indicators.id) AS id,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -10,7 +10,8 @@ namespace :db do
     'historical_emissions:import',
     'cait_indc:import',
     'wb_indc:import',
-    'adaptation:import'
+    'adaptation:import',
+    'wri_metadata:import'
   ]
 
   desc 'Imports all data in correct order, replaces all data'

--- a/lib/tasks/wri_metadata.rake
+++ b/lib/tasks/wri_metadata.rake
@@ -1,0 +1,6 @@
+namespace :wri_metadata do
+  desc 'Imports the WRI Metadata dataset from the csv sources'
+  task import: :environment do
+    ImportWriMetadata.new.call
+  end
+end

--- a/spec/controllers/api/v1/metadata_controller_spec.rb
+++ b/spec/controllers/api/v1/metadata_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Api::V1::MetadataController, type: :controller do
+  context do
+    let(:parsed_body) {
+      JSON.parse(response.body)
+    }
+    let!(:some_acronyms) {
+      FactoryGirl.create_list(:wri_metadata_acronym, 3)
+    }
+    let!(:some_metadat_values) {
+      FactoryGirl.create_list(:wri_metadata_value, 5)
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index
+        expect(response).to be_success
+      end
+
+      it 'returns all known acronyms' do
+        get :index
+        expect(parsed_body.length).to eq(5)
+      end
+    end
+
+    describe 'GET acronyms' do
+      it 'returns a successful 200 response' do
+        get :acronyms
+        expect(response).to be_success
+      end
+
+      it 'lists all known acronyms' do
+        get :acronyms
+        expect(parsed_body.length).to eq(3)
+      end
+    end
+  end
+end
+

--- a/spec/controllers/api/v1/metadata_controller_spec.rb
+++ b/spec/controllers/api/v1/metadata_controller_spec.rb
@@ -37,4 +37,3 @@ describe Api::V1::MetadataController, type: :controller do
     end
   end
 end
-

--- a/spec/factories/wri_metadata_acronyms.rb
+++ b/spec/factories/wri_metadata_acronyms.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :wri_metadata_acronym, class: 'WriMetadata::Acronym' do
+    acronym 'MT'
+    definition 'MyText'
+  end
+end
+
+

--- a/spec/factories/wri_metadata_acronyms.rb
+++ b/spec/factories/wri_metadata_acronyms.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :wri_metadata_acronym, class: 'WriMetadata::Acronym' do
-    acronym 'MT'
+    sequence :acronym { |n| ('AAA'..'ZZZ').to_a[n] }
     definition 'MyText'
   end
 end
-
-

--- a/spec/factories/wri_metadata_properties.rb
+++ b/spec/factories/wri_metadata_properties.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :wri_metadata_property, class: 'WriMetadata::Property' do
+    slug 'my-text'
+    name 'MyText'
+  end
+end
+

--- a/spec/factories/wri_metadata_properties.rb
+++ b/spec/factories/wri_metadata_properties.rb
@@ -4,4 +4,3 @@ FactoryGirl.define do
     name 'MyText'
   end
 end
-

--- a/spec/factories/wri_metadata_properties.rb
+++ b/spec/factories/wri_metadata_properties.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :wri_metadata_property, class: 'WriMetadata::Property' do
-    slug 'my-text'
+    sequence :slug { |n| ('aaa'..'zzz').to_a[n] }
     name 'MyText'
   end
 end

--- a/spec/factories/wri_metadata_sources.rb
+++ b/spec/factories/wri_metadata_sources.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :wri_metadata_source, class: 'WriMetadata::Source' do
+    name 'MyText'
+  end
+end
+
+

--- a/spec/factories/wri_metadata_sources.rb
+++ b/spec/factories/wri_metadata_sources.rb
@@ -3,5 +3,3 @@ FactoryGirl.define do
     name 'MyText'
   end
 end
-
-

--- a/spec/factories/wri_metadata_values.rb
+++ b/spec/factories/wri_metadata_values.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :wri_metadata_value, class: 'WriMetadata::Value' do
+    association :source, factory: :wri_metadata_source
+    association :property, factory: :wri_metadata_property
+    value 'MyText'
+  end
+end

--- a/spec/models/wri_metadata/acronym_spec.rb
+++ b/spec/models/wri_metadata/acronym_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe WriMetadata::Acronym, type: :model do
+  it 'should be invalid when acronym not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_acronym, acronym: nil)
+    ).to have(1).errors_on(:acronym)
+  end
+
+  it 'should be invalid when definition not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_acronym, definition: nil)
+    ).to have(1).errors_on(:definition)
+  end
+end

--- a/spec/models/wri_metadata/property_spec.rb
+++ b/spec/models/wri_metadata/property_spec.rb
@@ -7,4 +7,3 @@ describe WriMetadata::Property, type: :model do
     ).to have(1).errors_on(:name)
   end
 end
-

--- a/spec/models/wri_metadata/property_spec.rb
+++ b/spec/models/wri_metadata/property_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe WriMetadata::Property, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_property, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+end
+

--- a/spec/models/wri_metadata/source_spec.rb
+++ b/spec/models/wri_metadata/source_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe WriMetadata::Source, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_source, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+end

--- a/spec/models/wri_metadata/value_spec.rb
+++ b/spec/models/wri_metadata/value_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe WriMetadata::Value, type: :model do
+  it 'should be invalid when source not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_value, source: nil)
+    ).to have(1).errors_on(:source)
+  end
+
+  it 'should be invalid when property not present' do
+    expect(
+      FactoryGirl.build(:wri_metadata_value, property: nil)
+    ).to have(1).errors_on(:property)
+  end
+end

--- a/spec/services/import_wri_metadata_spec.rb
+++ b/spec/services/import_wri_metadata_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+object_contents = {
+  'metadata/Acronyms.csv' => <<~END,
+    Acronym,Definition
+    WRI ,World Resources Institute
+  END
+  'metadata/metadata_sources.csv' => <<~END,
+    dataset,title,subtitle
+    historical_emissions_CAIT,CAIT Historical Emissions,CAIT Historical Emissions
+  END
+  'metadata/metadata_sources_descriptions.csv' => <<~END
+    id,description
+    title,Title (75 character limit)
+    subtitle,"Subtitle (Abbreviated Source, ex. NASA)"
+  END
+}
+
+RSpec.describe ImportWriMetadata do
+  subject { ImportWriMetadata.new.call }
+
+  before :all do
+    Aws.config[:s3] = {
+      stub_responses: {
+        get_object: lambda { |context|
+          {body: object_contents[context.params[:key]]}
+        }
+      }
+    }
+  end
+
+  after :all do
+    Aws.config[:s3] = {
+      stub_responses: nil
+    }
+  end
+
+  it 'Creates new acronym definitions' do
+    expect { subject }.to change { WriMetadata::Acronym.count }.by(1)
+  end
+
+  it 'Creates new dataset properties' do
+    expect { subject }.to change { WriMetadata::Value.count }.by(2)
+  end
+end


### PR DESCRIPTION
This pull request makes available the following list of features.
To use them, you must:

```
rails db:migrate
rails wri_metadata:import
```

- `/api/v1/metadata` endpoint returns a list of data sources, each with a set of properties. The property `source` is a slug that behaves like the ID of each data source. sample: http://termbin.com/exdd

- `/api/v1/metadata/:slug` endpoint returns a single data source object from the list above. Use the `source` property as the slug. http://termbin.com/ufi0

- `/api/v1/metadata/acronyms` returns a list of acronym definitions that the WRI has given us. sample: http://termbin.com/k490

- `/api/v1/ndcs` has been updated to include a description of each indicator. it is available under each indicator object. sample: http://termbin.com/s74u (search for `"description"`, and mind that not all indicators have descriptions yet. only ones from the world bank dataset do.)