### PR TITLE
Sort ndc-sdg linkages targets

### DIFF
--- a/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list-component.jsx
+++ b/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list-component.jsx
@@ -17,7 +17,7 @@ class NdcSdgLinkagesList extends PureComponent {
   };
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { goal, onCloseClick, targetHover } = this.props;
+    const { goal, onCloseClick, targetHover, targets } = this.props;
     const headerStyle = { borderColor: goal.colour };
     return (
       <div className={styles.container}>
@@ -31,7 +31,7 @@ class NdcSdgLinkagesList extends PureComponent {
           </button>
         </div>
         <div className={styles.targetContainer}>
-          {goal.targets.map((target, index) => {
+          {targets.map((target, index) => {
             const isSelected = targetHover === target.number;
             const style = {
               borderBottom: `4px solid ${isSelected
@@ -62,6 +62,7 @@ class NdcSdgLinkagesList extends PureComponent {
 
 NdcSdgLinkagesList.propTypes = {
   goal: PropTypes.object.isRequired,
+  targets: PropTypes.array.isRequired,
   targetHover: PropTypes.string,
   onCloseClick: PropTypes.func.isRequired,
   onTargetHover: PropTypes.func.isRequired

--- a/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list.js
+++ b/app/javascript/app/components/ndc-sdg-linkages-list/ndc-sdg-linkages-list.js
@@ -1,3 +1,9 @@
+import { withProps } from 'recompose';
+import { compareIndexByKey } from 'utils/utils';
 import Component from './ndc-sdg-linkages-list-component';
 
-export default Component;
+const withSortedTargets = withProps(({ goal }) => ({
+  targets: goal.targets.sort(compareIndexByKey('number'))
+}));
+
+export default withSortedTargets(Component);


### PR DESCRIPTION
In the Ndc-Sdc linkages page, the targets from each goal were not correctly ordered by number. 

- Apply the compareIndexByKey function to sort the targets correctly

Now they are:
![image](https://user-images.githubusercontent.com/9701591/32447268-d71baf50-c30b-11e7-9f9f-d6f6bceec752.png)
