### PR TITLE
Uses document_type and language to enable switching from docs of the same type

### DIFF
--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-reducers.js
@@ -15,7 +15,6 @@ export default {
     if (isEmpty(payload)) {
       return setLoaded(true, setLoading(false, state));
     }
-
     const newState = {
       ...state,
       selected: payload[0].id,

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import uniqBy from 'lodash/uniqBy';
 
 const getCountries = state => state.countries.data;
 const getSelected = state => state.document || null;
@@ -28,10 +29,13 @@ const getLabel = item =>
   `${item.document_type.toUpperCase()} (${item.language.toUpperCase()})`;
 
 export const getContentOptions = createSelector(getContent, content =>
-  (content || []).map(item => ({
-    value: `${item.document_type}-${item.language}`,
-    label: getLabel(item)
-  }))
+  uniqBy(
+    (content || []).map(item => ({
+      value: `${item.document_type}-${item.language}`,
+      label: getLabel(item)
+    })),
+    'value'
+  )
 );
 
 export const getContentOptionSelected = createSelector(

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -14,7 +14,13 @@ export const getSelectedContent = createSelector(
   (selected, content) => {
     if (!content || !content.length) return null;
     if (!selected) return content[0];
-    return content.find(item => item.document_type === selected, 10);
+    const splitSelected = selected.split('-');
+    return content.find(
+      item =>
+        item.document_type === splitSelected[0] &&
+        item.language === splitSelected[1],
+      10
+    );
   }
 );
 
@@ -23,7 +29,7 @@ const getLabel = item =>
 
 export const getContentOptions = createSelector(getContent, content =>
   (content || []).map(item => ({
-    value: item.document_type,
+    value: `${item.document_type}-${item.language}`,
     label: getLabel(item)
   }))
 );


### PR DESCRIPTION
This PR fixes the following bug: https://www.pivotaltracker.com/story/show/152392874

The bug prevented us from switching between ndc documents when a country had multiple.
I've used both the document_type and the language to set the value of the dropdown, and now we can happily switch between multiple NDCs. We just got to wait for them to start having multiple NDCs on the same language.... =D but I think that's not going to happen, because they told us that it wouldn't. =)

## TEST

Go to the China full ndc page and switch between both NDCs. =) http://localhost:3000/ndcs/country/CHN/full