### PR TITLE
Feature/ensure sorting on all endpoints

### DIFF
--- a/app/controllers/api/v1/locations/countries_controller.rb
+++ b/app/controllers/api/v1/locations/countries_controller.rb
@@ -6,7 +6,7 @@ module Api
           countries = Location.where(
             location_type: 'COUNTRY',
             show_in_cw: true
-          )
+          ).order(:wri_standard_name)
 
           render json: countries,
                  each_serializer: Api::V1::LocationSerializer,

--- a/app/controllers/api/v1/locations/regions_controller.rb
+++ b/app/controllers/api/v1/locations/regions_controller.rb
@@ -6,7 +6,7 @@ module Api
           regions = Location.where(
             location_type: 'REGION',
             show_in_cw: true
-          ).includes(:members)
+          ).includes(:members).order(:wri_standard_name)
 
           render json: regions,
                  each_serializer: Api::V1::LocationSerializer,

--- a/app/controllers/api/v1/metadata_controller.rb
+++ b/app/controllers/api/v1/metadata_controller.rb
@@ -2,7 +2,9 @@ module Api
   module V1
     class MetadataController < ApiController
       def index
-        metadata = ::WriMetadata::Source.includes(values: :property)
+        metadata = ::WriMetadata::Source.
+          includes(values: :property).
+          order(:name)
         render json: metadata,
                each_serializer: Api::V1::WriMetadata::SourceSerializer
       end
@@ -17,7 +19,9 @@ module Api
       end
 
       def acronyms
-        acronyms = ::WriMetadata::Acronym.all
+        acronyms = ::WriMetadata::Acronym.
+          order(:acronym).
+          all
         render json: acronyms,
                each_serializer: Api::V1::WriMetadata::AcronymSerializer
       end

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -45,13 +45,16 @@ module Api
             }, locations: {
               iso_code3: params[:code]
             }
-          )
+          ).
+          order('indc_indicators.name')
+
 
         sectors = ::Indc::Sector.
           includes(:parent, values: :location).
           where(locations: {iso_code3: params[:code]}).
           map(&:parent).
           map(&:name).
+          sort.
           uniq
 
         render json: NdcOverview.new(values, sectors),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
         get :meta, on: :collection
       end
 
-      resources :ndcs, param: :code, only: [:index, :show] do
+      resources :ndcs, param: :code, only: [:index] do
         get :text, on: :collection, controller: :ndc_texts, action: :index
         get :text, on: :member, controller: :ndc_texts, action: :show
         get :sdgs, on: :collection, controller: :ndc_sdgs, action: :index


### PR DESCRIPTION
Add sorting where it is possible. Some endpoints return data in a indexed format so
it is not possible to sort those objects.