### PR TITLE
Search linkage text in all available ndc docs

### DIFF
--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -72,7 +72,11 @@ class ImportNdcSdgTargets
       Rails.logger.error "Location not found #{row}"
       return nil
     end
-    ndc = location.ndcs.first
+    indc_text = row['INDC_text'].strip
+    ndc = location.ndcs.detect do |n|
+      !n.full_text.downcase.index(indc_text.downcase).nil?
+    end
+
     Rails.logger.error "NDC not found #{row}" unless ndc
     ndc
   end

--- a/spec/services/import_ndc_sdg_targets_spec.rb
+++ b/spec/services/import_ndc_sdg_targets_spec.rb
@@ -17,10 +17,13 @@ RSpec.describe ImportNdcSdgTargets do
   end
 
   before(:each) do
+    full_text = <<~END
+      The NDC text contains the quote "Improving access by rural communities and farmers to water to support food security, reduce poverty and improve agricultural productions", which is amazing.
+    END
     afg = FactoryGirl.create(
       :location, iso_code3: 'AFG', location_type: 'COUNTRY'
     )
-    FactoryGirl.create(:ndc, location: afg)
+    FactoryGirl.create(:ndc, location: afg, full_text: full_text)
     FactoryGirl.create(:ndc_sdg_target, number: '1.1')
   end
 


### PR DESCRIPTION
Previously linkage text's search scope was the first ndc of a location only. This PR fixes this oversight. 

Please re-import linkages. `rails ndc_sdg_targets:import`