### PR TITLE
Feature/regions for ghg emissions

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -56,7 +56,7 @@ class GhgEmissions extends PureComponent {
             onValueChange={handleVersionChange}
             value={versionSelected}
             hideResetButton
-            disabled={versions.length === 1}
+            disabled={versions && versions.length === 1}
           />
           <Dropdown
             label="Break by"
@@ -69,8 +69,8 @@ class GhgEmissions extends PureComponent {
             selectedLabel={activeFilterRegion ? activeFilterRegion.label : null}
             label={breakSelected.label}
             groups={breakSelected.value === 'location' ? groups : null}
-            values={filtersSelected}
-            options={filters}
+            values={filtersSelected || []}
+            options={filters || []}
             onMultiValueChange={handleFilterChange}
           />
           <ButtonGroup
@@ -86,28 +86,32 @@ class GhgEmissions extends PureComponent {
             !loadingMeta &&
             (!data || !data.length) && (
               <NoContent
-                message={filtersSelected.length ? 'No data available' : 'No data selected'}
+                message={filtersSelected && filtersSelected.length ? 'No data available' : 'No data selected'}
                 className={styles.noContent}
                 icon
               />
             )}
-          <ChartLine config={config} data={data} height={500} />
-          <div className={styles.tags}>
-            {config.columns &&
-              config.columns.y.map(column => (
-                <Tag
-                  className={styles.tag}
-                  key={`${column.value}`}
-                  data={{
-                    color: config.theme[column.value].stroke,
-                    label: column.label,
-                    id: column.value
-                  }}
-                  canRemove
-                  onRemove={handleRemoveTag}
-                />
-              ))}
-          </div>
+          {data && config &&
+            <div>
+              <ChartLine config={config} data={data} height={500} />
+              <div className={styles.tags}>
+                {config.columns &&
+                  config.columns.y.map(column => (
+                    <Tag
+                      className={styles.tag}
+                      key={`${column.value}`}
+                      data={{
+                        color: config.theme[column.value].stroke,
+                        label: column.label,
+                        id: column.value
+                      }}
+                      canRemove
+                      onRemove={handleRemoveTag}
+                    />
+                  ))}
+              </div>
+            </div>
+          }
         </div>
       </div>
     );
@@ -115,22 +119,22 @@ class GhgEmissions extends PureComponent {
 }
 
 GhgEmissions.propTypes = {
-  data: PropTypes.array.isRequired,
-  config: PropTypes.object.isRequired,
-  groups: PropTypes.array.isRequired,
-  versions: PropTypes.array.isRequired,
-  versionSelected: PropTypes.object.isRequired,
+  data: PropTypes.array,
+  config: PropTypes.object,
+  groups: PropTypes.array,
+  versions: PropTypes.array,
+  versionSelected: PropTypes.object,
   handleVersionChange: PropTypes.func.isRequired,
-  sources: PropTypes.array.isRequired,
-  sourceSelected: PropTypes.object.isRequired,
+  sources: PropTypes.array,
+  sourceSelected: PropTypes.object,
   handleInfoClick: PropTypes.func.isRequired,
   handleSourceChange: PropTypes.func.isRequired,
-  breaksBy: PropTypes.array.isRequired,
-  breakSelected: PropTypes.object.isRequired,
+  breaksBy: PropTypes.array,
+  breakSelected: PropTypes.object,
   handleBreakByChange: PropTypes.func.isRequired,
   handleRemoveTag: PropTypes.func.isRequired,
-  filters: PropTypes.array.isRequired,
-  filtersSelected: PropTypes.array.isRequired,
+  filters: PropTypes.array,
+  filtersSelected: PropTypes.array,
   handleFilterChange: PropTypes.func.isRequired,
   loadingData: PropTypes.bool,
   loadingMeta: PropTypes.bool,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -34,7 +34,8 @@ class GhgEmissions extends PureComponent {
       handleFilterChange,
       handleRemoveTag,
       loadingMeta,
-      loadingData
+      loadingData,
+      activeFilterRegion
     } = this.props;
     return (
       <div>
@@ -65,6 +66,7 @@ class GhgEmissions extends PureComponent {
             hideResetButton
           />
           <MultiSelect
+            selectedLabel={activeFilterRegion ? activeFilterRegion.label : null}
             label={breakSelected.label}
             groups={breakSelected.value === 'location' ? groups : null}
             values={filtersSelected}
@@ -84,7 +86,7 @@ class GhgEmissions extends PureComponent {
             !loadingMeta &&
             (!data || !data.length) && (
               <NoContent
-                message="No data available"
+                message={filtersSelected.length ? 'No data available' : 'No data selected'}
                 className={styles.noContent}
                 icon
               />
@@ -131,7 +133,8 @@ GhgEmissions.propTypes = {
   filtersSelected: PropTypes.array.isRequired,
   handleFilterChange: PropTypes.func.isRequired,
   loadingData: PropTypes.bool,
-  loadingMeta: PropTypes.bool
+  loadingMeta: PropTypes.bool,
+  activeFilterRegion: PropTypes.object
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -33,8 +33,7 @@ class GhgEmissions extends PureComponent {
       filtersSelected,
       handleFilterChange,
       handleRemoveTag,
-      loadingMeta,
-      loadingData,
+      loading,
       activeFilterRegion
     } = this.props;
     return (
@@ -79,11 +78,10 @@ class GhgEmissions extends PureComponent {
           />
         </div>
         <div className={styles.chartWrapper}>
-          {(loadingMeta || loadingData) && (
+          {loading && (
             <Loading light className={styles.loader} />
           )}
-          {!loadingData &&
-            !loadingMeta &&
+          {!loading &&
             (!data || !data.length) && (
               <NoContent
                 message={filtersSelected && filtersSelected.length ? 'No data available' : 'No data selected'}
@@ -136,8 +134,7 @@ GhgEmissions.propTypes = {
   filters: PropTypes.array,
   filtersSelected: PropTypes.array,
   handleFilterChange: PropTypes.func.isRequired,
-  loadingData: PropTypes.bool,
-  loadingMeta: PropTypes.bool,
+  loading: PropTypes.bool,
   activeFilterRegion: PropTypes.object
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -297,13 +297,11 @@ export const getActiveFilterRegion = createSelector(
 
 // Map the data from the API
 export const filterData = createSelector(
-  [getData, getFiltersSelected, getBreakSelected],
+  [filterAndSortData, getFiltersSelected, getBreakSelected],
   (data, filters, breakBy) => {
     if (!data || !data.length || !filters || !filters.length) return null;
     const filterValues = filters.map(filter => filter.label);
-    return sortEmissionsByValue(
-      data.filter(d => filterValues.indexOf(d[breakBy.value]) > -1)
-    );
+    return data.filter(d => filterValues.indexOf(d[breakBy.value]) > -1);
   }
 );
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -208,7 +208,9 @@ export const getRegionsOptions = createSelector(
 export const getFilterOptions = createSelector(
   [getMeta, getSourceSelected, getBreakSelected, getRegionsOptions],
   (meta, sourceSelected, breakSelected, regions) => {
-    if (!sourceSelected || !breakSelected || isEmpty(meta) || !regions) { return []; }
+    if (!sourceSelected || !breakSelected || isEmpty(meta) || !regions) {
+      return [];
+    }
     const breakByValue = breakSelected.value;
     const activeSourceData = meta.data_source.find(
       source => source.value === sourceSelected.value
@@ -252,14 +254,36 @@ export const getFiltersSelected = createSelector(
 
 // get selector defaults
 export const getSelectorDefaults = createSelector(
-  [getSources, getSourceSelected],
-  (sources, sourceSelected) => {
-    if (!sources || !sourceSelected) return null;
-    const sourceData = sources.find(d => d.value === sourceSelected.value);
-    return {
-      sector: sourceData.sector[0],
-      gas: sourceData.gas[0]
-    };
+  [getSourceSelected, getMeta],
+  (sourceSelected, meta) => {
+    if (!sourceSelected || !meta) return null;
+    const defaults = {};
+    switch (sourceSelected.label) {
+      case 'CAIT':
+        defaults.sector = meta.sector.find(
+          s => s.label === 'Total excluding LUCF'
+        ).value;
+        defaults.gas = meta.gas.find(g => g.label === 'All GHG').value;
+        defaults.location = 'WORLD';
+        break;
+      case 'PIK':
+        defaults.sector = meta.sector.find(
+          s => s.label === 'Total excluding LUCF'
+        ).value;
+        defaults.gas = meta.gas.find(g => g.label === 'All GHG').value;
+        defaults.location = 'WORLD';
+        break;
+      case 'UNFCCC':
+        defaults.sector = meta.sector.find(
+          s => s.label === 'Total GHG emissions without LULUCF'
+        ).value;
+        defaults.gas = meta.gas.find(g => g.label === 'Aggregate GHGs').value;
+        defaults.location = 'ANNEXI';
+        break;
+      default:
+        return null;
+    }
+    return defaults;
   }
 );
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -81,10 +81,10 @@ const EXCLUDED_SECTORS = [
 ];
 
 // meta data for selectors
-const getMeta = state => state.meta || {};
-const getSources = state => state.meta.data_source || [];
-const getRegions = state => state.regions || [];
-const getVersions = state => state.meta.gwp || [];
+const getMeta = state => state.meta || null;
+const getSources = state => state.meta.data_source || null;
+const getRegions = state => state.regions || null;
+const getVersions = state => state.meta.gwp || null;
 
 // values from search
 const getSourceSelection = state => state.search.source || null;
@@ -95,35 +95,9 @@ const getFilterSelection = state => state.search.filter;
 // data for the graph
 const getData = state => state.data || [];
 
-//
-export const getRegionsOptions = createSelector(getRegions, regions => {
-  if (!regions) return [];
-  const mappedRegions = [
-    {
-      label: 'Top Emitters',
-      value: 'TOP',
-      members: TOP_EMITTERS,
-      iso: 'TOP',
-      groupId: 'regions'
-    }
-  ];
-  regions.forEach(d => {
-    if (d.iso_code3 !== 'WORLD') {
-      mappedRegions.push({
-        label: d.wri_standard_name,
-        value: d.iso_code3,
-        iso: d.iso_code3,
-        members: d.members.map(m => m.iso_code3),
-        groupId: 'regions'
-      });
-    }
-  });
-  return mappedRegions;
-});
-
 // Sources selectors
 export const getSourceOptions = createSelector(getSources, sources => {
-  if (!sources) return [];
+  if (!sources) return null;
   return sources.map(d => ({
     label: d.label,
     value: d.value,
@@ -134,7 +108,7 @@ export const getSourceOptions = createSelector(getSources, sources => {
 export const getSourceSelected = createSelector(
   [getSourceOptions, getSourceSelection],
   (sources, selected) => {
-    if (!sources || !sources.length) return {};
+    if (!sources) return null;
     if (!selected) return sources[0];
     return sources.find(category => category.value === parseInt(selected, 10));
   }
@@ -144,7 +118,7 @@ export const getSourceSelected = createSelector(
 export const getVersionOptions = createSelector(
   [getVersions, getSources, getSourceSelected, getData],
   (versions, sources, sourceSelected, data) => {
-    if (!sourceSelected || !versions || !data) return [];
+    if (!sourceSelected || !versions || !data) return null;
     const versionsFromData = groupBy(data, 'gwp');
     return sortBy(
       Object.keys(versionsFromData).map(version => ({
@@ -159,7 +133,7 @@ export const getVersionOptions = createSelector(
 export const getVersionSelected = createSelector(
   [getVersionOptions, getVersionSelection],
   (versions, selected) => {
-    if (!versions || !versions.length) return {};
+    if (!versions) return null;
     if (!selected) return versions[0];
     return (
       versions.find(version => version.value === parseInt(selected, 10)) ||
@@ -174,9 +148,59 @@ export const getBreaksByOptions = () => BREAY_BY_OPTIONS;
 export const getBreakSelected = createSelector(
   [getBreaksByOptions, getBreakSelection],
   (breaks, selected) => {
-    if (!breaks || !breaks.length) return {};
+    if (!breaks) return null;
     if (!selected) return breaks[0];
     return breaks.find(category => category.value === selected);
+  }
+);
+
+// Get data and filter and sort by emissions value
+export const filterAndSortData = createSelector(
+  [getData, getVersionSelected, getBreakSelected],
+  (data, version, breakBy) => {
+    if (!data || isEmpty(data)) return null;
+    const dataSorted = sortEmissionsByValue(
+      data.filter(
+        d =>
+          d.gwp === version.label &&
+          EXCLUDED_SECTORS.indexOf(d[breakBy.value]) === -1
+      )
+    );
+    return dataSorted;
+  }
+);
+
+// use filtered data to get top emitters for each region
+export const getRegionsOptions = createSelector(
+  [getRegions, filterAndSortData],
+  (regions, data) => {
+    if (!regions || !data) return null;
+    const mappedRegions = [
+      {
+        label: 'Top Emitters',
+        value: 'TOP',
+        members: TOP_EMITTERS,
+        iso: 'TOP',
+        groupId: 'regions'
+      }
+    ];
+    regions.forEach(region => {
+      const regionMembers = region.members.map(m => m.iso_code3);
+      const regionData = data.filter(
+        d => regionMembers.indexOf(d.iso_code3) > -1
+      );
+      const regionIsos = regionData.map(m => m.iso_code3).slice(0, 10);
+      if (region.iso_code3 !== 'WORLD') {
+        mappedRegions.push({
+          label: region.wri_standard_name,
+          value: region.iso_code3,
+          iso: region.iso_code3,
+          members: regionIsos,
+          groupId: 'regions'
+        });
+      }
+    });
+    return mappedRegions;
   }
 );
 
@@ -184,7 +208,7 @@ export const getBreakSelected = createSelector(
 export const getFilterOptions = createSelector(
   [getMeta, getSourceSelected, getBreakSelected, getRegionsOptions],
   (meta, sourceSelected, breakSelected, regions) => {
-    if (!sourceSelected || !breakSelected || isEmpty(meta)) return [];
+    if (!sourceSelected || !breakSelected || isEmpty(meta) || !regions) { return []; }
     const breakByValue = breakSelected.value;
     const activeSourceData = meta.data_source.find(
       source => source.value === sourceSelected.value
@@ -208,7 +232,7 @@ export const getFilterOptions = createSelector(
 export const getFiltersSelected = createSelector(
   [getFilterOptions, getFilterSelection, getBreakSelected],
   (filters, selected, breakBy) => {
-    if (!filters || !filters.length || selected === '') return [];
+    if (!filters || selected === '') return [];
     if (!selected && breakBy.value !== 'location') return filters;
     let selectedFilters = [];
     if (breakBy.value === 'location' && !selected) {
@@ -221,9 +245,6 @@ export const getFiltersSelected = createSelector(
       selectedFilters = filters.filter(
         filter => selectedValues.indexOf(`${filter.value}`) > -1
       );
-      return selectedFilters.length >= 10
-        ? selectedFilters.slice(0, 10)
-        : selectedFilters;
     }
     return selectedFilters;
   }
@@ -233,7 +254,7 @@ export const getFiltersSelected = createSelector(
 export const getSelectorDefaults = createSelector(
   [getSources, getSourceSelected],
   (sources, sourceSelected) => {
-    if (!sources || !sources.length || !sourceSelected) return {};
+    if (!sources || !sourceSelected) return null;
     const sourceData = sources.find(d => d.value === sourceSelected.value);
     return {
       sector: sourceData.sector[0],
@@ -245,24 +266,19 @@ export const getSelectorDefaults = createSelector(
 export const getActiveFilterRegion = createSelector(
   [getFiltersSelected],
   filters => {
-    if (!filters || !filters.length) return null;
+    if (!filters) return null;
     return filters.find(f => f.groupId === 'regions');
   }
 );
 
 // Map the data from the API
 export const filterData = createSelector(
-  [getData, getVersionSelected, getFiltersSelected, getBreakSelected],
-  (data, version, filters, breakBy) => {
-    if (!data || !data.length || !filters || !filters.length) return [];
+  [getData, getFiltersSelected, getBreakSelected],
+  (data, filters, breakBy) => {
+    if (!data || !data.length || !filters || !filters.length) return null;
     const filterValues = filters.map(filter => filter.label);
     return sortEmissionsByValue(
-      data.filter(
-        d =>
-          d.gwp === version.label &&
-          filterValues.indexOf(d[breakBy.value]) > -1 &&
-          EXCLUDED_SECTORS.indexOf(d[breakBy.value]) === -1
-      )
+      data.filter(d => filterValues.indexOf(d[breakBy.value]) > -1)
     );
   }
 );
@@ -270,7 +286,7 @@ export const filterData = createSelector(
 export const getChartData = createSelector(
   [filterData, getBreakSelected, getFiltersSelected],
   (data, breakBy, filters) => {
-    if (!data || !data.length || !breakBy || !filters) return [];
+    if (!data || !data.length || !breakBy || !filters) return null;
     const xValues = data[0].emissions.map(d => d.year);
     const dataParsed = xValues.map(x => {
       const yItems = {};
@@ -292,6 +308,7 @@ export const getChartData = createSelector(
 export const getChartConfig = createSelector(
   [filterData, getBreakSelected],
   (data, breakBy) => {
+    if (!data || !breakBy) return null;
     const yColumns = data.map(d => ({
       label: d[breakBy.value],
       value: getYColumnValue(d[breakBy.value])

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -36,6 +36,7 @@
 
 .chartWrapper {
   position: relative;
+  min-height: 450px;
 }
 
 .loader {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -83,7 +83,7 @@ function getFiltersParsed(props) {
   const filter = {};
   switch (breakSelected.value) {
     case 'gas':
-      filter.location = sourceSelected.label === 'UNFCCC' ? 'ANNEXI' : 'WORLD';
+      filter.location = sourceSelected.location;
       filter.sector = selectorDefaults.sector;
       break;
     case 'location':
@@ -92,7 +92,7 @@ function getFiltersParsed(props) {
       break;
     case 'sector':
       filter.gas = selectorDefaults.gas;
-      filter.location = sourceSelected.label === 'UNFCCC' ? 'ANNEXI' : 'WORLD';
+      filter.location = sourceSelected.location;
       break;
     default:
       break;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -83,7 +83,7 @@ function getFiltersParsed(props) {
   const filter = {};
   switch (breakSelected.value) {
     case 'gas':
-      filter.location = sourceSelected.location;
+      filter.location = selectorDefaults.location;
       filter.sector = selectorDefaults.sector;
       break;
     case 'location':
@@ -92,7 +92,7 @@ function getFiltersParsed(props) {
       break;
     case 'sector':
       filter.gas = selectorDefaults.gas;
-      filter.location = sourceSelected.location;
+      filter.location = selectorDefaults.location;
       break;
     default:
       break;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -62,8 +62,7 @@ const mapStateToProps = (state, { location }) => {
     filtersSelected: getFiltersSelected(ghg),
     selectorDefaults: getSelectorDefaults(ghg),
     activeFilterRegion: getActiveFilterRegion(ghg),
-    loadingMeta: state.ghgEmissionsMeta.loading,
-    loadingData: state.ghgEmissions.loading,
+    loading: state.ghgEmissionsMeta.loading || state.ghgEmissions.loading,
     groups
   };
 };

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -69,12 +69,12 @@ const mapStateToProps = (state, { location }) => {
 };
 
 function needsRequestData(props, nextProps) {
-  const { sourceSelected, breakSelected, filtersSelected } = nextProps;
-  const hasValues =
-    sourceSelected.value && breakSelected.value && filtersSelected;
+  const { sourceSelected, breakSelected } = nextProps;
+  const hasValues = sourceSelected && breakSelected;
   const hasChanged =
-    sourceSelected.value !== props.sourceSelected.value ||
-    breakSelected.value !== props.breakSelected.value;
+    hasValues &&
+    (sourceSelected !== props.sourceSelected ||
+      breakSelected !== props.breakSelected);
   return hasValues && hasChanged;
 }
 
@@ -109,7 +109,7 @@ class GhgEmissionsContainer extends PureComponent {
     super(props);
     const { sourceSelected, breakSelected, filtersSelected } = props;
     const hasValues =
-      sourceSelected.value && breakSelected.value && filtersSelected.length > 0;
+      sourceSelected && breakSelected && filtersSelected.length > 0;
     if (hasValues) {
       const filters = getFiltersParsed(props);
       props.fetchGhgEmissionsData(filters);
@@ -206,11 +206,15 @@ class GhgEmissionsContainer extends PureComponent {
 GhgEmissionsContainer.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  breakSelected: PropTypes.object.isRequired,
-  sourceSelected: PropTypes.object.isRequired,
+  breakSelected: PropTypes.object,
+  sourceSelected: PropTypes.object,
   setModalMetadata: PropTypes.func.isRequired,
   fetchGhgEmissionsData: PropTypes.func.isRequired,
   filtersSelected: PropTypes.array
+};
+
+GhgEmissionsContainer.defaultProps = {
+  sourceSelected: null
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -18,8 +18,10 @@ class Multiselect extends Component {
     };
   }
 
-  componentDidUpdate() {
-    this.selectorElement.highlightFirstSelectableOption();
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.search !== prevState.search) {
+      this.selectorElement.highlightFirstSelectableOption();
+    }
   }
 
   getSelectorValue() {

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -28,7 +28,7 @@ class Multiselect extends Component {
     const { values, options, selectedLabel } = this.props;
     const { search } = this.state;
     const hasValues = values && values.length;
-    if (selectedLabel) {
+    if (selectedLabel && !search) {
       return <span>{selectedLabel}</span>;
     }
     if (hasValues && !search) {

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -23,9 +23,12 @@ class Multiselect extends Component {
   }
 
   getSelectorValue() {
-    const { values, options } = this.props;
+    const { values, options, selectedLabel } = this.props;
     const { search } = this.state;
     const hasValues = values && values.length;
+    if (selectedLabel) {
+      return <span>{selectedLabel}</span>;
+    }
     if (hasValues && !search) {
       return values.length === options.length ? (
         <span>All selected</span>
@@ -89,7 +92,8 @@ Multiselect.propTypes = {
   onMultiValueChange: Proptypes.func,
   filterOptions: Proptypes.func,
   handleChange: Proptypes.func,
-  label: Proptypes.string
+  label: Proptypes.string,
+  selectedLabel: Proptypes.string
 };
 
 Multiselect.defaultProps = {

--- a/app/javascript/app/components/multiselect/multiselect-styles.scss
+++ b/app/javascript/app/components/multiselect/multiselect-styles.scss
@@ -20,12 +20,18 @@
   right: 0;
   left: 0;
   padding-left: 11px;
-  padding-right: 10px;
+  padding-right: 60px;
   display: flex;
   justify-content: flex-start;
   align-items: center;
   pointer-events: none;
   z-index: 10;
+
+  span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .multiSelect :global {

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-styles.scss
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-styles.scss
@@ -11,9 +11,9 @@
 .col2 {
   @extend %grid;
 
-  @include msGridColumns(1fr, 1fr);
+  @include msGridColumns(50%, 50%);
 
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, 50%);
 }
 
 .search {
@@ -31,7 +31,7 @@
 .contentCols {
   @extend %grid;
 
-  @include msGridColumns(1fr, 1fr);
+  @include msGridColumns(50%, 50%);
 
   grid-template-columns: repeat(2, 50%);
 }

--- a/app/javascript/app/styles/themes/dropdown/react-selectize.scss
+++ b/app/javascript/app/styles/themes/dropdown/react-selectize.scss
@@ -56,6 +56,18 @@ $height: 45px;
           flex-wrap: wrap;
           overflow: hidden;
           position: relative;
+          width: 100%;
+
+          .simple-value {
+            width: 100%;
+          }
+
+          span {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            width: 100%;
+          }
 
           .resizable-input {
             background: none;
@@ -75,6 +87,7 @@ $height: 45px;
             display: flex;
             align-items: flex-start;
             line-height: $height;
+            width: 100%;
           }
         }
 


### PR DESCRIPTION
Likely a confusing PR but very important. It contains two key features separated below.

### Update defaults for selectors 
Currently the GHG emissions graph is lying to you. It's deceit knows no bounds. This injustice must come to an end. I know its hard to believe, but the default selectors for each breakBy value are not correct. Currently we are using Energy for each one when we should be using a curated list of super excellent default values to give the correct overall values. To rectify this the defaults selector to return a specific list.

### Allow the selection of regions
Due to the world not being as simple sack of countries, regions are required to add greater understanding of our emissions data. This new functionality allows, when breaking by region, to select the top (max 10) emitters from each region to be displayed on the chart. It defaults to top world emitters. If a user selects additional countries this region is removed and the countries act again previously. If the user removes a region OR a selection the chart clears. Nice. To allow this quite a few changes were needed to the data parsing and the components to get the correct data and to improve performance sufficiently:
- Update how params are pushed to allow clearing of Filters selector
- If a region is selected get and show the region name in the selector
- Sort the data in two stages, to allow the selection of top emitters from the regions members list
- Add reselect nulls and uppdate components/container to handle these
- Simplify fetch logic
- Styles fixes to handle no data states for the chart

### BONUS ROUND
When exploring these changes I found the following bugs which have been addressed:
- Multi select overflow styles without elypsis
- Dropdown select overflow not showing elypsis
- Multi select jumping to beginning when props changing
 