### PR TITLE
Small adjustments to rendering docs on timeline

### DIFF
--- a/app/javascript/app/components/country-timeline/country-timeline-selectors.js
+++ b/app/javascript/app/components/country-timeline/country-timeline-selectors.js
@@ -13,7 +13,7 @@ export const getDates = createSelector(
     if (isEmpty(data) || !data[iso]) return null;
     const documents = [];
     uniqBy(data[iso], 'link').forEach(d => {
-      if (d.date && d.language === 'en') {
+      if (d.date) {
         documents.push({
           year: d.date.split('-')[0],
           link: d.link,

--- a/app/serializers/api/v1/timeline/document_serializer.rb
+++ b/app/serializers/api/v1/timeline/document_serializer.rb
@@ -27,7 +27,7 @@ module Api
           parts = []
           parts << object.text
           parts += object.notes.map(&:note) if object.notes.length.positive?
-          parts << object.language
+          parts << object.language unless object.language == 'English'
           parts.join(', ')
         end
       end


### PR DESCRIPTION
- hide language when it's english;
- show docs for all languages

To see it in effect you'll need to run `rails timeline:import` and then visit any country page. =)