### PR TITLE
Feature/display disclaimer for translated ndc texts

### DIFF
--- a/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-component.jsx
+++ b/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-component.jsx
@@ -1,0 +1,26 @@
+import React, { PureComponent } from 'react';
+import cx from 'classnames';
+
+import layout from 'styles/layout';
+import styles from './ndc-translation-disclaimer-styles.scss';
+
+class NdcTranslationDisclaimer extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const classnames = cx(styles.disclaimer, layout.content);
+
+    return (
+      <div className={classnames}>
+        Please note the following text has been translated for the purposes of
+        Climate Watch using an automated service (Google Translate). This text
+        has no status whatsoever under the UNFCCC, nor does it purport to be an
+        official or unofficial version of the INDC or NDC communicated by the
+        Party to the Registry. This text is for informational purposes only and
+        should not be treated as an official INDC or NDC and should not be cited
+        or referenced without this disclaimer.
+      </div>
+    );
+  }
+}
+
+export default NdcTranslationDisclaimer;

--- a/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-component.jsx
+++ b/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-component.jsx
@@ -1,16 +1,12 @@
 import React, { PureComponent } from 'react';
-import cx from 'classnames';
 
-import layout from 'styles/layout';
 import styles from './ndc-translation-disclaimer-styles.scss';
 
 class NdcTranslationDisclaimer extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const classnames = cx(styles.disclaimer, layout.content);
-
     return (
-      <div className={classnames}>
+      <div className={styles.disclaimer}>
         Please note the following text has been translated for the purposes of
         Climate Watch using an automated service (Google Translate). This text
         has no status whatsoever under the UNFCCC, nor does it purport to be an

--- a/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-styles.scss
+++ b/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-styles.scss
@@ -1,8 +1,9 @@
 @import '~styles/layout.scss';
 
 .disclaimer {
-  padding-top: 40px;
   font-size: $font-size-s;
   font-weight: $font-weight-light;
   color: $dark-gray;
+  max-width: 770px;
+  margin: auto;
 }

--- a/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-styles.scss
+++ b/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer-styles.scss
@@ -1,0 +1,8 @@
+@import '~styles/layout.scss';
+
+.disclaimer {
+  padding-top: 40px;
+  font-size: $font-size-s;
+  font-weight: $font-weight-light;
+  color: $dark-gray;
+}

--- a/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer.js
+++ b/app/javascript/app/components/ndc-translation-disclaimer/ndc-translation-disclaimer.js
@@ -1,0 +1,3 @@
+import NdcTranslationDisclaimerComponent from './ndc-translation-disclaimer-component';
+
+export default NdcTranslationDisclaimerComponent;

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -11,6 +11,7 @@ import ScrollToHighlightIndex from 'components/scroll-to-highlight-index';
 import Sticky from 'react-stickynode';
 import Button from 'components/button';
 import Loading from 'components/loading';
+import NdcTranslationDisclaimer from 'components/ndc-translation-disclaimer';
 
 import layout from 'styles/layout.scss';
 import contentStyles from 'styles/themes/content.scss';
@@ -87,6 +88,7 @@ class NDCCountryFull extends PureComponent {
             </div>
           </div>
         </Sticky>
+        {content && content.translated && <NdcTranslationDisclaimer />}
         <div className={styles.contentContainer} id="ndc-content-container">
           {loading && !content && <Loading light className={styles.loader} />}
           {this.getPageContent()}

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -25,10 +25,13 @@ class NDCCountryFull extends PureComponent {
       return (
         <div className={cx(layout.content, styles.bodyContent)}>
           {!isEmpty(content) && (
-            <div
-              className={cx(contentStyles.content, styles.innerContent)}
-              dangerouslySetInnerHTML={{ __html: content.html }} // eslint-disable-line
-            />
+            <div>
+              {<NdcTranslationDisclaimer className={styles.disclaimer} />}
+              <div
+                className={cx(contentStyles.content, styles.innerContent)}
+                dangerouslySetInnerHTML={{ __html: content.html }} // eslint-disable-line
+              />
+            </div>
           )}
           <ScrollToHighlightIndex
             idx={search.idx}
@@ -88,7 +91,6 @@ class NDCCountryFull extends PureComponent {
             </div>
           </div>
         </Sticky>
-        {content && content.translated && <NdcTranslationDisclaimer />}
         <div className={styles.contentContainer} id="ndc-content-container">
           {loading && !content && <Loading light className={styles.loader} />}
           {this.getPageContent()}

--- a/app/serializers/api/v1/ndc_text_search_result_serializer.rb
+++ b/app/serializers/api/v1/ndc_text_search_result_serializer.rb
@@ -3,8 +3,13 @@ module Api
     class NdcTextSearchResultSerializer < ActiveModel::Serializer
       include Rails.application.routes.url_helpers
 
-      attributes :language, :document_type, :links, :linkages
+      attribute :language
+      attribute :translated
+      attribute :document_type
+      attribute :links
+      attribute :linkages
       attribute :matches
+
       belongs_to :location, serializer: Api::V1::LocationNanoSerializer
 
       def links

--- a/app/serializers/api/v1/ndc_text_serializer.rb
+++ b/app/serializers/api/v1/ndc_text_serializer.rb
@@ -3,7 +3,14 @@ module Api
     class NdcTextSerializer < ActiveModel::Serializer
       include Rails.application.routes.url_helpers
 
-      attributes :id, :language, :document_type, :links, :linkages, :html
+      attribute :id
+      attribute :language
+      attribute :translated
+      attribute :document_type
+      attribute :links
+      attribute :linkages
+      attribute :html
+
       belongs_to :location, serializer: Api::V1::LocationNanoSerializer
 
       def links

--- a/app/services/import_ndc_texts.rb
+++ b/app/services/import_ndc_texts.rb
@@ -25,6 +25,10 @@ class ImportNdcTexts
     type = Regexp.last_match[2]
     lang = Regexp.last_match[3]
     location = Location.find_by_iso_code3(code)
+
+    translated = lang.match?(/_TR$/)
+    lang = lang.chomp('_TR') if translated
+
     unless location
       Rails.logger.error "Location not found: #{code}"
       return
@@ -36,7 +40,8 @@ class ImportNdcTexts
       location: location,
       full_text: html_content,
       document_type: type.downcase,
-      language: lang
+      language: lang,
+      translated: translated
     )
   end
 

--- a/db/migrate/20171109140033_change_ndcs.rb
+++ b/db/migrate/20171109140033_change_ndcs.rb
@@ -1,0 +1,5 @@
+class ChangeNdcs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ndcs, :translated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107115316) do
+ActiveRecord::Schema.define(version: 20171109140033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -254,6 +254,7 @@ ActiveRecord::Schema.define(version: 20171107115316) do
     t.datetime "updated_at", null: false
     t.text "document_type", default: "ndc"
     t.text "language"
+    t.boolean "translated", default: false
     t.index ["full_text_tsv"], name: "index_ndcs_on_full_text_tsv", using: :gin
     t.index ["location_id"], name: "index_ndcs_on_location_id"
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,12 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+copy-to-clipboard@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 core-js@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -8056,6 +8062,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 topojson-client@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Adds support for the 'translated' NDC attribute. This attribute indicates if an NDC has been automatically translated. This attribute is inferred from the NDC filename (if the language field ends with `_TR`).

The front-end development was not based in any design specs: https://cl.ly/1R3z3n142f2V

You'll need to run:

`rails ndcs:full:import` to see it locally. And Andorra (AND) is a good country to test, after the import.