### PR TITLE
Calculate top position even on not table first level elements

### DIFF
--- a/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
+++ b/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
@@ -18,11 +18,23 @@ class ScrollToHighlightIndex extends PureComponent {
     const e = idx
       ? document.querySelectorAll(targetElementsSelector)[idx]
       : document.querySelectorAll(targetElementsSelector)[0];
+
+    const topPosition = element => {
+      const PADDING = -200;
+      let firstLevelElement = element;
+      let elementPosition = firstLevelElement.offsetTop;
+      while (firstLevelElement.tagName !== 'TABLE') {
+        elementPosition += firstLevelElement.offsetParent.offsetTop;
+        firstLevelElement = firstLevelElement.offsetParent;
+      }
+      return elementPosition + PADDING;
+    };
+
     if (e) {
       window.scrollTo({
         behavior: 'smooth',
         left: 0,
-        top: e.offsetTop - 200
+        top: topPosition(e)
       });
     }
   };

--- a/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
+++ b/app/javascript/app/components/scroll-to-highlight-index/scroll-to-highlight-index.js
@@ -23,7 +23,7 @@ class ScrollToHighlightIndex extends PureComponent {
       const PADDING = -200;
       let firstLevelElement = element;
       let elementPosition = firstLevelElement.offsetTop;
-      while (firstLevelElement.tagName !== 'TABLE') {
+      while (firstLevelElement.id !== 'ndc-content-container') {
         elementPosition += firstLevelElement.offsetParent.offsetTop;
         firstLevelElement = firstLevelElement.offsetParent;
       }

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -87,7 +87,7 @@ class NDCCountryFull extends PureComponent {
             </div>
           </div>
         </Sticky>
-        <div className={styles.contentContainer}>
+        <div className={styles.contentContainer} id="ndc-content-container">
           {loading && !content && <Loading light className={styles.loader} />}
           {this.getPageContent()}
         </div>


### PR DESCRIPTION
In the country full content page, some queries of the linkages were apparently highlighting the text but not scrolling to it, i. e: Goal 1: No poverty.
Actually what it was happening is that only the offset to the parent div was added to the scroll. So for list elements or so the top position was not the correct.

- Calculate top position even on not table first level elements

---
There are still some goals without linkages (e.g. Goal 2)