### PR TITLE
Fix filtering categories object

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -24,6 +24,12 @@ module Api
         categories = ::Indc::Category.all
         sectors = ::Indc::Sector.all
 
+        if params[:filter]
+          categories = categories.where(
+            category_type: params[:filter]
+          )
+        end
+
         render json: NdcIndicators.new(indicators, categories, sectors),
                serializer: Api::V1::Indc::NdcIndicatorsSerializer
       end


### PR DESCRIPTION
The `/ndcs/` endpoint was returning `categories` of type both 'map' and 'overview' even when the `filter` parameter is used. This led to weird behaviour in the NDC map screen.

This fixes it so that it only shows categories of type map or overview when the `filter` query param is used.

I'd like to have validation from the FE team to check if this change in behaviour breaks anything in the site. I think it won't but...