### PR TITLE
Feature/scroll management

### DIFF
--- a/app/javascript/app/app.jsx
+++ b/app/javascript/app/app.jsx
@@ -4,18 +4,20 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { renderRoutes } from 'react-router-config';
 import createBrowserHistory from 'history/createBrowserHistory';
+import ScrollToTop from 'components/scroll-to-top';
 
 import store from 'app/store';
 import routes from 'app/routes';
 
 const history = createBrowserHistory();
 
-const App = ({ data }) =>
-  (<Provider store={store(data)}>
+const App = ({ data }) => (
+  <Provider store={store(data)}>
     <Router history={history}>
-      {renderRoutes(routes)}
+      <ScrollToTop>{renderRoutes(routes)}</ScrollToTop>
     </Router>
-  </Provider>);
+  </Provider>
+);
 
 App.propTypes = {
   data: PropTypes.object

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -20,12 +20,14 @@ class ChartLine extends PureComponent {
       <ResponsiveContainer height={height}>
         <LineChart
           data={data}
-          margin={{ top: 0, right: 0, left: -10, bottom: 0 }}
+          margin={{ top: 20, right: 0, left: -10, bottom: 0 }}
           onMouseMove={onMouseMove}
         >
           <XAxis
             dataKey="x"
             tick={{ stroke: '#8f8fa1', strokeWidth: 0.5, fontSize: '13px' }}
+            padding={{ left: 15, right: 20 }}
+            tickSize={8}
           />
           <YAxis
             axisLine={false}

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -118,6 +118,7 @@ class ChartStackedArea extends PureComponent {
             dataKey="x"
             padding={{ left: 30, right: 40 }}
             tick={tickFormat}
+            tickSize={8}
           />
           <YAxis
             type="number"

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -1,5 +1,7 @@
 @import '~styles/layout.scss';
 
+$min-height: 550px;
+
 .col4 {
   @extend %grid;
 
@@ -7,7 +9,7 @@
 
   grid-template-columns: repeat(5, 1fr);
   align-items: end;
-  margin-bottom: 40px;
+  margin-bottom: 15px;
 }
 
 .colEnd {
@@ -36,11 +38,11 @@
 
 .chartWrapper {
   position: relative;
-  min-height: 450px;
+  min-height: $min-height;
 }
 
 .loader {
-  min-height: 450px;
+  min-height: $min-height;
   position: absolute;
   top: 0;
   right: 0;
@@ -48,7 +50,7 @@
 }
 
 .noContent {
-  min-height: 450px;
+  min-height: $min-height;
   position: absolute;
   top: 0;
   right: 0;

--- a/app/javascript/app/components/scroll-to-top/scroll-to-top.js
+++ b/app/javascript/app/components/scroll-to-top/scroll-to-top.js
@@ -1,0 +1,36 @@
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+
+const EXCEPTIONS = [
+  'table',
+  'mitigation',
+  'adaptation',
+  'sectoral-information',
+  'ndcs'
+];
+
+class ScrollToTop extends PureComponent {
+  componentDidUpdate(prevProps) {
+    const currentPath = this.props.location.pathname;
+    const paths = currentPath.split('/');
+    const lastPath = paths.slice(paths.length - 1)[0];
+    if (
+      currentPath !== prevProps.location.pathname &&
+      EXCEPTIONS.indexOf(lastPath) === -1
+    ) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  location: PropTypes.object.isRequired,
+  children: PropTypes.node
+};
+
+export default withRouter(ScrollToTop);

--- a/app/javascript/app/components/simple-menu/simple-menu-styles.scss
+++ b/app/javascript/app/components/simple-menu/simple-menu-styles.scss
@@ -57,6 +57,7 @@
     width: 225px;
     z-index: 20;
     border-top: 1px solid $theme-border;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
 
     &.open {
       display: block;


### PR DESCRIPTION
Small PR to handle persistence of scroll position in fancy new modern browsers. When changing routes, react router does not do anything with scroll positions, Chrome for example maintains scroll positions, so sometime you end up at the bottom of the next page.

This PR add a default scroll to top of next page, unless a route exception is added to handle this. It does not effect moving through the history, only genuine route changes through the router.