### PR TITLE
Fix/sort sdg card dots

### DIFF
--- a/app/javascript/app/components/sdg-card/sdg-card-component.jsx
+++ b/app/javascript/app/components/sdg-card/sdg-card-component.jsx
@@ -1,9 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import Icon from 'components/icon';
-
 import styles from './sdg-card-styles.scss';
 
 class SDGCard extends PureComponent {
@@ -37,6 +35,26 @@ class SDGCard extends PureComponent {
     );
 
     const title = square ? goal.title : `${goal.number}. ${goal.cw_title}`;
+
+    const compare = (a, b) => {
+      const aRegex = a.number.match(/(.*)\.(.*)/);
+      const fullA = (aRegex && aRegex[1]) || a.number.match(/(.*)\.?/);
+      const decimalA = aRegex && aRegex[2];
+      const bRegex = b.number.match(/(.*)\.(.*)/);
+      const fullB = (bRegex && bRegex[1]) || b.number.match(/(.*)\.?/);
+      const decimalB = bRegex && bRegex[2];
+      if (
+        !decimalA ||
+        !decimalB ||
+        parseInt(fullA, 10) !== parseInt(fullB, 10) ||
+        decimalA.match(/[^0-9.]/) ||
+        decimalA.match(/[^0-9.]/)
+      ) {
+        return fullA < fullB ? 1 : -1;
+      }
+      return parseInt(decimalA, 10) - parseInt(decimalB, 10);
+    };
+
     return (
       <div
         className={cardStyle}
@@ -48,7 +66,7 @@ class SDGCard extends PureComponent {
         <h4 className={styles.title}>{title}</h4>
         <div className={styles.dots}>
           {targets &&
-            targets.map(target => {
+            targets.sort(compare).map(target => {
               const isSmall =
                 target.sectors &&
                 activeSector &&

--- a/app/javascript/app/components/sdg-card/sdg-card-component.jsx
+++ b/app/javascript/app/components/sdg-card/sdg-card-component.jsx
@@ -37,20 +37,24 @@ class SDGCard extends PureComponent {
     const title = square ? goal.title : `${goal.number}. ${goal.cw_title}`;
 
     const compare = (a, b) => {
-      const aRegex = a.number.match(/(.*)\.(.*)/);
-      const fullA = (aRegex && aRegex[1]) || a.number.match(/(.*)\.?/);
-      const decimalA = aRegex && aRegex[2];
-      const bRegex = b.number.match(/(.*)\.(.*)/);
-      const fullB = (bRegex && bRegex[1]) || b.number.match(/(.*)\.?/);
-      const decimalB = bRegex && bRegex[2];
+      const divideRegex = /(.*)\.(.*)/;
+      const match = x => x.number.match(divideRegex);
+      const fullNumber = x =>
+        (match(x) && match(x)[1]) || x.number.match(divideRegex);
+      const decimalNumber = x => match(x) && match(x)[2];
+      const fullA = fullNumber(a);
+      const fullB = fullNumber(b);
+      const decimalA = decimalNumber(a);
+      const decimalB = decimalNumber(b);
       if (
         !decimalA ||
         !decimalB ||
-        parseInt(fullA, 10) !== parseInt(fullB, 10) ||
-        decimalA.match(/[^0-9.]/) ||
-        decimalA.match(/[^0-9.]/)
+        parseInt(fullA, 10) !== parseInt(fullB, 10)
       ) {
-        return fullA < fullB ? 1 : -1;
+        return fullA > fullB ? 1 : -1;
+      }
+      if (decimalA.match(/[^0-9.]/) || decimalA.match(/[^0-9.]/)) {
+        return decimalA > decimalB ? 1 : -1;
       }
       return parseInt(decimalA, 10) - parseInt(decimalB, 10);
     };
@@ -77,7 +81,7 @@ class SDGCard extends PureComponent {
                 targetData.targets[target.number].sectors;
               return (
                 <span
-                  key={target.number}
+                  key={target.id}
                   data-for={tooltipId}
                   data-tip
                   onMouseEnter={() => setTooltipData(target)}

--- a/app/javascript/app/components/sdg-card/sdg-card-component.jsx
+++ b/app/javascript/app/components/sdg-card/sdg-card-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from 'components/icon';
+import { compareIndex } from 'utils/utils';
 import styles from './sdg-card-styles.scss';
 
 class SDGCard extends PureComponent {
@@ -36,29 +37,6 @@ class SDGCard extends PureComponent {
 
     const title = square ? goal.title : `${goal.number}. ${goal.cw_title}`;
 
-    const compare = (a, b) => {
-      const divideRegex = /(.*)\.(.*)/;
-      const match = x => x.number.match(divideRegex);
-      const fullNumber = x =>
-        (match(x) && match(x)[1]) || x.number.match(divideRegex);
-      const decimalNumber = x => match(x) && match(x)[2];
-      const fullA = fullNumber(a);
-      const fullB = fullNumber(b);
-      const decimalA = decimalNumber(a);
-      const decimalB = decimalNumber(b);
-      if (
-        !decimalA ||
-        !decimalB ||
-        parseInt(fullA, 10) !== parseInt(fullB, 10)
-      ) {
-        return fullA > fullB ? 1 : -1;
-      }
-      if (decimalA.match(/[^0-9.]/) || decimalA.match(/[^0-9.]/)) {
-        return decimalA > decimalB ? 1 : -1;
-      }
-      return parseInt(decimalA, 10) - parseInt(decimalB, 10);
-    };
-
     return (
       <div
         className={cardStyle}
@@ -70,7 +48,7 @@ class SDGCard extends PureComponent {
         <h4 className={styles.title}>{title}</h4>
         <div className={styles.dots}>
           {targets &&
-            targets.sort(compare).map(target => {
+            targets.sort(compareIndex).map(target => {
               const isSmall =
                 target.sectors &&
                 activeSector &&

--- a/app/javascript/app/components/sdg-card/sdg-card-component.jsx
+++ b/app/javascript/app/components/sdg-card/sdg-card-component.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from 'components/icon';
-import { compareIndex } from 'utils/utils';
+import { compareIndexByKey } from 'utils/utils';
 import styles from './sdg-card-styles.scss';
 
 class SDGCard extends PureComponent {
@@ -48,7 +48,7 @@ class SDGCard extends PureComponent {
         <h4 className={styles.title}>{title}</h4>
         <div className={styles.dots}>
           {targets &&
-            targets.sort(compareIndex).map(target => {
+            targets.sort(compareIndexByKey('number')).map(target => {
               const isSmall =
                 target.sectors &&
                 activeSector &&

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -10,27 +10,30 @@ export function isCountryIncluded(countriesIncluded = [], iso) {
   return countriesIncluded.includes(iso);
 }
 
-export function compareIndex(a, b) {
-  const divideByDot = /(.*)\.(.*)/;
-  const isNotNumber = /[^0-9.]/;
-  const match = x => x.number.match(divideByDot);
-  const fullNumber = x =>
-    (match(x) && match(x)[1]) || x.number.match(divideByDot);
-  const decimalNumber = x => match(x) && match(x)[2];
-  const fullA = fullNumber(a);
-  const fullB = fullNumber(b);
-  const decimalA = decimalNumber(a);
-  const decimalB = decimalNumber(b);
-  if (!decimalA || !decimalB || parseInt(fullA, 10) !== parseInt(fullB, 10)) {
-    return fullA > fullB ? 1 : -1;
-  }
-  if (decimalA.match(isNotNumber) || decimalA.match(isNotNumber)) {
-    return decimalA > decimalB ? 1 : -1;
-  }
-  return parseInt(decimalA, 10) - parseInt(decimalB, 10);
+export function compareIndexByKey(attribute) {
+  return function compareIndex(a, b) {
+    const divideByDot = /(.*)\.(.*)/;
+    const isNotNumber = /[^0-9.]/;
+    const match = x => x[attribute].match(divideByDot);
+    const fullNumber = x =>
+      (match(x) && match(x)[1]) || x[attribute].match(divideByDot);
+    const decimalNumber = x => match(x) && match(x)[2];
+    const fullA = fullNumber(a);
+    const fullB = fullNumber(b);
+    const decimalA = decimalNumber(a);
+    const decimalB = decimalNumber(b);
+    if (!decimalA || !decimalB || parseInt(fullA, 10) !== parseInt(fullB, 10)) {
+      return fullA > fullB ? 1 : -1;
+    }
+    if (decimalA.match(isNotNumber) || decimalA.match(isNotNumber)) {
+      return decimalA > decimalB ? 1 : -1;
+    }
+    return parseInt(decimalA, 10) - parseInt(decimalB, 10);
+  };
 }
 
 export default {
+  compareIndexByKey,
   deburrUpper,
   isCountryIncluded
 };

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -10,6 +10,26 @@ export function isCountryIncluded(countriesIncluded = [], iso) {
   return countriesIncluded.includes(iso);
 }
 
+export function compareIndex(a, b) {
+  const divideByDot = /(.*)\.(.*)/;
+  const isNotNumber = /[^0-9.]/;
+  const match = x => x.number.match(divideByDot);
+  const fullNumber = x =>
+    (match(x) && match(x)[1]) || x.number.match(divideByDot);
+  const decimalNumber = x => match(x) && match(x)[2];
+  const fullA = fullNumber(a);
+  const fullB = fullNumber(b);
+  const decimalA = decimalNumber(a);
+  const decimalB = decimalNumber(b);
+  if (!decimalA || !decimalB || parseInt(fullA, 10) !== parseInt(fullB, 10)) {
+    return fullA > fullB ? 1 : -1;
+  }
+  if (decimalA.match(isNotNumber) || decimalA.match(isNotNumber)) {
+    return decimalA > decimalB ? 1 : -1;
+  }
+  return parseInt(decimalA, 10) - parseInt(decimalB, 10);
+}
+
 export default {
   deburrUpper,
   isCountryIncluded


### PR DESCRIPTION
Correctly sort dots

Created compareIndexByKey method in utils which can be reused for some other sort cases

e.g array.sort(compareIndexByKey('objectKey'))

1.1 < 1.2 < 1.10 < 1.a
![image](https://user-images.githubusercontent.com/9701591/32343838-354dbb86-c005-11e7-81b9-f9293b3757a6.png)
