### PR TITLE
Optimize searching by goal, sector and target

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,16 +64,17 @@ Metrics/ModuleLength:
   Enabled: false
 
 Metrics/AbcSize:
+  Max: 20
   Exclude:
     - 'lib/modules/*'
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 25
   Exclude:
     - 'lib/modules/*'
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 250
 
 Bundler/OrderedGems:
   Enabled: false

--- a/app/controllers/api/v1/ndc_sdgs_controller.rb
+++ b/app/controllers/api/v1/ndc_sdgs_controller.rb
@@ -37,6 +37,14 @@ module Api
         render json: goals,
                each_serializer: Api::V1::NdcSdg::GoalOverviewSerializer
       end
+
+      def linkages_dataset
+        send_data(
+          ::NdcSdg::NdcTarget.to_csv,
+          type: Mime[:csv],
+          disposition: 'attachment; filename=ndc_sdg_targets.csv'
+        )
+      end
     end
   end
 end

--- a/app/controllers/api/v1/ndc_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_texts_controller.rb
@@ -5,7 +5,7 @@ module Api
         ndcs = Ndc.includes(:location)
         ndcs =
           if params[:target] || params[:goal] || params[:sector]
-            with_linkage_highlights(ndcs, false, false)
+            with_linkage_highlights(ndcs, false)
           elsif params[:query]
             with_highlights(ndcs, false, false)
           else
@@ -60,85 +60,67 @@ module Api
         highlighted_ndcs
       end
 
-      def highlight_text(text, linkages)
-        return text unless linkages.length.positive?
-
+      def highlight_indices(linkages, text_length)
         indices = linkages.reduce([]) do |list, linkage|
           list.push(linkage.starts_at, linkage.ends_at)
         end
 
         if indices.length.positive?
           indices.unshift(1)
-          indices.push(text.length)
+          indices.push(text_length)
         end
 
-        parts = indices.each_cons(2).map.with_index do |(i1, i2), idx|
-          if idx % 2 == 0 && idx == 0
-            text[i1..(i2-1)]
-          elsif idx % 2 == 0
-            text[(i1+1)..(i2-1)]
-          else
-            text[i1..i2]
+        indices
+      end
+
+      def highlight_text(text, linkages)
+        return text unless linkages.length.positive?
+
+        parts = highlight_indices(linkages, text.length).
+          each_cons(2).
+          map.with_index do |(i1, i2), idx|
+            if idx.zero?
+              text[i1..(i2 - 1)]
+            elsif idx.even?
+              text[(i1 + 1)..(i2 - 1)]
+            else
+              text[i1..i2]
+            end
           end
-        end
 
-        idx = 0
-        parts.reduce("") do |memo, part|
-          memo +=
-            if idx % 2 > 0
+        parts.each.with_index.reduce('') do |memo, (part, idx)|
+          memo +
+            if idx.even?
+              part
+            else
               [
                 Ndc::PG_SEARCH_HIGHLIGHT_START,
                 part,
                 Ndc::PG_SEARCH_HIGHLIGHT_END
               ].join
-            else
-              part
             end
-          idx += 1
-          memo
         end
       end
 
       def with_linkage_highlights(
         ndcs,
-        include_not_matched = true,
-        highlight_matches = true
+        include_not_matched = true
       )
-        linkages = Ndc.linkages(params)
-
         unless include_not_matched
           if params[:target]
-            ids = ::NdcSdg::Target.
-              includes(:ndc_targets).
-              find_by!(number: params[:target]).
-              ndc_targets.
-              map(&:ndc_id).
-              uniq
-            ndcs = ndcs.where(id: ids)
+            ndcs = ndcs.where(id: ::NdcSdg::Target.ndc_ids(params[:target]))
           end
 
           if params[:goal]
-            ids = ::NdcSdg::Goal.
-              includes(targets: :ndc_targets).
-              find_by!(number: params[:goal]).
-              targets.
-              flat_map(&:ndc_targets).
-              map(&:ndc_id).
-              uniq
-            ndcs = ndcs.where(id: ids)
+            ndcs = ndcs.where(id: ::NdcSdg::Goal.ndc_ids(params[:goal]))
           end
 
           if params[:sector]
-            ids = ::NdcSdg::Sector.
-              includes(:ndc_targets).
-              find_by!(id: params[:sector]).
-              ndc_targets.
-              map(&:ndc_id).
-              uniq
-            ndcs = ndcs.where(id: ids)
+            ndcs = ndcs.where(id: ::NdcSdg::Sector.ndc_ids(params[:sector]))
           end
         end
 
+        linkages = Ndc.linkages(params)
         ndcs.map do |ndc|
           ndc_linkages = linkages.
             select { |linkage| linkage.ndc_id == ndc.id }

--- a/app/controllers/api/v1/ndc_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_texts_controller.rb
@@ -86,15 +86,15 @@ module Api
 
         unless include_not_matched
           if params[:target]
-            ndcs = ndcs.where(ndc_sdg_targets: { number: params[:target] })
+            ndcs = ndcs.where(ndc_sdg_targets: {number: params[:target]})
           end
 
           if params[:goal]
-            ndcs = ndcs.where(ndc_sdg_goals: { number: params[:goal] })
+            ndcs = ndcs.where(ndc_sdg_goals: {number: params[:goal]})
           end
 
           if params[:sector]
-            ndcs = ndcs.where(ndc_sdg_sectors: { id: params[:sector] })
+            ndcs = ndcs.where(ndc_sdg_sectors: {id: params[:sector]})
           end
         end
 

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -74,7 +74,8 @@ class Ndc < ApplicationRecord
       ndc_target_sectors: [:sector],
       ndc: [:location]
     ).where(query_params).
-      map(&:indc_text)
+      map(&:indc_text).
+      uniq
   end
 
   def self.linkages_for(iso_code3)

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -52,7 +52,7 @@ class Ndc < ApplicationRecord
     update_all(sql)
   end
 
-  def self.linkage_texts(params)
+  def self.linkages(params)
     query_params = {}
 
     filters = {
@@ -74,8 +74,9 @@ class Ndc < ApplicationRecord
       ndc_target_sectors: [:sector],
       ndc: [:location]
     ).where(query_params).
-      map(&:indc_text).
-      uniq
+      reject { |n| n.starts_at.nil? }.
+      uniq(&:indc_text).
+      sort_by(&:starts_at)
   end
 
   def self.linkages_for(iso_code3)

--- a/app/models/ndc_sdg/goal.rb
+++ b/app/models/ndc_sdg/goal.rb
@@ -5,5 +5,14 @@ module NdcSdg
     validates :number, presence: true, uniqueness: true
     validates :title, presence: true
     validates :cw_title, presence: true
+
+    def self.ndc_ids(goal_number)
+      Goal.includes(targets: :ndc_targets).
+        find_by!(number: goal_number).
+        targets.
+        flat_map(&:ndc_targets).
+        map(&:ndc_id).
+        uniq
+    end
   end
 end

--- a/app/models/ndc_sdg/ndc_target.rb
+++ b/app/models/ndc_sdg/ndc_target.rb
@@ -1,4 +1,6 @@
 module NdcSdg
+  require 'CSV'
+
   class NdcTarget < ApplicationRecord
     belongs_to :ndc
     belongs_to :target, class_name: 'NdcSdg::Target'
@@ -8,5 +10,45 @@ module NdcSdg
     has_many :sectors,
              class_name: 'NdcSdg::Sector',
              through: :ndc_target_sectors
+
+    def self.to_csv
+      attributes = %w{
+        Country wri_standard_name iso_code3 Goal Target INDC_text Status
+        Sector Climate_response Type_of_information text_starts_at
+      }
+
+      linkages = NdcSdg::NdcTarget.
+        includes(:sectors, ndc: :location, target: :goal).
+        order('locations.wri_standard_name asc').
+        all
+
+      CSV.generate(headers: true) do |csv|
+        csv << attributes
+
+        linkages.each do |l|
+          csv << attributes.map { |attr| get_attribute(l, attr) }
+        end
+      end
+    end
+
+    private_class_method def self.get_attribute(linkage, attribute)
+      attr_map = {
+        'Country' => -> { linkage.ndc.location.wri_standard_name },
+        'wri_standard_name' => -> { linkage.ndc.location.wri_standard_name },
+        'iso_code3' => -> { linkage.ndc.location.iso_code3 },
+        'Goal' => -> { "Goal #{linkage.target.goal.number} - #{linkage.target.goal.title}" },
+        'Target' => -> { linkage.target.number },
+        'INDC_text' => -> { linkage.indc_text },
+        'Status' => -> { linkage.status },
+        'Sector' => -> { linkage.sectors.map(&:name).join(' }, ') },
+        'Climate_response' => -> { linkage.climate_response },
+        'Type_of_information' => -> { linkage.type_of_information },
+        'text_starts_at' => -> { linkage.starts_at }
+      }
+
+      return unless attr_map.key?(attribute)
+
+      attr_map[attribute].call
+    end
   end
 end

--- a/app/models/ndc_sdg/ndc_target.rb
+++ b/app/models/ndc_sdg/ndc_target.rb
@@ -1,6 +1,6 @@
-module NdcSdg
-  require 'CSV'
+require 'csv'
 
+module NdcSdg
   class NdcTarget < ApplicationRecord
     belongs_to :ndc
     belongs_to :target, class_name: 'NdcSdg::Target'

--- a/app/models/ndc_sdg/sector.rb
+++ b/app/models/ndc_sdg/sector.rb
@@ -7,5 +7,13 @@ module NdcSdg
              through: :ndc_target_sectors
     has_many :targets,
              through: :ndc_targets
+
+    def self.ndc_ids(sector_id)
+      Sector.includes(:ndc_targets).
+        find_by!(id: sector_id).
+        ndc_targets.
+        map(&:ndc_id).
+        uniq
+    end
   end
 end

--- a/app/models/ndc_sdg/target.rb
+++ b/app/models/ndc_sdg/target.rb
@@ -9,5 +9,13 @@ module NdcSdg
              through: :ndc_target_sectors
     validates :number, presence: true, uniqueness: true
     validates :title, presence: true
+
+    def self.ndc_ids(target_number)
+      Target.includes(:ndc_targets).
+        find_by!(number: target_number).
+        ndc_targets.
+        map(&:ndc_id).
+        uniq
+    end
   end
 end

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -33,13 +33,18 @@ class ImportNdcSdgTargets
       ndc = ndc(row)
       target = target(row)
       next unless ndc && target
+      indc_text = row['INDC_text'].strip
+      starts_at = ndc.full_text.downcase.index(indc_text.downcase)
+      ends_at = starts_at + indc_text.length - 1 if starts_at
       ndc_target = NdcSdg::NdcTarget.find_or_create_by(
         ndc: ndc,
         target: target,
-        indc_text: row['INDC_text'].strip,
+        indc_text: indc_text,
         status: row['Status'],
         climate_response: row['Climate_response'],
-        type_of_information: row['Type_of_information']
+        type_of_information: row['Type_of_information'],
+        starts_at: starts_at,
+        ends_at: ends_at
       )
       import_ndc_target_sectors(row, ndc_target)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
           action: :sdgs_overview
         get :content_overview, on: :member, controller: :ndcs,
           action: :content_overview
+        get :linkages_dataset, on: :collection, controller: :ndc_sdgs,
+          action: :linkages_dataset, defaults: { format: :csv }
       end
       resources :adaptations, only: [:index]
       resources :quantifications, only: [:index]

--- a/db/migrate/20171107115316_change_ndc_sdg_ndc_targets.rb
+++ b/db/migrate/20171107115316_change_ndc_sdg_ndc_targets.rb
@@ -1,0 +1,6 @@
+class ChangeNdcSdgNdcTargets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ndc_sdg_ndc_targets, :starts_at, :integer
+    add_column :ndc_sdg_ndc_targets, :ends_at, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101202433) do
+ActiveRecord::Schema.define(version: 20171107115316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,6 +224,8 @@ ActiveRecord::Schema.define(version: 20171101202433) do
     t.text "type_of_information"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "starts_at"
+    t.integer "ends_at"
     t.index ["ndc_id"], name: "index_ndc_sdg_ndc_targets_on_ndc_id"
     t.index ["target_id"], name: "index_ndc_sdg_ndc_targets_on_target_id"
   end

--- a/spec/controllers/api/v1/ndc_sdgs_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_sdgs_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'csv'
 
 describe Api::V1::NdcSdgsController, type: :controller do
   context do
@@ -80,6 +81,23 @@ describe Api::V1::NdcSdgsController, type: :controller do
       it 'returns a list of goals' do
         get :sdgs_overview
         expect(parsed_response.length).to eq(5)
+      end
+    end
+
+    describe 'GET linkages_dataset' do
+      let!(:some_ndc_sdg_goals) {
+        FactoryGirl.create_list(:ndc_sdg_goal, 5, :with_dependants)
+      }
+
+      it 'returns a successful 200 response' do
+        get :linkages_dataset
+        expect(response).to be_success
+      end
+
+      it 'returns a list of goals' do
+        get :linkages_dataset
+        csv = CSV.parse(response.body)
+        expect(csv.length).to eq(6)
       end
     end
   end

--- a/spec/controllers/api/v1/ndc_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_texts_controller_spec.rb
@@ -19,6 +19,12 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
   let(:pol_html_linkage_text) {
     'Nullam aliquam pretium risus laoreet.'
   }
+  let(:pol_html_linkage_text_starts_at) {
+    pol_html.index(pol_html_linkage_text)
+  }
+  let(:pol_html_linkage_text_ends_at) {
+    pol_html.index(pol_html_linkage_text) + pol_html_linkage_text.length - 1
+  }
   let(:pol_html_with_highlight) {
     pol_html.gsub(
       'Hello',
@@ -36,7 +42,9 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
     FactoryGirl.create(
       :ndc_sdg_ndc_target,
       ndc: pol_ndc,
-      indc_text: pol_html_linkage_text
+      indc_text: pol_html_linkage_text,
+      starts_at: pol_html_linkage_text_starts_at,
+      ends_at: pol_html_linkage_text_ends_at
     )
   }
   let!(:pol_ndc_sdg_ndc_target_sector) {


### PR DESCRIPTION
Instead of retrieving all phrases associated with goals, sectors and targets and then searching for all of them using wildcard, search in ndc_targets texts, retrieve ndc_targets directly using the given params and the relations between models.

Instead of using regular expressions to find and replace the relevant parts with highlighted parts, we store the start and end position of each linkage quote upon import, and then use this information to create the highlighted text. 

Also we added an endpoint `/api/v1/ndcs/linkages_dataset` that returns the linkages dataset file `ndc_sdg_targets.csv`, with an extra column `starts_at`, which tells at which character position the linkage quote occurs in the original text. This can be used by the WRI to identify errors in the linkages dataset.
