### PR TITLE
Fix/bridge null values in charts

### DIFF
--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -147,11 +147,11 @@ class ChartStackedArea extends PureComponent {
                 key={column.value}
                 dataKey={column.value}
                 dot={false}
+                stackId={1}
                 stroke={'transparent' || ''}
                 strokeWidth={0}
                 fill={config.theme[column.value].fill || ''}
-                connectNulls
-                type="monotone"
+                type="step"
               />
             ))}
           {includeTotalLine && (
@@ -161,7 +161,7 @@ class ChartStackedArea extends PureComponent {
               dot={false}
               stroke="#113750"
               strokeWidth={2}
-              connectNulls
+              type="step"
             />
           )}
           {showLastPoint && (

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -22,9 +22,12 @@ import { format } from 'd3-format';
 
 function includeTotalData(data, config) {
   return data.map(d => {
-    let total = 0;
+    let total = null;
     config.columns.y.forEach(key => {
-      total += d[key.value];
+      if (d[key.value]) {
+        if (!total) total = 0;
+        total += d[key.value];
+      }
     });
     return {
       ...d,
@@ -102,7 +105,6 @@ class ChartStackedArea extends PureComponent {
       domain.y[1] =
         max(points.map(p => (isArray(p.y) ? max(p.y) : p.y))) + 1000000;
     }
-
     return (
       <ResponsiveContainer height={height}>
         <ComposedChart
@@ -145,10 +147,11 @@ class ChartStackedArea extends PureComponent {
                 key={column.value}
                 dataKey={column.value}
                 dot={false}
-                stackId={1}
                 stroke={'transparent' || ''}
                 strokeWidth={0}
                 fill={config.theme[column.value].fill || ''}
+                connectNulls
+                type="monotone"
               />
             ))}
           {includeTotalLine && (
@@ -158,6 +161,7 @@ class ChartStackedArea extends PureComponent {
               dot={false}
               stroke="#113750"
               strokeWidth={2}
+              connectNulls
             />
           )}
           {showLastPoint && (

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -10,7 +10,7 @@ class TooltipChart extends PureComponent {
     if (!keys || !data) return '';
     let total = 0;
     keys.forEach(key => {
-      total += data.payload[key.value];
+      if (data.payload[key.value]) total += data.payload[key.value];
     });
     return `${format('.3s')(total)}t`;
   };
@@ -19,6 +19,7 @@ class TooltipChart extends PureComponent {
     const { config, content, showTotal } = this.props;
     const unit =
       config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
+
     return (
       <div className={styles.tooltip}>
         <span
@@ -58,6 +59,7 @@ class TooltipChart extends PureComponent {
                 </div>
               ) : null)
           )}
+        {content && !content.payload && <div>No data fool</div>}
       </div>
     );
   }

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -263,7 +263,9 @@ export const getChartData = createSelector(
         );
         if (yData) {
           const scaledYData = yData.value * DATA_SCALE;
-          yItems[yKey] = scaledYData / calculationRatio;
+          if (yData.value) {
+            yItems[yKey] = scaledYData / calculationRatio;
+          }
         }
       });
       const item = {


### PR DESCRIPTION
Fixes for the country stacked area graph to handle correctly when there are null values:
- Force null values to stay null
- Change the stacked area to a step visualisation for more truthful data
- Update tooltips to match