### PR TITLE
Add parent sector information to accordion

### DIFF
--- a/app/javascript/app/components/accordion/accordion-component.jsx
+++ b/app/javascript/app/components/accordion/accordion-component.jsx
@@ -35,6 +35,9 @@ class Accordion extends PureComponent {
                 isOpen = false;
               }
             }
+            const title = section.parent
+              ? `${section.parent.name} | ${section.title}`
+              : section.title;
             return (
               <section
                 key={`${section.slug}-${section.title}`}
@@ -46,7 +49,7 @@ class Accordion extends PureComponent {
                 >
                   <div className={layout.content}>
                     <div className={styles.title}>
-                      {section.title}
+                      {title}
                       <Icon
                         icon={dropdownArrow}
                         className={cx(styles.iconArrow, {

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -112,7 +112,7 @@ export const parsedCategoriesWithSectors = createSelector(
                 definitions
               };
             }),
-          'title'
+          ['parent.name', 'title']
         );
         return {
           title: cat.name,

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -103,9 +103,12 @@ export const parsedCategoriesWithSectors = createSelector(
                 }),
                 'title'
               );
+              const parent =
+                sectors[sec].parent_id && sectors[sectors[sec].parent_id];
               return {
                 title: sectors[sec].name,
                 slug: snakeCase(sectors[sec].name),
+                parent,
                 definitions
               };
             }),


### PR DESCRIPTION
I decided to modify the accordion component in case they decide that a string format
of "parent | sector" isn't good enough and in that case we'd need to do custom styling.

An alternative could be to have a selector modify the title attribute of each sector,
in that case we wouldn't have to put the concern of checking for 'parent' attributes
inside the accordion which is something that might be a bit weird. Thoughts?

https://cl.ly/3P392K3H2C0v
https://cl.ly/133Y25470Q0g

bc thread: https://basecamp.com/1756858/projects/13795275/todos/328481533#comment_575648775

edit: wip because I broke sorting

edit: sorting fixed