### PR TITLE
Change gdp scale

### DIFF
--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -203,7 +203,8 @@ export const filterData = createSelector(
 
 const calculatedRatio = (selected, calculationData, x) => {
   if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
-    return calculationData[x][0].gdp;
+    // GDP is in dollars and we want to display it in million dollars
+    return calculationData[x][0].gdp / 1000000;
   }
   if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
     return calculationData[x][0].population;

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -204,7 +204,7 @@ export const filterData = createSelector(
 const calculatedRatio = (selected, calculationData, x) => {
   if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
     // GDP is in dollars and we want to display it in million dollars
-    return calculationData[x][0].gdp / 1000000;
+    return calculationData[x][0].gdp / DATA_SCALE;
   }
   if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
     return calculationData[x][0].population;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/152503610

GDP was shown in $ instead of million $ the chart lines weren't even showing because the value was too low.

We could also change this scale in the import of the data in the backend. Only if we are not going to use dollars in some other place. That will need a reimport.