### PR TITLE
Re-orders sections as requested on Basecamp

### DIFF
--- a/app/javascript/app/components/country-climate-vulnerability/country-climate-vulnerability-selectors.js
+++ b/app/javascript/app/components/country-climate-vulnerability/country-climate-vulnerability-selectors.js
@@ -53,12 +53,6 @@ export const getSectionData = createSelector(
         data: getData(sections, iso, 'poverty_14')
       },
       {
-        sectionType: 'LINE',
-        title: getSection(sections, 'climate_risks').name,
-        slug: 'climate_risks',
-        data: getData(sections, iso, 'climate_risks')
-      },
-      {
         sectionType: 'LIST',
         title: 'Key hazards',
         slug: 'hazards',
@@ -66,16 +60,22 @@ export const getSectionData = createSelector(
         metadataUrl: getListMetadata(sections, iso, 'wb_urls')
       },
       {
-        sectionType: 'CIRCULAR',
-        title: getSection(sections, 'readiness').name,
-        slug: 'readiness',
-        data: getData(sections, iso, 'readiness')
+        sectionType: 'LINE',
+        title: getSection(sections, 'climate_risks').name,
+        slug: 'climate_risks',
+        data: getData(sections, iso, 'climate_risks')
       },
       {
         sectionType: 'CIRCULAR',
         title: getSection(sections, 'vulnerability').name,
         slug: 'vulnerability',
         data: getData(sections, iso, 'vulnerability')
+      },
+      {
+        sectionType: 'CIRCULAR',
+        title: getSection(sections, 'readiness').name,
+        slug: 'readiness',
+        data: getData(sections, iso, 'readiness')
       },
       {
         sectionType: 'LINK',


### PR DESCRIPTION
This PR adjusts the order of the boxes on the Poverty section of the country pages, as per the request on Basecamp: https://basecamp.com/1756858/projects/13795275/todos/327318991