### PR TITLE
Feature/consume rss feed

### DIFF
--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class StoriesController < ApiController
+      def index
+        stories = Story.limit(stories_limit).order(:published_at)
+
+        render json: stories, each_serializer: Api::V1::StorySerializer
+      end
+
+      private
+
+      def stories_limit
+        params[:limit] || 5
+      end
+    end
+  end
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,0 +1,2 @@
+class Story < ApplicationRecord
+end

--- a/app/serializers/api/v1/story_serializer.rb
+++ b/app/serializers/api/v1/story_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class StorySerializer < ActiveModel::Serializer
+      attribute :title
+      attribute :link
+      attribute :background_image_url
+      attribute :published_at
+    end
+  end
+end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -2,10 +2,8 @@ class ImportStories
   require 'rss'
   require 'open-uri'
 
-  def call reset=false
-    if reset
-      cleanup
-    end
+  def call reset = false
+    cleanup if reset
 
     import_stories
   end
@@ -18,7 +16,7 @@ class ImportStories
 
   def import_stories
     existing = Story.count
-    url = "http://feeds.feedburner.com/WRI_News_and_Views.rss"
+    url = 'http://feeds.feedburner.com/WRI_News_and_Views.rss'
     rss = open(url)
     feed = RSS::Parser.parse(rss)
     puts "Channel Title: #{feed.channel.title}"
@@ -33,66 +31,5 @@ class ImportStories
       story.save
     end
     puts "#{Story.count - existing} new stories"
-  end
-
-  def import_data
-    @data.each do |d|
-      l = Location.find_by(iso_code3: d[:country])
-      if l
-        @metakeys.each do |k|
-          r = d[:"#{k}_rank"]
-          v = value_attributes(k, d, l, r)
-          Adaptation::Value.create!(v) if v
-        end
-      else
-        Rails.logger.error "Location #{d[:country]} not found"
-      end
-    end
-  end
-
-  def variable_attributes(m)
-    {
-      slug: m[:column_name],
-      name: m[:long_name]
-    }
-  end
-
-  def value_attributes(k, d, l, r)
-    s = {
-      location: l,
-      variable: Adaptation::Variable.find_by(slug: k),
-      absolute_rank: r
-    }
-
-    return nil if d[k].nil?
-    return s.merge(boolean_value: d[k] == 'YES') if %w(YES NO).include?(d[k])
-    return s.merge(number_value: d[k]) if d[k].numeric?
-    return s.merge(string_value: d[k]) if d[k] != '#N/A'
-  end
-
-  # rubocop:disable MethodLength
-  def update_ranks
-    sql = <<~END
-      WITH ranks AS (
-        SELECT var.id AS variable_id, val.id AS value_id,
-          val.absolute_rank AS rank
-        FROM adaptation_variables AS var
-          INNER JOIN adaptation_values AS val ON var.id = val.variable_id
-        WHERE val.absolute_rank IS NOT NULL
-      ), ranges AS (
-        SELECT var.id AS variable_id, MAX(val.absolute_rank) AS max_rank
-        FROM adaptation_variables AS var
-          INNER JOIN adaptation_values AS val ON var.id = val.variable_id
-        GROUP BY var.id
-      )
-      UPDATE adaptation_values val
-        SET relative_rank =
-          ROUND(ranks.rank::NUMERIC / ranges.max_rank::NUMERIC, 2)
-      FROM ranges
-        INNER JOIN ranks ON ranges.variable_id = ranks.variable_id
-      WHERE val.id = ranks.value_id;
-    END
-
-    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -2,7 +2,7 @@ class ImportStories
   require 'rss'
   require 'open-uri'
 
-  def call reset = false
+  def call(reset = false)
     cleanup if reset
 
     import_stories

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -1,0 +1,98 @@
+class ImportStories
+  require 'rss'
+  require 'open-uri'
+
+  def call reset=false
+    if reset
+      cleanup
+    end
+
+    import_stories
+  end
+
+  private
+
+  def cleanup
+    Story.delete_all
+  end
+
+  def import_stories
+    existing = Story.count
+    url = "http://feeds.feedburner.com/WRI_News_and_Views.rss"
+    rss = open(url)
+    feed = RSS::Parser.parse(rss)
+    puts "Channel Title: #{feed.channel.title}"
+    feed.items.each do |item|
+      title = item.title
+      published_at = item.pubDate
+      story = Story.find_or_initialize_by(title: title,
+                                          published_at: published_at)
+
+      story.description = item.description
+      story.link = item.link
+      story.save
+    end
+    puts "#{Story.count - existing} new stories"
+  end
+
+  def import_data
+    @data.each do |d|
+      l = Location.find_by(iso_code3: d[:country])
+      if l
+        @metakeys.each do |k|
+          r = d[:"#{k}_rank"]
+          v = value_attributes(k, d, l, r)
+          Adaptation::Value.create!(v) if v
+        end
+      else
+        Rails.logger.error "Location #{d[:country]} not found"
+      end
+    end
+  end
+
+  def variable_attributes(m)
+    {
+      slug: m[:column_name],
+      name: m[:long_name]
+    }
+  end
+
+  def value_attributes(k, d, l, r)
+    s = {
+      location: l,
+      variable: Adaptation::Variable.find_by(slug: k),
+      absolute_rank: r
+    }
+
+    return nil if d[k].nil?
+    return s.merge(boolean_value: d[k] == 'YES') if %w(YES NO).include?(d[k])
+    return s.merge(number_value: d[k]) if d[k].numeric?
+    return s.merge(string_value: d[k]) if d[k] != '#N/A'
+  end
+
+  # rubocop:disable MethodLength
+  def update_ranks
+    sql = <<~END
+      WITH ranks AS (
+        SELECT var.id AS variable_id, val.id AS value_id,
+          val.absolute_rank AS rank
+        FROM adaptation_variables AS var
+          INNER JOIN adaptation_values AS val ON var.id = val.variable_id
+        WHERE val.absolute_rank IS NOT NULL
+      ), ranges AS (
+        SELECT var.id AS variable_id, MAX(val.absolute_rank) AS max_rank
+        FROM adaptation_variables AS var
+          INNER JOIN adaptation_values AS val ON var.id = val.variable_id
+        GROUP BY var.id
+      )
+      UPDATE adaptation_values val
+        SET relative_rank =
+          ROUND(ranks.rank::NUMERIC / ranges.max_rank::NUMERIC, 2)
+      FROM ranges
+        INNER JOIN ranks ON ranges.variable_id = ranks.variable_id
+      WHERE val.id = ranks.value_id;
+    END
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
       end
       resources :timeline, param: :code, only: [:index, :show]
 
+      resources :stories, only: [:index]
+
       get '(*endpoint)', controller: :api, action: :route_not_found
     end
   end

--- a/db/migrate/20171101202433_create_stories.rb
+++ b/db/migrate/20171101202433_create_stories.rb
@@ -1,0 +1,13 @@
+class CreateStories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :stories do |t|
+      t.string :title
+      t.text :description
+      t.datetime :published_at
+      t.string :background_image_url
+      t.string :link
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031100456) do
+ActiveRecord::Schema.define(version: 20171101202433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -290,6 +290,16 @@ ActiveRecord::Schema.define(version: 20171031100456) do
     t.datetime "updated_at", null: false
     t.index ["location_id", "year"], name: "index_socioeconomic_indicators_on_location_id_and_year", unique: true
     t.index ["location_id"], name: "index_socioeconomic_indicators_on_location_id"
+  end
+
+  create_table "stories", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.datetime "published_at"
+    t.string "background_image_url"
+    t.string "link"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "timeline_documents", force: :cascade do |t|

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -14,7 +14,8 @@ namespace :db do
     'wb_extra:import',
     'timeline:import',
     'quantifications:import',
-    'socioeconomics:import'
+    'socioeconomics:import',
+    'stories:import'
   ]
 
   desc 'Imports all data in correct order, replaces all data'
@@ -32,6 +33,8 @@ namespace :db do
     puts "Deleting Locations"
     Location.all.each(&:destroy)
     puts "Starting the import"
+    puts "Deleting stories"
+    Story.delete_all
     Rake::Task['db:import'].invoke
   end
 end

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -1,19 +1,19 @@
 namespace :stories do
   desc 'Import new stories from WRI RSS feed'
   task import: :environment do
-    puts "##############################"
-    puts "# Starting to import stories #"
-    puts "##############################"
+    puts '##############################'
+    puts '# Starting to import stories #'
+    puts '##############################'
     ImportStories.call
-    puts "########### ENDED ############"
+    puts '########### ENDED ############'
   end
 
   desc 'Delete stories and re-import'
   task fresh_import: :environment do
-    puts "##############################"
-    puts "# Starting to import stories #"
-    puts "##############################"
+    puts '##############################'
+    puts '# Starting to import stories #'
+    puts '##############################'
     ImportStories.call(true)
-    puts "########### ENDED ############"
+    puts '########### ENDED ############'
   end
 end

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -1,0 +1,19 @@
+namespace :stories do
+  desc 'Import new stories from WRI RSS feed'
+  task import: :environment do
+    puts "##############################"
+    puts "# Starting to import stories #"
+    puts "##############################"
+    ImportStories.call
+    puts "########### ENDED ############"
+  end
+
+  desc 'Delete stories and re-import'
+  task fresh_import: :environment do
+    puts "##############################"
+    puts "# Starting to import stories #"
+    puts "##############################"
+    ImportStories.call(true)
+    puts "########### ENDED ############"
+  end
+end

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -4,7 +4,7 @@ namespace :stories do
     puts '##############################'
     puts '# Starting to import stories #'
     puts '##############################'
-    ImportStories.call
+    ImportStories.new.call
     puts '########### ENDED ############'
   end
 
@@ -13,7 +13,7 @@ namespace :stories do
     puts '##############################'
     puts '# Starting to import stories #'
     puts '##############################'
-    ImportStories.call(true)
+    ImportStories.new.call(true)
     puts '########### ENDED ############'
   end
 end

--- a/spec/controllers/api/v1/stories_controller_spec.rb
+++ b/spec/controllers/api/v1/stories_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Api::V1::StoriesController, type: :controller do
+  context do
+    let!(:some_stories) {
+      FactoryGirl.create_list(:story, 7)
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index
+        expect(response).to be_success
+      end
+
+      it 'lists six stories' do
+        get :index, params: {limit: 6}
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(6)
+      end
+    end
+  end
+end

--- a/spec/factories/story.rb
+++ b/spec/factories/story.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :story do
+    sequence :title { |n| "#{n} Stories about climate and love" }
+    link 'http://my.dreams.com'
+    background_image_url 'http://pictures.of.me/1.png'
+    published_at Time.now
+  end
+end


### PR DESCRIPTION
## Overview

This PR adds the basic support to consume stories from WRI's RSS feed and to share these via our own API.

## What it includes 

- [x] create model
- [x] create migration
- [x] create import script
- [x] create rake task to use import script
- [x] create controller to expose the data
- [x] added specs for the controller

## Outstanding for another time

This overall task will still require some work once they update their feed, we will need to:

- [ ] add pagination support (hopefully)
- [ ] parse the data based on the tags of the elements
- [ ] hook up the background image which is currently missing from the feed
- [ ] setup a cron job to consume stories every so often

## To test

Run `rails db:migrate` and `rails stories:import`, and then visit the endpoint `GET /api/v1/stories`, you should see some stories. =)

Feel free to merge if it looks good.