### PR TITLE
Render emissions chart in country page even when sociodemographic data isn't available

### DIFF
--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -234,13 +234,7 @@ export const getChartData = createSelector(
     getQuantifications
   ],
   (data, filters, calculationData, calculationSelected) => {
-    if (
-      !data ||
-      !data.length ||
-      !filters ||
-      !calculationData ||
-      !calculationSelected
-    ) {
+    if (!data || !data.length || !filters || !calculationSelected) {
       return [];
     }
 
@@ -251,7 +245,7 @@ export const getChartData = createSelector(
     ) {
       xValues = intersection(
         xValues,
-        Object.keys(calculationData).map(y => parseInt(y, 10))
+        Object.keys(calculationData || []).map(y => parseInt(y, 10))
       );
     }
 


### PR DESCRIPTION
This will allow for the correct rendering of the emissions chart in the country page for EU28 as a country.

However, our adaptations and linkages datasets are missing EU28 data, so the elements that display it will have no content (still render fine though).

Please remember to run `rails locations:import location_members:import`