### PR TITLE
Feature: ndc category navigation

### DIFF
--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -2,9 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-collapse';
 import Icon from 'components/icon';
-import NoContent from 'components/no-content';
 import cx from 'classnames';
-import Loading from 'components/loading';
 
 import dropdownArrow from 'assets/icons/dropdown-arrow.svg';
 import layout from 'styles/layout.scss';
@@ -17,13 +15,10 @@ class Accordion extends PureComponent {
       data,
       handleOnClick,
       activeSection,
-      compare,
-      loading
+      compare
     } = this.props;
     return (
       <div className={className}>
-        {loading && <Loading light className={styles.loader} />}
-        {!data.length && !loading && <NoContent message="Nothing here" />}
         {data.map((section, index) => {
           let isOpen = index === 0;
           if (activeSection) {
@@ -107,8 +102,7 @@ Accordion.propTypes = {
       definitions: PropTypes.array.isRequired
     })
   ),
-  compare: PropTypes.bool,
-  loading: PropTypes.bool
+  compare: PropTypes.bool
 };
 
 Accordion.defaultProps = {

--- a/app/javascript/app/components/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country-ndc-overview/country-ndc-overview-component.jsx
@@ -13,7 +13,7 @@ import styles from './country-ndc-overview-styles.scss';
 class CountryNdcOverview extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { iso, sectors, values, loading } = this.props;
+    const { iso, sectors, values, loading, actions } = this.props;
     const hasSectors = values && sectors;
     return (
       <div className={styles.wrapper}>
@@ -21,29 +21,37 @@ class CountryNdcOverview extends PureComponent {
           {loading && <Loading light className={styles.loader} />}
           {hasSectors && (
             <div>
-              <div className={cx(styles.header, styles.col2)}>
+              <div className={cx(styles.header, actions ? styles.col2 : '')}>
                 <Intro
                   theme={introTheme}
-                  title="Nationally Determined Contribution (NDC) Overview"
+                  title={
+                    actions ? (
+                      'Nationally Determined Contribution (NDC) Overview'
+                    ) : (
+                      'Overview'
+                    )
+                  }
                   description={values.indc_summary[0].value}
                 />
-                <div className={styles.actions}>
-                  <div className={styles.printButton} />
-                  <Button
-                    className={styles.exploreBtn}
-                    color="white"
-                    link={`/ndcs/compare?locations=${iso}`}
-                  >
-                    Compare
-                  </Button>
-                  <Button
-                    className={styles.exploreBtn}
-                    color="yellow"
-                    link={`/ndcs/country/${iso}`}
-                  >
-                    Explore NDC content
-                  </Button>
-                </div>
+                {actions && (
+                  <div className={styles.actions}>
+                    <div className={styles.printButton} />
+                    <Button
+                      className={styles.exploreBtn}
+                      color="white"
+                      link={`/ndcs/compare?locations=${iso}`}
+                    >
+                      Compare
+                    </Button>
+                    <Button
+                      className={styles.exploreBtn}
+                      color="yellow"
+                      link={`/ndcs/country/${iso}`}
+                    >
+                      Explore NDC content
+                    </Button>
+                  </div>
+                )}
               </div>
               <h4 className={styles.subTitle}>Mitigation contribution</h4>
               <div className={styles.cards}>
@@ -97,7 +105,7 @@ class CountryNdcOverview extends PureComponent {
                           // eslint-disable-line
                           __html: values.coverage_sectors_short[0].value
                         }}
-                      /> // eslint-disable-line
+                      />
                     ) : (
                       <div className={styles.noContent}>Not included</div>
                     )}
@@ -136,7 +144,8 @@ CountryNdcOverview.propTypes = {
   iso: PropTypes.string,
   sectors: PropTypes.array,
   values: PropTypes.object,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  actions: PropTypes.bool
 };
 
 export default CountryNdcOverview;

--- a/app/javascript/app/components/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country-ndc-overview/country-ndc-overview.js
@@ -2,6 +2,7 @@ import { PureComponent, createElement } from 'react';
 import { connect } from 'react-redux';
 import Proptypes from 'prop-types';
 import { withRouter } from 'react-router';
+import isEmpty from 'lodash/isEmpty';
 
 import actions from './country-ndc-overview-actions';
 import reducers, { initialState } from './country-ndc-overview-reducers';
@@ -17,15 +18,16 @@ const mapStateToProps = (state, { match }) => {
     iso,
     values: getValuesGrouped(countryData),
     loading: state.countryNDCOverview.loading,
-    sectors: countryData ? countryData.sectors : null
+    sectors: countryData ? countryData.sectors : null,
+    fetched: !isEmpty(overviewData[iso])
   };
 };
 
 class CountryNdcOverviewContainer extends PureComponent {
   componentWillMount() {
-    const { match, loading, fetchCountryNdcOverviewData } = this.props;
+    const { match, loading, fetched, fetchCountryNdcOverviewData } = this.props;
     const { iso } = match.params;
-    if (iso && !loading) {
+    if (iso && !loading && !fetched) {
       fetchCountryNdcOverviewData(iso);
     }
   }
@@ -40,7 +42,8 @@ class CountryNdcOverviewContainer extends PureComponent {
 CountryNdcOverviewContainer.propTypes = {
   match: Proptypes.object.isRequired,
   loading: Proptypes.bool,
-  fetchCountryNdcOverviewData: Proptypes.func
+  fetchCountryNdcOverviewData: Proptypes.func,
+  fetched: Proptypes.bool
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -1,0 +1,42 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+
+const fetchNdcsCountryAccordionInit = createAction(
+  'fetchNdcsCountryAccordionInit'
+);
+const fetchNdcsCountryAccordionReady = createAction(
+  'fetchNdcsCountryAccordionReady'
+);
+const fetchNdcsCountryAccordionFailed = createAction(
+  'fetchNdcsCountryAccordionFailed'
+);
+
+const fetchNdcsCountryAccordion = createThunkAction(
+  'fetchNdcsCountryAccordion',
+  (iso, category) => dispatch => {
+    dispatch(fetchNdcsCountryAccordionInit());
+    fetch(`/api/v1/ndcs?location=${iso}&category=${category}&filter=overview`)
+      .then(response => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then(data => {
+        const dataWithIso = {
+          iso,
+          data
+        };
+        dispatch(fetchNdcsCountryAccordionReady(dataWithIso));
+      })
+      .catch(error => {
+        dispatch(fetchNdcsCountryAccordionFailed(iso));
+        console.info(error);
+      });
+  }
+);
+
+export default {
+  fetchNdcsCountryAccordion,
+  fetchNdcsCountryAccordionInit,
+  fetchNdcsCountryAccordionReady,
+  fetchNdcsCountryAccordionFailed
+};

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Accordion from 'components/accordion';
+import NoContent from 'components/no-content';
+import Loading from 'components/loading';
 
 import styles from './ndcs-country-accordion-styles.scss';
 
@@ -9,11 +11,23 @@ class NdcsCountryAccordion extends PureComponent {
   render() {
     const { ndcsData, loading } = this.props;
     return (
-      <Accordion
-        className={styles.accordion}
-        data={ndcsData}
-        loading={loading}
-      />
+      <div className={styles.wrapper}>
+        {loading && <Loading light className={styles.loader} />}
+        {!ndcsData.length && !loading && (
+          <NoContent
+            message="No content for this category"
+            icon
+            className={styles.noContent}
+          />
+        )}
+        {ndcsData && ndcsData.length > 0 && (
+          <Accordion
+            className={styles.accordion}
+            data={ndcsData}
+            loading={loading}
+          />
+        )}
+      </div>
     );
   }
 }

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
@@ -1,0 +1,26 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Accordion from 'components/accordion';
+
+import styles from './ndcs-country-accordion-styles.scss';
+
+class NdcsCountryAccordion extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const { ndcsData, loading } = this.props;
+    return (
+      <Accordion
+        className={styles.accordion}
+        data={ndcsData}
+        loading={loading}
+      />
+    );
+  }
+}
+
+NdcsCountryAccordion.propTypes = {
+  ndcsData: PropTypes.array,
+  loading: PropTypes.bool
+};
+
+export default NdcsCountryAccordion;

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-reducers.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-reducers.js
@@ -1,0 +1,34 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  data: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+
+export default {
+  fetchNdcsCountryAccordionInit: state => setLoading(true, state),
+  fetchNdcsCountryAccordionReady: (state, { payload }) => {
+    const newState = {
+      ...state,
+      data: {
+        ...state.data,
+        [payload.iso]: payload.data
+      }
+    };
+
+    return setLoaded(true, setLoading(false, newState));
+  },
+  fetchNdcsCountryAccordionFailed: (state, { payload }) => {
+    const newState = {
+      ...state,
+      data: {
+        ...state.data,
+        [payload]: []
+      }
+    };
+
+    return setLoaded(true, setLoading(false, newState));
+  }
+};

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -1,0 +1,71 @@
+import { createSelector } from 'reselect';
+import { deburrUpper } from 'app/utils';
+
+const getCountries = state => state.countries;
+const getAllIndicators = state => (state.data ? state.data.indicators : {});
+const getCategories = state => (state.data ? state.data.categories : {});
+const getSearch = state => deburrUpper(state.search);
+
+export const parseIndicatorsDefs = createSelector(
+  [getAllIndicators, getCategories, getCountries],
+  (indicators, categories, countries) => {
+    if (!indicators || !categories || !countries) return {};
+    const parsedIndicators = {};
+    Object.keys(categories).forEach(category => {
+      const categoryIndicators = indicators.filter(
+        indicator => indicator.category_ids.indexOf(category) > -1
+      );
+      const parsedDefinitions = categoryIndicators.map(def => {
+        const descriptions = countries.map(country => ({
+          iso: country,
+          value: def.locations[country] ? def.locations[country][0].value : null
+        }));
+        return {
+          title: def.name,
+          slug: def.slug,
+          descriptions
+        };
+      });
+      parsedIndicators[category] = parsedDefinitions;
+    });
+    return parsedIndicators;
+  }
+);
+
+export const getNDCs = createSelector(
+  [getCategories, parseIndicatorsDefs],
+  (categories, indicators) => {
+    if (!categories) return [];
+    const ndcs = Object.keys(categories).map(category => ({
+      title: categories[category].name,
+      slug: categories[category].slug,
+      definitions: indicators[category] ? indicators[category] : []
+    }));
+    return ndcs;
+  }
+);
+
+export const filterNDCs = createSelector(
+  [getNDCs, getSearch],
+  (ndcs, search) => {
+    if (!ndcs) return [];
+    const filteredNDCs = ndcs.map(ndc => {
+      const defs = ndc.definitions.filter(
+        def =>
+          deburrUpper(def.title).indexOf(search) > -1 ||
+          deburrUpper(def.descriptions[0].value).indexOf(search) > -1
+      );
+
+      return {
+        ...ndc,
+        definitions: defs
+      };
+    });
+    const reducedNDCs = filteredNDCs.filter(ndc => ndc.definitions.length > 0);
+    return reducedNDCs;
+  }
+);
+
+export default {
+  filterNDCs
+};

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
@@ -1,7 +1,26 @@
 @import '~styles/layout.scss';
 
+$min-height: 450px;
+
+.wrapper {
+  position: relative;
+}
+
 .accordion {
   margin-bottom: -1px;
   position: relative;
-  min-height: 400px;
+  min-height: $min-height;
+}
+
+.loader {
+  min-height: $min-height;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 5;
+}
+
+.noContent {
+  min-height: $min-height;
 }

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
@@ -1,0 +1,7 @@
+@import '~styles/layout.scss';
+
+.accordion {
+  margin-bottom: -1px;
+  position: relative;
+  min-height: 400px;
+}

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion.js
@@ -1,0 +1,53 @@
+import { PureComponent, createElement } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import qs from 'query-string';
+
+import actions from './ndcs-country-accordion-actions';
+import reducers, { initialState } from './ndcs-country-accordion-reducers';
+
+import NdcsCountryAccordionComponent from './ndcs-country-accordion-component';
+import { filterNDCs } from './ndcs-country-accordion-selectors';
+
+const mapStateToProps = (state, { match, location }) => {
+  const { iso } = match.params;
+  const search = qs.parse(location.search);
+  const ndcsData = {
+    data: state.ndcCountryAccordion.data[match.params.iso],
+    search: search.search,
+    countries: [match.params.iso]
+  };
+  return {
+    fetched: state.ndcCountryAccordion.data[iso],
+    loading: state.ndcCountryAccordion.loading,
+    search: search.search,
+    ndcsData: filterNDCs(ndcsData),
+    iso
+  };
+};
+
+class NdcsCountryAccordionContainer extends PureComponent {
+  componentWillMount() {
+    const { iso, fetchNdcsCountryAccordion, category } = this.props;
+    fetchNdcsCountryAccordion(iso, category);
+  }
+
+  render() {
+    return createElement(NdcsCountryAccordionComponent, {
+      ...this.props
+    });
+  }
+}
+
+NdcsCountryAccordionContainer.propTypes = {
+  fetchNdcsCountryAccordion: PropTypes.func,
+  iso: PropTypes.string,
+  category: PropTypes.string
+};
+
+export { actions, reducers, initialState };
+
+export default withRouter(
+  connect(mapStateToProps, actions)(NdcsCountryAccordionContainer)
+);

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
@@ -59,7 +59,7 @@ export const parseIndicatorsDefs = createSelector(
       const parsedDefinitions = categoryIndicators.map(def => {
         const descriptions = countries.map(country => ({
           iso: country,
-          value: def.locations[country] ? def.locations[country].value : null
+          values: def.locations[country] ? def.locations[country] : null
         }));
         return {
           title: def.name,

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
@@ -59,7 +59,7 @@ export const parseIndicatorsDefs = createSelector(
       const parsedDefinitions = categoryIndicators.map(def => {
         const descriptions = countries.map(country => ({
           iso: country,
-          values: def.locations[country] ? def.locations[country] : null
+          value: def.locations[country] ? def.locations[country].value : null
         }));
         return {
           title: def.name,

--- a/app/javascript/app/pages/ndc-country/ndc-country-actions.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-actions.js
@@ -1,9 +1,6 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 
-/* @tmpfix: remove usage of indcTransform */
-import indcTransform from 'utils/indctransform';
-
 const fetchCountryNDCInit = createAction('fetchCountryNDCInit');
 const fetchCountryNDCReady = createAction('fetchCountryNDCReady');
 const fetchCountryNDCFailed = createAction('fetchCountryNDCFailed');
@@ -17,7 +14,6 @@ const fetchCountryNDC = createThunkAction(
         if (response.ok) return response.json();
         throw Error(response.statusText);
       })
-      .then(data => indcTransform(data))
       .then(data => {
         const dataWithIso = {
           iso,

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { renderRoutes } from 'react-router-config';
 import Header from 'components/header';
 import Intro from 'components/intro';
-import Accordion from 'components/accordion';
 import Button from 'components/button';
 import Search from 'components/search';
 import cx from 'classnames';
@@ -21,8 +20,6 @@ class NDCCountry extends PureComponent {
       match,
       onSearchChange,
       search,
-      ndcsData,
-      loading,
       route,
       anchorLinks
     } = this.props;
@@ -67,11 +64,6 @@ class NDCCountry extends PureComponent {
           </Header>
         )}
         <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
-        <Accordion
-          className={styles.accordion}
-          data={ndcsData}
-          loading={loading}
-        />
       </div>
     );
   }
@@ -83,8 +75,6 @@ NDCCountry.propTypes = {
   country: PropTypes.object,
   onSearchChange: PropTypes.func.isRequired,
   search: PropTypes.string,
-  ndcsData: PropTypes.array,
-  loading: PropTypes.bool,
   anchorLinks: PropTypes.array
 };
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -1,14 +1,15 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { renderRoutes } from 'react-router-config';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import Accordion from 'components/accordion';
 import Button from 'components/button';
-import Icon from 'components/icon';
 import Search from 'components/search';
 import cx from 'classnames';
+import Sticky from 'react-stickynode';
+import AnchorNav from 'components/anchor-nav';
 
-import backIcon from 'assets/icons/back.svg';
 import lightSearch from 'styles/themes/search/search-light.scss';
 import layout from 'styles/layout.scss';
 import styles from './ndc-country-styles.scss';
@@ -22,7 +23,8 @@ class NDCCountry extends PureComponent {
       search,
       ndcsData,
       loading,
-      route
+      route,
+      anchorLinks
     } = this.props;
     return (
       <div>
@@ -32,14 +34,6 @@ class NDCCountry extends PureComponent {
               className={cx(layout.content, styles.doubleFold, styles.header)}
             >
               <div className={styles.title}>
-                <Button
-                  className={styles.backButton}
-                  color="transparent"
-                  link="/ndcs"
-                  square
-                >
-                  <Icon className={styles.backIcon} icon={backIcon} />
-                </Button>
                 <Intro title={country.wri_standard_name} />
               </div>
               <div className={styles.threeFold}>
@@ -63,8 +57,16 @@ class NDCCountry extends PureComponent {
                 />
               </div>
             </div>
+            <Sticky activeClass="sticky">
+              <AnchorNav
+                useRoutes
+                links={anchorLinks}
+                className={layout.content}
+              />
+            </Sticky>
           </Header>
         )}
+        <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
         <Accordion
           className={styles.accordion}
           data={ndcsData}
@@ -82,7 +84,8 @@ NDCCountry.propTypes = {
   onSearchChange: PropTypes.func.isRequired,
   search: PropTypes.string,
   ndcsData: PropTypes.array,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  anchorLinks: PropTypes.array
 };
 
 export default NDCCountry;

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -75,7 +75,22 @@ export const getCountry = createSelector(
   getCountryByIso
 );
 
+export const getAnchorLinks = createSelector(
+  [
+    state => state.route.routes || [],
+    state => state.iso,
+    state => state.location.search
+  ],
+  (routes, iso, search) =>
+    routes.filter(route => route.anchor).map(route => ({
+      label: route.label,
+      path: `/ndcs/country/${iso}/${route.param ? route.param : ''}`,
+      search
+    }))
+);
+
 export default {
   getCountry,
-  filterNDCs
+  filterNDCs,
+  getAnchorLinks
 };

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -1,74 +1,10 @@
 import { createSelector } from 'reselect';
-import { deburrUpper } from 'app/utils';
 
 const getCountries = state => state.countries;
 const getIso = state => state.iso;
-const getAllIndicators = state => (state.data ? state.data.indicators : {});
-const getCategories = state => (state.data ? state.data.categories : {});
-const getSearch = state => deburrUpper(state.search);
 
 const getCountryByIso = (countries, iso) =>
   countries.find(country => country.iso_code3 === iso);
-
-export const parseIndicatorsDefs = createSelector(
-  [getAllIndicators, getCategories, getCountries],
-  (indicators, categories, countries) => {
-    if (!indicators || !categories || !countries) return {};
-    const parsedIndicators = {};
-    Object.keys(categories).forEach(category => {
-      const categoryIndicators = indicators.filter(
-        indicator => indicator.category_ids.indexOf(category) > -1
-      );
-      const parsedDefinitions = categoryIndicators.map(def => {
-        const descriptions = countries.map(country => ({
-          iso: country,
-          value: def.locations[country] ? def.locations[country].value : null
-        }));
-        return {
-          title: def.name,
-          slug: def.slug,
-          descriptions
-        };
-      });
-      parsedIndicators[category] = parsedDefinitions;
-    });
-    return parsedIndicators;
-  }
-);
-
-export const getNDCs = createSelector(
-  [getCategories, parseIndicatorsDefs],
-  (categories, indicators) => {
-    if (!categories) return [];
-    const ndcs = Object.keys(categories).map(category => ({
-      title: categories[category].name,
-      slug: categories[category].slug,
-      definitions: indicators[category] ? indicators[category] : []
-    }));
-    return ndcs;
-  }
-);
-
-export const filterNDCs = createSelector(
-  [getNDCs, getSearch],
-  (ndcs, search) => {
-    if (!ndcs) return [];
-    const filteredNDCs = ndcs.map(ndc => {
-      const defs = ndc.definitions.filter(
-        def =>
-          deburrUpper(def.title).indexOf(search) > -1 ||
-          deburrUpper(def.descriptions[0].value).indexOf(search) > -1
-      );
-
-      return {
-        ...ndc,
-        definitions: defs
-      };
-    });
-    const reducedNDCs = filteredNDCs.filter(ndc => ndc.definitions.length > 0);
-    return reducedNDCs;
-  }
-);
 
 export const getCountry = createSelector(
   [getCountries, getIso],
@@ -91,6 +27,5 @@ export const getAnchorLinks = createSelector(
 
 export default {
   getCountry,
-  filterNDCs,
   getAnchorLinks
 };

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -31,9 +31,3 @@
   justify-content: flex-start;
   align-items: flex-start;
 }
-
-.accordion {
-  margin-bottom: -1px;
-  position: relative;
-  min-height: 400px;
-}

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -7,9 +7,13 @@ import actions from './ndc-country-actions';
 import reducers, { initialState } from './ndc-country-reducers';
 
 import NDCCountryComponent from './ndc-country-component';
-import { getCountry, filterNDCs } from './ndc-country-selectors';
+import {
+  getCountry,
+  filterNDCs,
+  getAnchorLinks
+} from './ndc-country-selectors';
 
-const mapStateToProps = (state, { match, location }) => {
+const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
   const search = qs.parse(location.search);
   const countryData = {
@@ -21,12 +25,18 @@ const mapStateToProps = (state, { match, location }) => {
     search: search.search,
     countries: [match.params.iso]
   };
+  const routeData = {
+    iso,
+    location,
+    route
+  };
   return {
     fetched: state.countryNDC.data[iso],
     loading: state.countryNDC.loading,
     country: getCountry(countryData),
     search: search.search,
-    ndcsData: filterNDCs(ndcsData)
+    ndcsData: filterNDCs(ndcsData),
+    anchorLinks: getAnchorLinks(routeData)
   };
 };
 

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -1,7 +1,9 @@
-import { createElement } from 'react';
+import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
+import Proptypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
+import { getLocationParamUpdated } from 'utils/navigation';
 
 import actions from './ndc-country-actions';
 import reducers, { initialState } from './ndc-country-reducers';
@@ -28,23 +30,27 @@ const mapStateToProps = (state, { match, location, route }) => {
   };
 };
 
-const NDCCountryContainer = props => {
-  const { location, history } = props;
-
-  const onSearchChange = query => {
-    const search = qs.parse(location.search);
-    const newSearch = { ...search, search: query };
-
-    history.replace({
-      pathname: location.pathname,
-      search: qs.stringify(newSearch)
-    });
+class NDCCountryContainer extends PureComponent {
+  onSearchChange = query => {
+    this.updateUrlParam({ name: 'search', value: query });
   };
 
-  return createElement(NDCCountryComponent, {
-    ...props,
-    onSearchChange
-  });
+  updateUrlParam = (params, clear) => {
+    const { history, location } = this.props;
+    history.replace(getLocationParamUpdated(location, params, clear));
+  };
+
+  render() {
+    return createElement(NDCCountryComponent, {
+      ...this.props,
+      onSearchChange: this.onSearchChange
+    });
+  }
+}
+
+NDCCountryContainer.propTypes = {
+  history: Proptypes.object.isRequired,
+  location: Proptypes.object.isRequired
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -7,11 +7,7 @@ import actions from './ndc-country-actions';
 import reducers, { initialState } from './ndc-country-reducers';
 
 import NDCCountryComponent from './ndc-country-component';
-import {
-  getCountry,
-  filterNDCs,
-  getAnchorLinks
-} from './ndc-country-selectors';
+import { getCountry, getAnchorLinks } from './ndc-country-selectors';
 
 const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
@@ -20,32 +16,20 @@ const mapStateToProps = (state, { match, location, route }) => {
     countries: state.countries.data,
     iso: match.params.iso
   };
-  const ndcsData = {
-    data: state.countryNDC.data[match.params.iso],
-    search: search.search,
-    countries: [match.params.iso]
-  };
   const routeData = {
     iso,
     location,
     route
   };
   return {
-    fetched: state.countryNDC.data[iso],
-    loading: state.countryNDC.loading,
     country: getCountry(countryData),
     search: search.search,
-    ndcsData: filterNDCs(ndcsData),
     anchorLinks: getAnchorLinks(routeData)
   };
 };
 
 const NDCCountryContainer = props => {
-  const { location, match, history, fetchCountryNDC, loading, fetched } = props;
-  const { iso } = match.params;
-  if (iso && !loading && !fetched) {
-    fetchCountryNDC(iso);
-  }
+  const { location, history } = props;
 
   const onSearchChange = query => {
     const search = qs.parse(location.search);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -27,7 +27,7 @@ const providersReducers = {
 
 // Pages
 import * as NDCSPage from 'pages/ndcs';
-import * as countryNDCPage from 'pages/ndc-country';
+
 import * as countryNDCFullPage from 'pages/ndc-country-full';
 import * as NDCComparePage from 'pages/ndc-compare';
 import * as ndcSearchPage from 'pages/ndc-search';
@@ -35,7 +35,6 @@ import * as ndcSdgPage from 'pages/ndc-sdg';
 
 const pagesReducers = {
   ndcs: handleActions(NDCSPage),
-  countryNDC: handleActions(countryNDCPage),
   countryNDCFull: handleActions(countryNDCFullPage),
   NDCCompare: handleActions(NDCComparePage),
   ndcSearch: handleActions(ndcSearchPage),
@@ -49,6 +48,7 @@ import * as storiesComponent from 'components/stories';
 import * as countrySelectComponent from 'components/countries-select';
 import * as ghgEmissionsComponent from 'components/ghg-emissions';
 import * as modalMetadataComponent from 'components/modal-metadata';
+import * as ndcCountryAccordion from 'components/ndcs-country-accordion';
 import * as countryGhgEmissionsMapComponent from 'components/country-ghg-map';
 import * as countryGhgEmissionsComponent from 'components/country-ghg-emissions';
 import * as countrySDGLinkagesComponent from 'components/country-ndc-sdg-linkages';
@@ -61,6 +61,7 @@ const componentsReducers = {
   countrySelect: handleActions(countrySelectComponent),
   ghgEmissions: handleActions(ghgEmissionsComponent),
   modalMetadata: handleActions(modalMetadataComponent),
+  ndcCountryAccordion: handleActions(ndcCountryAccordion),
   countryGhgEmissionsMap: handleActions(countryGhgEmissionsMapComponent),
   countryGhgEmissions: handleActions(countryGhgEmissionsComponent),
   countrySDGLinkages: handleActions(countrySDGLinkagesComponent),

--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -9,6 +9,7 @@ import NDCMap from 'components/ndcs-map';
 import NDCTable from 'components/ndcs-table';
 import NDCCountry from 'pages/ndc-country';
 import NDCCountryFull from 'pages/ndc-country-full';
+import NDCCountryAccordion from 'components/ndcs-country-accordion';
 import NDCCompare from 'pages/ndc-compare';
 import CountryIndex from 'pages/country-index';
 import Country from 'pages/country';
@@ -80,7 +81,7 @@ export default [
           {
             path: '/ndcs/country/:iso/mitigation',
             component: () =>
-              createElement(NDCCountry, {
+              createElement(NDCCountryAccordion, {
                 category: 'migitation',
                 type: 'overview'
               }),
@@ -92,7 +93,7 @@ export default [
           {
             path: '/ndcs/country/:iso/adaptation',
             component: () =>
-              createElement(NDCCountry, {
+              createElement(NDCCountryAccordion, {
                 category: 'adaptation',
                 type: 'overview'
               }),

--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -60,16 +60,52 @@ export default [
         label: 'SECTORS'
       },
       {
-        path: '/ndcs/country/:iso',
-        component: NDCCountry,
-        exact: true,
-        headerImage: 'ndc'
-      },
-      {
         path: '/ndcs/country/:iso/full',
         component: NDCCountryFull,
         exact: true,
         headerImage: 'ndc'
+      },
+      {
+        path: '/ndcs/country/:iso',
+        component: NDCCountry,
+        headerImage: 'ndc',
+        routes: [
+          {
+            path: '/ndcs/country/:iso',
+            component: () => createElement(CountryNdcOverview),
+            exact: true,
+            anchor: true,
+            label: 'Overview'
+          },
+          {
+            path: '/ndcs/country/:iso/mitigation',
+            component: () =>
+              createElement(NDCCountry, {
+                category: 'migitation',
+                type: 'overview'
+              }),
+            exact: true,
+            anchor: true,
+            label: 'Mitigation',
+            param: 'mitigation'
+          },
+          {
+            path: '/ndcs/country/:iso/adaptation',
+            component: () =>
+              createElement(NDCCountry, {
+                category: 'adaptation',
+                type: 'overview'
+              }),
+            exact: true,
+            anchor: true,
+            label: 'Adaptation',
+            param: 'adaptation'
+          },
+          {
+            path: '/ndcs/country/:iso',
+            component: () => createElement(Redirect, { to: '/ndcs' })
+          }
+        ]
       },
       {
         path: '/ndcs/compare',
@@ -133,7 +169,8 @@ export default [
             hash: 'ndc-content-overview',
             label: 'NDC Content Overview',
             anchor: true,
-            component: CountryNdcOverview
+            component: () =>
+              createElement(CountryNdcOverview, { actions: true })
           },
           {
             hash: 'ndc-sdg-linkages',


### PR DESCRIPTION
Add category navigation to the NDCs country pages so that you can filter by 'mitigation', 'adaptation', and 'sectoral_information'.

TODO:
- [x] Add anchor menu to country page
- [x] More actions and reducers to parent accordion component
- [x] Show country content overview
- [x] Show accordion for 'mitigation' and 'adaptation'
- [x] Update search to match
- [x] Make sure compare is still working