### PR TITLE
Fix/ie grid

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -2,6 +2,9 @@
   "plugins": {
     "postcss-cssnext": {
       "browsers": ["last 2 versions", "IE > 10"]
+    },
+    "autoprefixer": {
+      "grid": true
     }
   }
 }

--- a/app/javascript/app/components/accordion/accordion-styles.scss
+++ b/app/javascript/app/components/accordion/accordion-styles.scss
@@ -45,6 +45,8 @@
 .definitionCompare {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(4, 1fr);
   padding: 30px 0;
   border-bottom: solid 1px rgba(#9090b2, 0.15);
@@ -56,6 +58,8 @@
 
 .definition {
   @extend %grid;
+
+  @include msGridColumns(1fr, 3fr);
 
   grid-template-columns: 1fr 3fr;
   padding: 20px 0;

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-styles.scss
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-styles.scss
@@ -1,6 +1,8 @@
 @import '../../styles/layout.scss';
 
 .grid {
+  @include msGridColumns(1fr);
+
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr auto;
@@ -23,6 +25,8 @@
 
 .graphControls {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
 
   grid-template-columns: repeat(4, 1fr);
   margin-bottom: 25px;

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-styles.scss
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-styles.scss
@@ -11,6 +11,19 @@
   height: 100%;
   border-right: solid 1px $border-color;
   padding-right: $gutter-padding;
+
+  > div:nth-child(1) {
+    -ms-grid-row: 1;
+  }
+
+  > div:nth-child(2) {
+    -ms-grid-row: 2;
+    min-height: 200px;
+  }
+
+  > div:nth-child(3) {
+    -ms-grid-row: 3;
+  }
 }
 
 .title {

--- a/app/javascript/app/components/country-ghg/country-ghg-styles.scss
+++ b/app/javascript/app/components/country-ghg/country-ghg-styles.scss
@@ -1,11 +1,14 @@
 @import '~styles/layout.scss';
 
 .grid {
-  @include msGridColumns(7fr, 5fr);
-
   display: grid;
   grid-template-columns: 7fr 5fr;
   position: relative;
   height: calc(100vh - 100px);
   max-height: 800px;
+  min-height: 500px;
+
+  > div:nth-child(2) {
+    -ms-grid-column: 2;
+  }
 }

--- a/app/javascript/app/components/country-ghg/country-ghg-styles.scss
+++ b/app/javascript/app/components/country-ghg/country-ghg-styles.scss
@@ -1,6 +1,8 @@
 @import '~styles/layout.scss';
 
 .grid {
+  @include msGridColumns(7fr, 5fr);
+
   display: grid;
   grid-template-columns: 7fr 5fr;
   position: relative;

--- a/app/javascript/app/components/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country-ndc-overview/country-ndc-overview-styles.scss
@@ -8,6 +8,8 @@
 .col2 {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr);
+
   grid-template-columns: repeat(2, 1fr);
 }
 
@@ -17,6 +19,8 @@
 
 .actions {
   @extend %grid;
+
+  @include msGridColumns(1fr, 2fr, 3fr);
 
   grid-template-columns: 1fr 2fr 3fr;
 }
@@ -30,6 +34,8 @@
 
 .cards {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
 
   grid-template-columns: repeat(4, 1fr);
   margin-bottom: 60px;

--- a/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -3,6 +3,8 @@
 .header {
   @extend %grid;
 
+  @include msGridColumns(3fr, 1fr);
+
   grid-template-columns: 3fr 1fr;
   margin-bottom: 10px;
   margin-top: 20px;
@@ -10,6 +12,8 @@
 
 .sdgs {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr);
 
   grid-template-columns: repeat(3, 1fr);
   grid-column-gap: 0;

--- a/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -11,15 +11,12 @@
 }
 
 .sdgs {
-  @extend %grid;
+  @include clearFix();
 
-  @include msGridColumns(1fr, 1fr, 1fr);
-
-  grid-template-columns: repeat(3, 1fr);
-  grid-column-gap: 0;
-  position: relative;
-  margin-left: -1px;
-  margin-bottom: 40px;
+  > div {
+    float: left;
+    width: 33.333333%;
+  }
 }
 
 .titleContainer {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -3,6 +3,8 @@
 .col4 {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(5, 1fr);
   align-items: end;
   margin-bottom: 40px;

--- a/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list-styles.scss
+++ b/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list-styles.scss
@@ -5,6 +5,7 @@
   border-bottom: solid 1px $border-color;
   border-left: solid 1px $border-color;
   border-right: solid 1px $border-color;
+  min-height: 686px;
 
   .header {
     display: flex;
@@ -36,7 +37,7 @@
 
   .targetContainer {
     overflow-y: auto;
-    max-height: 601px;
+    max-height: 616px;
 
     &::-webkit-scrollbar {
       width: 0;

--- a/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table-styles.scss
+++ b/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table-styles.scss
@@ -2,6 +2,9 @@
 
 .container {
   display: grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(3, 1fr);
   grid-column-gap: 0;
   background-color: $white;

--- a/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table-styles.scss
+++ b/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table-styles.scss
@@ -1,16 +1,17 @@
 @import '~styles/layout.scss';
 
 .container {
-  display: grid;
+  @include clearFix();
 
-  @include msGridColumns(1fr, 1fr, 1fr);
+  > div {
+    float: left;
+    width: 33.333333%;
+    background-color: $white;
+  }
 
-  grid-template-columns: repeat(3, 1fr);
-  grid-column-gap: 0;
-  background-color: $white;
   margin-bottom: 1px;
 }
 
 .loading {
-  min-height: 654px;
+  min-height: 686px;
 }

--- a/app/javascript/app/components/ndcs-map/ndcs-map-styles.scss
+++ b/app/javascript/app/components/ndcs-map/ndcs-map-styles.scss
@@ -8,6 +8,8 @@
 .col4 {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(4, 1fr);
   align-items: end;
 }

--- a/app/javascript/app/components/ndcs-table/ndcs-table-styles.scss
+++ b/app/javascript/app/components/ndcs-table/ndcs-table-styles.scss
@@ -4,6 +4,8 @@
 .col4 {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(4, 1fr);
   align-items: end;
 }

--- a/app/javascript/app/components/sdg-card/sdg-card-styles.scss
+++ b/app/javascript/app/components/sdg-card/sdg-card-styles.scss
@@ -34,7 +34,7 @@ $animation-delay-time: 0.1s;
 }
 
 .square {
-  min-height: 110px;
+  min-height: 115px;
   padding: 10px;
 }
 
@@ -121,7 +121,7 @@ $animation-delay-time: 0.1s;
 
   @for $i from 1 through length($sdg-colors) {
     &#{$i} {
-      background-color: rgba(nth($sdg-colors, $i), 0.6);
+      background-color: rgba(nth($sdg-colors, $i), 0.6) !important;
     }
   }
 }

--- a/app/javascript/app/components/section/section-styles.scss
+++ b/app/javascript/app/components/section/section-styles.scss
@@ -4,6 +4,8 @@
 .doubleFold {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr);
+
   grid-template-columns: repeat(2, 1fr);
 }
 

--- a/app/javascript/app/components/stories/stories-styles.scss
+++ b/app/javascript/app/components/stories/stories-styles.scss
@@ -16,9 +16,6 @@
 
 .grid {
   display: grid;
-
-  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
-
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: 300px 300px;
 }
@@ -31,7 +28,7 @@
   color: $white;
   font-size: $font-size-large;
   z-index: 0;
-  background-size: 106%;
+  background-size: cover;
   background-position: center;
   transition: background-size 0.3s ease-in;
 
@@ -47,13 +44,37 @@
     z-index: -1;
   }
 
-  &:hover {
-    background-size: 110%;
+  &:hover::after {
+    background-image: linear-gradient(-180deg, rgba($bg-blue, 0) 0%, rgba($bg-blue, 0.2) 100%);
   }
 
   &:first-child {
     grid-column: 1 / span 2;
     grid-row: 1 / span 2;
     font-size: $font-size-x-large;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2;
+    -ms-grid-row: 1;
+    -ms-grid-row-span: 2;
+  }
+
+  &:nth-child(2) {
+    -ms-grid-column: 3;
+    -ms-grid-row: 1;
+  }
+
+  &:nth-child(3) {
+    -ms-grid-column: 4;
+    -ms-grid-row: 1;
+  }
+
+  &:nth-child(4) {
+    -ms-grid-column: 3;
+    -ms-grid-row: 2;
+  }
+
+  &:nth-child(5) {
+    -ms-grid-column: 4;
+    -ms-grid-row: 2;
   }
 }

--- a/app/javascript/app/components/stories/stories-styles.scss
+++ b/app/javascript/app/components/stories/stories-styles.scss
@@ -16,6 +16,9 @@
 
 .grid {
   display: grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: 300px 300px;
 }

--- a/app/javascript/app/pages/about/about-styles.scss
+++ b/app/javascript/app/pages/about/about-styles.scss
@@ -20,6 +20,8 @@
 .partners {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(3, 1fr);
   grid-row-gap: $gutter-padding;
   justify-items: start;
@@ -45,6 +47,8 @@
   }
 
   &.additionalData {
+    @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr, 1fr);
+
     grid-template-columns: repeat(6, 1fr);
   }
 }

--- a/app/javascript/app/pages/country/country-styles.scss
+++ b/app/javascript/app/pages/country/country-styles.scss
@@ -4,6 +4,8 @@
 .header {
   @extend %grid;
 
+  @include msGridColumns(10fr, 2fr);
+
   grid-template-columns: 10fr 2fr;
 }
 

--- a/app/javascript/app/pages/home/home-styles.scss
+++ b/app/javascript/app/pages/home/home-styles.scss
@@ -4,6 +4,8 @@
 .doubleFold {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr);
+
   grid-template-columns: repeat(2, 1fr);
 }
 

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-styles.scss
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-styles.scss
@@ -33,6 +33,8 @@ $country-filter-height: 60px;
 .fourFold {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr);
+
   grid-template-columns: repeat(4, 1fr);
   grid-column-gap: 0;
 }

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -3,11 +3,15 @@
 .twoFold {
   @extend %grid;
 
+  @include msGridColumns(7fr, 5fr);
+
   grid-template-columns: 7fr 5fr;
 }
 
 .twoFoldReversed {
   @extend %grid;
+
+  @include msGridColumns(5fr, 7fr);
 
   grid-template-columns: 5fr 7fr;
 }
@@ -29,6 +33,8 @@
 .actions {
   @extend %grid;
 
+  @include msGridColumns(3fr, 4fr, 5fr);
+
   grid-template-columns: 3fr 4fr 5fr;
   padding-top: 30px;
   padding-bottom: 40px;
@@ -47,6 +53,8 @@
 
 .bodyContent {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr, 1fr);
 
   grid-template-columns: repeat(6, 1fr);
   padding-top: 80px;

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -3,11 +3,15 @@
 .doubleFold {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr);
+
   grid-template-columns: repeat(2, 1fr);
 }
 
 .threeFold {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr, 1fr);
 
   grid-template-columns: repeat(3, 1fr);
 }

--- a/app/javascript/app/pages/ndc-sdg/ndc-sdg-styles.scss
+++ b/app/javascript/app/pages/ndc-sdg/ndc-sdg-styles.scss
@@ -3,6 +3,8 @@
 .grid {
   @extend %grid;
 
+  @include msGridColumns(4fr, 8fr);
+
   grid-template-columns: 4fr 8fr;
 }
 

--- a/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
+++ b/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
@@ -4,11 +4,15 @@
 .headerCols {
   @extend %grid;
 
+  @include msGridColumns(7fr, 5fr);
+
   grid-template-columns: 7fr 5fr;
 }
 
 .contentCols {
   @extend %grid;
+
+  @include msGridColumns(1fr, 1fr);
 
   grid-template-columns: repeat(2, 50%);
 }

--- a/app/javascript/app/pages/ndcs/ndcs-styles.scss
+++ b/app/javascript/app/pages/ndcs/ndcs-styles.scss
@@ -10,5 +10,7 @@
 .cols {
   @extend %grid;
 
+  @include msGridColumns(1fr, 1fr);
+
   grid-template-columns: repeat(2, 1fr);
 }

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -35,3 +35,23 @@
   display: -ms-grid;
   -ms-grid-columns: $frs;
 }
+
+@mixin clearFix() {
+  &::before,
+  &::after {
+    content: " ";
+    display: table;
+  }
+
+  &::after {
+    display: block;
+    clear: both;
+    height: 1px;
+    margin-top: -1px;
+    visibility: hidden;
+  }
+
+  & {
+    *zoom: 1;
+  }
+}

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -12,3 +12,26 @@
   display: grid;
   grid-column-gap: $gutter-padding;
 }
+
+@mixin msGridColumns($columns...) {
+  $frs: ();
+
+  @for $i from 1 through length($columns) {
+    $item: nth($columns, $i);
+
+    @if $i==$columns {
+      $frs: append($frs, $item);
+    }
+
+    @else {
+      $frs: append($frs, $item $gutter-padding);
+    }
+
+    > *:nth-child(#{$i}) {
+      -ms-grid-column: #{$i + ($i - 1)};
+    }
+  }
+
+  display: -ms-grid;
+  -ms-grid-columns: $frs;
+}

--- a/app/javascript/app/styles/themes/header/header.scss
+++ b/app/javascript/app/styles/themes/header/header.scss
@@ -4,5 +4,7 @@
 .headerGrid {
   @extend %grid;
 
+  @include msGridColumns(7fr, 5fr);
+
   grid-template-columns: 7fr 5fr;
 }

--- a/config/webpack/loaders/sass.js
+++ b/config/webpack/loaders/sass.js
@@ -2,6 +2,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const { resolve } = require('path');
 const { env, settings } = require('../configuration');
 
+const postcssConfig = resolve(process.cwd(), '.postcssrc');
 const sourceMap = env.NODE_ENV === 'development';
 
 const sassConfig = [
@@ -12,7 +13,10 @@ const sassConfig = [
       localIdentName: '[name]__[local]__[hash:base64:5]'
     }
   },
-  { loader: 'postcss-loader', options: { sourceMap } },
+  {
+    loader: 'postcss-loader',
+    options: { sourceMap, config: { path: postcssConfig } }
+  },
   {
     loader: `sass-loader?includePaths[]='${resolve(
       settings.source_path,

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -25,7 +25,7 @@ development:
   <<: *default
 
   dev_server:
-    host: 0.0.0.0
+    host: 192.168.1.48
     port: 8080
     https: false
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -25,7 +25,7 @@ development:
   <<: *default
 
   dev_server:
-    host: 192.168.1.48
+    host: 0.0.0.0
     port: 8080
     https: false
 


### PR DESCRIPTION
A lot of crazy css stuff to make edge happy also make the autoprefixer config available.

Included a [mixin](https://github.com/Vizzuality/climate-watch/compare/fix/ie-grid?expand=1#diff-98c071b619746cac29b2229daa3de7c1R16) that saves us when only columns but still have to handle manually the rows (as for example in the [home stories](https://github.com/Vizzuality/climate-watch/compare/fix/ie-grid?expand=1#diff-e253114f0ea9cb0b6c59607426b22645R55)).

Also to next tests we have to change the webpacker ip to be able to test from other laptop in the same network to our internall ip ([example](https://github.com/Vizzuality/climate-watch/commit/9394c659436b7af9e9cda11ac5ab5e4201b1b365))

