### PR TITLE
Update UNFCCC to handle multiple sectors by default

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -274,9 +274,14 @@ export const getSelectorDefaults = createSelector(
         defaults.location = 'WORLD';
         break;
       case 'UNFCCC':
-        defaults.sector = meta.sector.find(
-          s => s.label === 'Total GHG emissions without LULUCF'
-        ).value;
+        defaults.sector = meta.sector
+          .filter(
+            s =>
+              s.label === 'Total GHG emissions without LULUCF' ||
+              s.label === 'Total GHG emissions excluding LULUCF/LUCF'
+          )
+          .map(d => d.value)
+          .toString();
         defaults.gas = meta.gas.find(g => g.label === 'Aggregate GHGs').value;
         defaults.location = 'ANNEXI';
         break;


### PR DESCRIPTION
GHG emissions for UNFCCC regions were missing data for AR2 due to difference in syntax for default sectors. Now 'Total GHG emissions excluding LULUCF/LUCF' is also passed by default to fetch those that have AR2.