### PR TITLE
Feature/nested sectors ndc accordions

### DIFF
--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -16,7 +16,8 @@ class Accordion extends PureComponent {
       handleOnClick,
       openSlug,
       children,
-      isChild
+      isChild,
+      hasNestedCollapse
     } = this.props;
     return (
       <div className={className}>
@@ -41,7 +42,7 @@ class Accordion extends PureComponent {
               >
                 <button
                   className={cx(styles.header, isChild ? styles.subHeader : '')}
-                  onClick={() => handleOnClick(section.slug)}
+                  onClick={() => handleOnClick(section.slug, isOpen)}
                 >
                   <div className={layout.content}>
                     <div className={styles.title}>
@@ -55,12 +56,18 @@ class Accordion extends PureComponent {
                     </div>
                   </div>
                 </button>
-                <Collapse isOpened={isOpen}>
-                  <div />
-                  {React.Children.map(children, (child, i) => {
-                    if (i === index) return child;
-                    return null;
-                  })}
+                <Collapse
+                  isOpened={isOpen}
+                  hasNestedCollapse={hasNestedCollapse}
+                >
+                  {isOpen && (
+                    <div>
+                      {React.Children.map(children, (child, i) => {
+                        if (i === index) return child;
+                        return null;
+                      })}
+                    </div>
+                  )}
                 </Collapse>
               </section>
             );
@@ -82,7 +89,8 @@ Accordion.propTypes = {
     })
   ),
   children: PropTypes.node,
-  isChild: PropTypes.bool
+  isChild: PropTypes.bool,
+  hasNestedCollapse: PropTypes.bool
 };
 
 Accordion.defaultProps = {

--- a/app/javascript/app/components/accordion/accordion.js
+++ b/app/javascript/app/components/accordion/accordion.js
@@ -16,10 +16,9 @@ const mapStateToProps = (state, { location, param }) => {
 };
 
 class AccordionContainer extends PureComponent {
-  handleOnClick = slug => {
-    const { param, location } = this.props;
-    const search = qs.parse(location.search);
-    const newSlug = search[param] === slug || !search[param] ? 'none' : slug;
+  handleOnClick = (slug, open) => {
+    const { param } = this.props;
+    const newSlug = !open ? slug : 'none';
     this.updateUrlParam({ name: param, value: newSlug });
   };
 

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-component.jsx
@@ -43,27 +43,28 @@ class NdcsCountryAccordion extends PureComponent {
                     className={styles.accordion}
                     param="section"
                     data={ndcsData}
+                    hasNestedCollapse
                   >
                     {ndcsData &&
                   ndcsData.length > 0 &&
                   ndcsData.map(
                     section =>
-                      (section.indicators.length > 0 ? (
+                      (section.sectors.length > 0 ? (
                         <Accordion
                           key={section.slug}
                           isChild
                           className={styles.subAccordion}
-                          param="subSection"
-                          data={section.indicators}
+                          param="sector"
+                          data={section.sectors}
                         >
-                          {section.indicators.map(desc => (
+                          {section.sectors.map(desc => (
                             <div
                               key={desc.title}
                               className={styles.definitionList}
                             >
                               <DefinitionList
                                 className={layout.content}
-                                definitions={desc.descriptions}
+                                definitions={desc.definitions}
                                 compare={compare}
                               />
                             </div>

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -75,8 +75,8 @@ export const getCategoriesWithSectors = createSelector(
 );
 
 export const parsedCategoriesWithSectors = createSelector(
-  [getCategoriesWithSectors, getSectors],
-  (categories, sectors) => {
+  [getCategoriesWithSectors, getSectors, getCountries],
+  (categories, sectors, countries) => {
     if (!categories) return null;
     return sortBy(
       categories.map(cat => {
@@ -86,13 +86,13 @@ export const parsedCategoriesWithSectors = createSelector(
             cat.sectors.map(sec => {
               const definitions = sortBy(
                 cat.indicators.map(ind => {
-                  const descriptions = Object.keys(ind.locations).map(loc => {
-                    const value = ind.locations[loc].find(
-                      v => v.sector_id === sec
-                    );
+                  const descriptions = countries.map(loc => {
+                    const value = ind.locations[loc]
+                      ? ind.locations[loc].find(v => v.sector_id === sec)
+                      : null;
                     return {
                       iso: loc,
-                      value: value ? value.value : null
+                      value: value ? value.value : '—'
                     };
                   });
                   return {

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 import { deburrUpper } from 'app/utils';
 import sortBy from 'lodash/sortBy';
+import uniq from 'lodash/uniq';
+import snakeCase from 'lodash/snakeCase';
 
 const getCountries = state => state.countries;
 const getAllIndicators = state => (state.data ? state.data.indicators : {});
@@ -36,61 +38,87 @@ export const parseIndicatorsDefs = createSelector(
   }
 );
 
-export const parseIndicatorsDefsWithSectors = createSelector(
-  [getAllIndicators, getCategories, getCountries, getSectors],
-  (indicators, categories, countries, sectors) => {
-    if (!indicators || !categories || !countries || !sectors) return null;
-    const parsedIndicators = [];
-    Object.keys(categories).forEach(category => {
-      const indicatorsWithCategory = indicators.filter(
-        indicator => indicator.category_ids.indexOf(parseInt(category, 10)) > -1
-      );
-      const parsedDefinitions = indicatorsWithCategory.map(indicator => {
-        const sectorIds = [];
-        let descriptions = [];
-        Object.keys(indicator.locations).forEach(location => {
-          indicator.locations[location].forEach(def =>
-            sectorIds.push(def.sector_id)
+export const groupIndicatorsByCategory = createSelector(
+  [getAllIndicators, getCategories],
+  (indicators, categories) => {
+    if (!indicators || !categories) return null;
+    return Object.keys(categories)
+      .map(cat => ({
+        ...categories[cat],
+        indicators: indicators.filter(
+          ind => ind.category_ids.indexOf(parseInt(cat, 10)) > -1
+        )
+      }))
+      .filter(cat => cat.indicators.length);
+  }
+);
+
+export const getCategoriesWithSectors = createSelector(
+  [groupIndicatorsByCategory],
+  categories => {
+    if (!categories) return null;
+    return categories.map(cat => {
+      const sectorIds = [];
+      cat.indicators.forEach(ind => {
+        Object.keys(ind.locations).forEach(location => {
+          ind.locations[location].forEach(
+            value => value.sector_id && sectorIds.push(value.sector_id)
           );
         });
-        if (sectorIds && sectorIds.length && sectorIds[0]) {
-          sectorIds.forEach(sector => {
-            const descriptionsBySector = countries.map(country => {
-              const value = indicator.locations[country]
-                ? indicator.locations[country].find(
-                  indicValue => indicValue.sector_id === sector
-                )
-                : '';
-              return {
-                iso: country,
-                value: value ? value.value : null
-              };
-            });
-            descriptions.push({
-              title: sectors[sector].name,
-              slug: sector,
-              descriptions: descriptionsBySector
-            });
-          });
-        } else {
-          descriptions = countries.map(country => ({
-            iso: country,
-            values: indicator.locations[country]
-              ? indicator.locations[country]
-              : null
-          }));
-        }
-        return {
-          title: indicator.name,
-          slug: indicator.slug,
-          descriptions: sortBy(descriptions, 'title')
-        };
       });
-      if (parsedDefinitions) {
-        parsedIndicators[category] = sortBy(parsedDefinitions, 'title');
-      }
+      return {
+        ...cat,
+        sectors: sectorIds.length ? uniq(sectorIds) : null
+      };
     });
-    return parsedIndicators;
+  }
+);
+
+export const parsedCategoriesWithSectors = createSelector(
+  [getCategoriesWithSectors, getSectors],
+  (categories, sectors) => {
+    if (!categories) return null;
+    return sortBy(
+      categories.map(cat => {
+        const sectorsParsed = sortBy(
+          cat.sectors &&
+            cat.sectors.length &&
+            cat.sectors.map(sec => {
+              const definitions = sortBy(
+                cat.indicators.map(ind => {
+                  const descriptions = Object.keys(ind.locations).map(loc => {
+                    const value = ind.locations[loc].find(
+                      v => v.sector_id === sec
+                    );
+                    return {
+                      iso: loc,
+                      value: value ? value.value : null
+                    };
+                  });
+                  return {
+                    title: ind.name,
+                    slug: ind.slug,
+                    descriptions
+                  };
+                }),
+                'title'
+              );
+              return {
+                title: sectors[sec].name,
+                slug: snakeCase(sectors[sec].name),
+                definitions
+              };
+            }),
+          'title'
+        );
+        return {
+          title: cat.name,
+          slug: cat.slug,
+          sectors: sectorsParsed
+        };
+      }),
+      'title'
+    );
   }
 );
 
@@ -102,19 +130,6 @@ export const getNDCs = createSelector(
       title: categories[category].name,
       slug: categories[category].slug,
       definitions: indicators[category] ? indicators[category] : []
-    }));
-    return ndcs;
-  }
-);
-
-export const getSectoralNDCs = createSelector(
-  [getCategories, parseIndicatorsDefsWithSectors],
-  (categories, indicators) => {
-    if (!categories || !indicators) return null;
-    const ndcs = Object.keys(categories).map(category => ({
-      title: categories[category].name,
-      slug: categories[category].slug,
-      indicators: indicators[category] ? indicators[category] : []
     }));
     return ndcs;
   }
@@ -142,34 +157,34 @@ export const filterNDCs = createSelector(
 );
 
 export const filterSectoralNDCs = createSelector(
-  [getSectoralNDCs, getSearch],
+  [parsedCategoriesWithSectors, getSearch],
   (ndcs, search) => {
     if (!ndcs) return null;
-    const reducedNDCs = ndcs.filter(
-      ndc => ndc.indicators && ndc.indicators.length
-    );
-    const filteredNDCs = reducedNDCs.map(ndc => {
-      const defs = [];
-      ndc.indicators.forEach(def => {
-        const descs = def.descriptions.filter(
-          desc =>
-            deburrUpper(desc.title).indexOf(search) > -1 ||
-            deburrUpper(desc.descriptions[0].value).indexOf(search) > -1
+    if (!search) return ndcs;
+    const filteredNDCs = [];
+    ndcs.forEach(ndc => {
+      const sectors = [];
+      ndc.sectors.forEach(sec => {
+        const definitions = sec.definitions.filter(
+          def =>
+            deburrUpper(def.title).indexOf(search) > -1 ||
+            deburrUpper(def.descriptions[0].value).indexOf(search) > -1
         );
-        if (descs && descs.length) {
-          defs.push({
-            ...def,
-            descriptions: descs
+        if (definitions.length) {
+          sectors.push({
+            ...sec,
+            definitions
           });
         }
       });
-
-      return {
-        ...ndc,
-        indicators: defs
-      };
+      if (sectors.length) {
+        filteredNDCs.push({
+          ...ndc,
+          sectors
+        });
+      }
     });
-    return sortBy(filteredNDCs, 'title');
+    return filteredNDCs;
   }
 );
 

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-styles.scss
@@ -10,6 +10,11 @@ $min-height: 450px;
 .accordion {
   margin-bottom: -1px;
   position: relative;
+  background-color: $light-gray;
+}
+
+.subAccordion {
+  background-color: $light-gray;
 }
 
 .loader {

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import compact from 'lodash/compact';
+import qs from 'query-string';
 
 const getCountries = state => state.data || null;
 const getLocations = state => state.locations || null;
@@ -52,12 +53,15 @@ export const getCountry = createSelector(
 
 export const getAnchorLinks = createSelector(
   [state => state.route.routes || [], state => state.location.search],
-  (routes, search) =>
-    routes.filter(route => route.anchor).map(route => ({
+  (routes, search) => {
+    const searchQuery = qs.parse(search);
+    const searchParams = { locations: searchQuery.locations };
+    return routes.filter(route => route.anchor).map(route => ({
       label: route.label,
       path: `/ndcs/compare/${route.param ? route.param : ''}`,
-      search
-    }))
+      search: `?${qs.stringify(searchParams)}`
+    }));
+  }
 );
 
 export default {

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import upperCase from 'lodash/upperCase';
+import qs from 'query-string';
 
 const getCountries = state => state.countries || null;
 const getIso = state => state.iso || null;
@@ -20,12 +21,14 @@ export const getAnchorLinks = createSelector(
     state => state.iso,
     state => state.location.search
   ],
-  (routes, iso, search) =>
-    routes.filter(route => route.anchor).map(route => ({
+  (routes, iso, search) => {
+    const searchParams = { search: qs.parse(search).search };
+    return routes.filter(route => route.anchor).map(route => ({
       label: route.label,
       path: `/ndcs/country/${iso}/${route.param ? route.param : ''}`,
-      search
-    }))
+      search: `?${qs.stringify(searchParams)}`
+    }));
+  }
 );
 
 export const getDocumentsOptions = createSelector(

--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -108,7 +108,7 @@ export default [
                 category: 'sectoral_information'
               }),
             exact: true,
-            anchor: false,
+            anchor: true,
             label: 'Sectoral Information',
             param: 'sectoral-information'
           },
@@ -155,7 +155,7 @@ export default [
                 compare: true
               }),
             exact: true,
-            anchor: false,
+            anchor: true,
             label: 'Sectoral Information',
             param: 'sectoral-information'
           },


### PR DESCRIPTION
Big update to the ndcs country and compare accordions to handle nested sectors (as opposed to nested indicators):
- Show the sectoral tabs again
- Fix: interactions on accordion have been simplified so now it always open and closes correctly when clicked
- New selectors to parsed sectors instead of indicators first in hierarchy
- Performance improvements for compare accordion by only rendering when needed