### PR TITLE
Use calculation for map and pass search prop to force rerender

### DIFF
--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -3,7 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import groupBy from 'lodash/groupBy';
 import intersection from 'lodash/intersection';
-import CALCULATION_OPTIONS from 'app/data/constants';
+import { CALCULATION_OPTIONS } from 'app/data/constants';
 
 import {
   getYColumnValue,
@@ -209,7 +209,9 @@ export const getChartData = createSelector(
 
     let xValues = [];
     xValues = data[0].emissions.map(d => d.year);
-    if (calculationSelected.value !== 'ABSOLUTE_VALUE') {
+    if (
+      calculationSelected.value !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
+    ) {
       xValues = intersection(
         xValues,
         Object.keys(calculationData).map(y => parseInt(y, 10))

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -3,6 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import groupBy from 'lodash/groupBy';
 import intersection from 'lodash/intersection';
+import CALCULATION_OPTIONS from 'app/data/constants';
 
 import {
   getYColumnValue,
@@ -38,20 +39,10 @@ const EXCLUDED_SECTORS = [
   'Total excluding LULUCF'
 ];
 
-const CALCULATION_OPTIONS = [
-  {
-    label: 'Absolute value',
-    value: 'ABSOLUTE_VALUE'
-  },
-  {
-    label: 'per Capita',
-    value: 'PER_CAPITA'
-  },
-  {
-    label: 'per GDP',
-    value: 'PER_GDP'
-  }
-];
+const calculationKeys = Object.keys(CALCULATION_OPTIONS);
+const options = calculationKeys.map(
+  calculationKey => CALCULATION_OPTIONS[calculationKey]
+);
 
 // meta data for selectors
 const getMeta = state => state.meta || {};
@@ -92,7 +83,7 @@ export const getCalculationOptions = createSelector(
   parseCalculationData,
   calculationData => {
     if (!calculationData) return [];
-    return CALCULATION_OPTIONS;
+    return options;
   }
 );
 
@@ -108,10 +99,8 @@ export const getSourceSelected = createSelector(
 export const getCalculationSelected = createSelector(
   [getCalculationSelection],
   selected => {
-    if (!selected) return CALCULATION_OPTIONS[0];
-    return CALCULATION_OPTIONS.find(
-      calculation => calculation.value === selected
-    );
+    if (!selected) return options[0];
+    return options.find(calculation => calculation.value === selected);
   }
 );
 
@@ -191,10 +180,10 @@ export const filterData = createSelector(
 );
 
 const calculatedRatio = (selected, calculationData, x) => {
-  if (selected === 'PER_GDP') {
+  if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
     return calculationData[x][0].gdp;
   }
-  if (selected === 'PER_CAPITA') {
+  if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
     return calculationData[x][0].population;
   }
   return 1;

--- a/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
+++ b/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { scalePow } from 'd3-scale';
 import isEmpty from 'lodash/isEmpty';
-import CALCULATION_OPTIONS from 'app/data/constants';
+import { CALCULATION_OPTIONS } from 'app/data/constants';
 
 import worldPaths from 'app/data/world-50m-paths';
 

--- a/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
+++ b/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
@@ -12,6 +12,7 @@ const isLoading = state => state.loading;
 const getSources = state => state.meta.data_source || null;
 const getSourceSelection = state => state.search.source || false;
 const getYear = state => parseInt(state.year, 10);
+const getCalculationSelection = state => state.search.calculation || null;
 
 const EXCLUDED_INDICATORS = ['WORLD'];
 const buckets = [
@@ -146,10 +147,22 @@ export const getPathsWithStyles = createSelector([getDataParsed], data => {
   });
 });
 
-export const getLegendData = createSelector(getYearSelected, year => ({
-  title: `GHG Emissions per capita in ${year}`,
-  buckets
-}));
+export const getLegendData = createSelector(
+  [getCalculationSelection, getYearSelected],
+  (calculation, year) => {
+    let calculationText = '';
+    if (calculation === 'PER_CAPITA') {
+      calculationText = 'per capita ';
+    } else if (calculation === 'PER_GDP') {
+      calculationText = 'per GDP ';
+    }
+
+    return {
+      title: `GHG Emissions ${calculationText}in ${year}`,
+      buckets
+    };
+  }
+);
 
 export const getMapReady = createSelector(
   [isLoaded, isLoading],

--- a/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
+++ b/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
@@ -152,7 +152,10 @@ export const getLegendData = createSelector(
   [getCalculationSelection, getYearSelected],
   (calculation, year) => {
     let calculationText = '';
-    if (calculation !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value) {
+    if (
+      calculation &&
+      calculation !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
+    ) {
       calculationText = `${CALCULATION_OPTIONS[calculation].label} `;
     }
 

--- a/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
+++ b/app/javascript/app/components/country-ghg-map/country-ghg-map-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { scalePow } from 'd3-scale';
 import isEmpty from 'lodash/isEmpty';
+import CALCULATION_OPTIONS from 'app/data/constants';
 
 import worldPaths from 'app/data/world-50m-paths';
 
@@ -151,10 +152,8 @@ export const getLegendData = createSelector(
   [getCalculationSelection, getYearSelected],
   (calculation, year) => {
     let calculationText = '';
-    if (calculation === 'PER_CAPITA') {
-      calculationText = 'per capita ';
-    } else if (calculation === 'PER_GDP') {
-      calculationText = 'per GDP ';
+    if (calculation !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value) {
+      calculationText = `${CALCULATION_OPTIONS[calculation].label} `;
     }
 
     return {

--- a/app/javascript/app/components/country-ghg/country-ghg-component.jsx
+++ b/app/javascript/app/components/country-ghg/country-ghg-component.jsx
@@ -43,7 +43,7 @@ class CountryGhg extends PureComponent {
 }
 
 CountryGhg.propTypes = {
-  search: PropTypes.string
+  search: PropTypes.node
 };
 
 export default CountryGhg;

--- a/app/javascript/app/components/country-ghg/country-ghg-component.jsx
+++ b/app/javascript/app/components/country-ghg/country-ghg-component.jsx
@@ -43,7 +43,7 @@ class CountryGhg extends PureComponent {
 }
 
 CountryGhg.propTypes = {
-  search: PropTypes.node
+  search: PropTypes.object
 };
 
 export default CountryGhg;

--- a/app/javascript/app/components/country-ghg/country-ghg-component.jsx
+++ b/app/javascript/app/components/country-ghg/country-ghg-component.jsx
@@ -4,6 +4,7 @@ import GHGCountryMap from 'components/country-ghg-map';
 import EmissionsMetaProvider from 'providers/ghg-emissions-meta-provider';
 import WbCountryDataProvider from 'providers/wb-country-data-provider';
 import cx from 'classnames';
+import PropTypes from 'prop-types';
 import throttle from 'lodash/throttle';
 
 import layout from 'styles/layout.scss';
@@ -25,17 +26,24 @@ class CountryGhg extends PureComponent {
   }, 10);
 
   render() {
+    const { search } = this.props;
     return (
       <div className={cx(layout.content, styles.grid)}>
         <EmissionsMetaProvider />
         <WbCountryDataProvider />
         <GHGCountryEmissions handleYearHover={this.handleYearHover} />
-        <GHGCountryMap className={styles.map} year={this.state.year} />
+        <GHGCountryMap
+          search={search}
+          className={styles.map}
+          year={this.state.year}
+        />
       </div>
     );
   }
 }
 
-CountryGhg.propTypes = {};
+CountryGhg.propTypes = {
+  search: PropTypes.string
+};
 
 export default CountryGhg;

--- a/app/javascript/app/components/country-ghg/country-ghg.js
+++ b/app/javascript/app/components/country-ghg/country-ghg.js
@@ -1,3 +1,11 @@
+import { withRouter } from 'react-router-dom';
+import qs from 'query-string';
+import { connect } from 'react-redux';
 import Component from './country-ghg-component';
 
-export default Component;
+const mapStateToProps = (state, { location }) => {
+  const search = qs.parse(location.search);
+  return { search };
+};
+
+export default withRouter(connect(mapStateToProps, null)(Component));

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -1,0 +1,14 @@
+export default {
+  ABSOLUTE_VALUE: {
+    label: 'Absolute value',
+    value: 'ABSOLUTE_VALUE'
+  },
+  PER_CAPITA: {
+    label: 'per Capita',
+    value: 'PER_CAPITA'
+  },
+  PER_GDP: {
+    label: 'per GDP',
+    value: 'PER_GDP'
+  }
+};

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -1,4 +1,4 @@
-export default {
+export const CALCULATION_OPTIONS = {
   ABSOLUTE_VALUE: {
     label: 'Absolute value',
     value: 'ABSOLUTE_VALUE'
@@ -11,4 +11,8 @@ export default {
     label: 'per GDP',
     value: 'PER_GDP'
   }
+};
+
+export default {
+  CALCULATION_OPTIONS
 };


### PR DESCRIPTION
[Country page's map's legend should update with the selection of calculation on the graph.](https://www.pivotaltracker.com/story/show/152344219)

- Use calculation to get correct legend for the map
- Pass search to the GHGCountryMap component to force rerender when the calculation is changed

![image](https://user-images.githubusercontent.com/9701591/32117592-df81b396-bb46-11e7-976a-f129e7590507.png)
