### PR TITLE
Fix indc endpoint serialization

### DIFF
--- a/app/lib/indexed_serializer.rb
+++ b/app/lib/indexed_serializer.rb
@@ -11,4 +11,19 @@ module IndexedSerializer
       sort_by(&:first).
       to_h
   end
+
+  def self.serialize_collection(objects, options, &block)
+    serialized_values = ActiveModel::Serializer.
+      serializer_for(objects).
+      new(objects, options).
+      as_json
+
+    objects.
+      map(&block).
+      zip(serialized_values).
+      group_by(&:first).
+      each_with_object({}) do |value, memo|
+        memo[value.first] = value.second.map(&:second)
+      end
+  end
 end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -20,9 +20,10 @@ module Api
         end
 
         def locations
-          IndexedSerializer.serialize(
+          IndexedSerializer.serialize_collection(
             object.values,
-            serializer: ValueSerializer
+            serializer: ValueSerializer,
+            ree: object.id == 'wb36'
           ) do |v|
             v.location.iso_code3
           end


### PR DESCRIPTION
**don't merge before frontend update**

In the old CAIT indicator dataset, each indicator takes one value per location.

In the new WB indicator dataset, each indicator takes multiple values per location,
as it takes one value per location and sector. To correctly reflect this fact we
need to change the serialization format of this object. Previously, the serialization
format was:

```
    {
      "id": "wb36",
      "source": "wb",
      "name": "Capacity Building Needs for Sectorial Implementation",
      "slug": "A_Sc_CapBud",
      "description": "Capacity building needs for sectorial implementation",
      "category_ids": Array[2][
        "wb7",
        "wb6"
      ],
      "labels": {

      },
      "locations": {
        "AFG": {
          "value": "Operators and analysts for hydrological, meteorological and data integrated systems",
          "sector_id": "wb20"
        }
      }
    },
```

Whereas now, the format will be:

```
    {
      "id": "wb36",
      "source": "wb",
      "name": "Capacity Building Needs for Sectorial Implementation",
      "slug": "A_Sc_CapBud",
      "description": "Capacity building needs for sectorial implementation",
      "category_ids": Array[2][
        "wb7",
        "wb6"
      ],
      "labels": {

      },
      "locations": {
        "AFG": Array[9][
          {
            "value": "Ecological engineering and spatial planning for water resources",
            "sector_id": "wb2"
          },
          {
            "value": "Practitioners for watershed management",
            "sector_id": "wb6"
          },
          {
            "value": "Vocational and engineering capacity to design, build and maintain climate friendly irrigation networks and local schemes",
            "sector_id": "wb8"
          },
          {
            "value": "Protected areas and species ecologists, and ecological economists trained and working",
            "sector_id": "wb9"
          },
          {
            "value": "Practitioners group built in university, government and local delivery levels",
            "sector_id": "wb11"
          },
          {
            "value": "National centre for sustainable energy strengthened and expanded. Combine public and private competencies.",
            "sector_id": "wb14"
          },
          {
            "value": "Training Afghan climate policy experts",
            "sector_id": "wb18"
          },
          {
            "value": "Climate science institutes with university",
            "sector_id": "wb19"
          },
          {
            "value": "Operators and analysts for hydrological, meteorological and data integrated systems",
            "sector_id": "wb20"
          }
        ]
      }
    },
```

For obvious reasons, don't merge this branch until the front-end gets updated.