### PR TITLE
Force source key to lowercase and strip spaces

### DIFF
--- a/app/services/import_wri_metadata.rb
+++ b/app/services/import_wri_metadata.rb
@@ -48,7 +48,7 @@ class ImportWriMetadata
     sources = @metadata.map { |r| r[:dataset] }.uniq
     sources.each do |s|
       @sources_index[s] = WriMetadata::Source.create!(
-        name: s
+        name: s.strip.downcase
       )
     end
   end


### PR DESCRIPTION
This PR forces the conversion of dataset names to lowercase and strips any leading/trailing spaces. Since this is done on the import process, please run `rails wri_metadata:import` after merging so that changes become visible.