### PR TITLE
Feature/esp graph filters

### DIFF
--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -29,7 +29,7 @@ class EmissionPathwayGraph extends PureComponent {
           <EspLocationsProvider />
           {filtersSelected &&
           filtersSelected.location &&
-            filtersSelected.scenario && (
+            filtersSelected.model && (
               <EspTimeSeriesProvider
                 location={filtersSelected.location.value}
                 model={filtersSelected.model.value}

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -27,7 +27,8 @@ class EmissionPathwayGraph extends PureComponent {
       <div className={styles.wrapper}>
         <div className={layout.content}>
           <EspLocationsProvider />
-          {filtersSelected && filtersSelected.location &&
+          {filtersSelected &&
+          filtersSelected.location &&
             filtersSelected.scenario && (
               <EspTimeSeriesProvider
                 location={filtersSelected.location.value}
@@ -39,21 +40,23 @@ class EmissionPathwayGraph extends PureComponent {
             <Dropdown
               label="Country/Region"
               options={filtersOptions.locations}
-              onValueChange={(option) => handleSelectorChange(option, 'currentLocation', true)}
+              onValueChange={option =>
+                handleSelectorChange(option, 'currentLocation', true)}
               value={filtersSelected.location}
               hideResetButton
             />
             <Dropdown
               label="Models and scenarios"
               options={filtersOptions.models}
-              onValueChange={(option) => handleSelectorChange(option, 'model')}
+              onValueChange={option => handleSelectorChange(option, 'model')}
               value={filtersSelected.model}
               hideResetButton
             />
             <Dropdown
               label="Indicators"
               options={filtersOptions.indicators}
-              onValueChange={(option) => handleSelectorChange(option, 'indicator')}
+              onValueChange={option =>
+                handleSelectorChange(option, 'indicator')}
               value={filtersSelected.indicator}
               hideResetButton
             />
@@ -75,18 +78,18 @@ class EmissionPathwayGraph extends PureComponent {
                   <ChartLine config={config} data={data} height={500} />
                   <div className={styles.tags}>
                     {config.columns &&
-                      config.columns.y.map(column => (
-                        <Tag
-                          className={styles.tag}
-                          key={`${column.value}`}
-                          data={{
-                            color: config.theme[column.value].stroke,
-                            label: column.label,
-                            id: column.value
-                          }}
-                          canRemove
-                        />
-                      ))}
+                    config.columns.y.map(column => (
+                      <Tag
+                        className={styles.tag}
+                        key={`${column.value}`}
+                        data={{
+                          color: config.theme[column.value].stroke,
+                          label: column.label,
+                          id: column.value
+                        }}
+                        canRemove
+                      />
+                    ))}
                   </div>
                 </div>
               )}

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -61,6 +61,7 @@ class EmissionPathwayGraph extends PureComponent {
               value={filtersSelected.indicator}
               hideResetButton
             />
+            <div />
             <ButtonGroup className={styles.colEnd} />
           </div>
           <div className={styles.chartWrapper}>

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -21,7 +21,7 @@ class EmissionPathwayGraph extends PureComponent {
       loading,
       filtersOptions,
       filtersSelected,
-      handleLocationChange
+      handleSelectorChange
     } = this.props;
     return (
       <div className={styles.wrapper}>
@@ -39,8 +39,22 @@ class EmissionPathwayGraph extends PureComponent {
             <Dropdown
               label="Country/Region"
               options={filtersOptions.locations}
-              onValueChange={handleLocationChange}
+              onValueChange={(option) => handleSelectorChange(option, 'currentLocation', true)}
               value={filtersSelected.location}
+              hideResetButton
+            />
+            <Dropdown
+              label="Models and scenarios"
+              options={filtersOptions.models}
+              onValueChange={(option) => handleSelectorChange(option, 'model')}
+              value={filtersSelected.model}
+              hideResetButton
+            />
+            <Dropdown
+              label="Indicators"
+              options={filtersOptions.indicators}
+              onValueChange={(option) => handleSelectorChange(option, 'indicator')}
+              value={filtersSelected.indicator}
               hideResetButton
             />
             <ButtonGroup className={styles.colEnd} />
@@ -89,7 +103,7 @@ EmissionPathwayGraph.propTypes = {
   loading: PropTypes.bool,
   filtersOptions: PropTypes.object,
   filtersSelected: PropTypes.object,
-  handleLocationChange: PropTypes.func
+  handleSelectorChange: PropTypes.func
 };
 
 export default EmissionPathwayGraph;

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -32,6 +32,7 @@ class EmissionPathwayGraph extends PureComponent {
             filtersSelected.scenario && (
               <EspTimeSeriesProvider
                 location={filtersSelected.location.value}
+                model={filtersSelected.model.value}
                 scenario={filtersSelected.scenario.value}
               />
             )}

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -33,7 +33,6 @@ class EmissionPathwayGraph extends PureComponent {
               <EspTimeSeriesProvider
                 location={filtersSelected.location.value}
                 model={filtersSelected.model.value}
-                scenario={filtersSelected.scenario.value}
               />
             )}
           <h2 className={styles.title}>Emission Pathways</h2>

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-component.jsx
@@ -19,29 +19,28 @@ class EmissionPathwayGraph extends PureComponent {
       data,
       config,
       loading,
-      locationsOptions,
-      locationSelected,
-      scenarioSelected,
+      filtersOptions,
+      filtersSelected,
       handleLocationChange
     } = this.props;
     return (
       <div className={styles.wrapper}>
         <div className={layout.content}>
           <EspLocationsProvider />
-          {locationSelected &&
-            scenarioSelected && (
+          {filtersSelected && filtersSelected.location &&
+            filtersSelected.scenario && (
               <EspTimeSeriesProvider
-                location={locationSelected}
-                scenario={scenarioSelected}
+                location={filtersSelected.location.value}
+                scenario={filtersSelected.scenario.value}
               />
             )}
           <h2 className={styles.title}>Emission Pathways</h2>
           <div className={styles.col4}>
             <Dropdown
               label="Country/Region"
-              options={locationsOptions}
+              options={filtersOptions.locations}
               onValueChange={handleLocationChange}
-              value={locationSelected}
+              value={filtersSelected.location}
               hideResetButton
             />
             <ButtonGroup className={styles.colEnd} />
@@ -88,10 +87,9 @@ EmissionPathwayGraph.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
   loading: PropTypes.bool,
-  locationsOptions: PropTypes.array,
-  locationSelected: PropTypes.object,
-  handleLocationChange: PropTypes.func,
-  scenarioSelected: PropTypes.string
+  filtersOptions: PropTypes.object,
+  filtersSelected: PropTypes.object,
+  handleLocationChange: PropTypes.func
 };
 
 export default EmissionPathwayGraph;

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -46,10 +46,12 @@ const AXES_CONFIG = {
 const getLocations = state => state.locations || null;
 const getModels = state => state.models || null;
 const getScenarios = state => state.scenarios || null;
+const getIndicators = state => state.indicators || null;
 
 const getLocation = state => state.location || null;
 const getModel = state => state.model || null;
-const getScenario = state => state.scenario || '31,32,33';
+const getScenario = state => state.scenario || null;
+const getIndicator = state => state.indicator || null;
 
 // data for the graph
 const getData = state => state.data || null;
@@ -79,12 +81,29 @@ export const getScenariosOptions = createSelector([getScenarios], scenarios => {
   }));
 });
 
+export const getIndicatorsOptions = createSelector(
+  [getIndicators],
+  indicators => {
+    if (!indicators || !indicators.length) return [];
+    return indicators.map(i => ({
+      label: i.category,
+      value: i.id.toString()
+    }));
+  }
+);
+
 export const getFiltersOptions = createSelector(
-  [getLocationsOptions, getModelsOptions, getScenariosOptions],
-  (locations, models, scenarios) => ({
+  [
+    getLocationsOptions,
+    getModelsOptions,
+    getScenariosOptions,
+    getIndicatorsOptions
+  ],
+  (locations, models, scenarios, indicators) => ({
     locations,
     models,
-    scenarios
+    scenarios,
+    indicators
   })
 );
 
@@ -116,12 +135,27 @@ export const getScenarioSelected = createSelector(
   }
 );
 
+export const getIndicatorSelected = createSelector(
+  [getIndicatorsOptions, getIndicator],
+  (indicators, indicatorSelected) => {
+    if (!indicators) return null;
+    if (!indicatorSelected) return indicators[0];
+    return indicators.find(i => indicatorSelected === i.value);
+  }
+);
+
 export const getFiltersSelected = createSelector(
-  [getLocationSelected, getModelSelected, getScenarioSelected],
-  (location, model, scenario) => ({
+  [
+    getLocationSelected,
+    getModelSelected,
+    getScenarioSelected,
+    getIndicatorSelected
+  ],
+  (location, model, scenario, indicator) => ({
     location,
     model,
-    scenario
+    scenario,
+    indicator
   })
 );
 

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -86,7 +86,7 @@ export const getIndicatorsOptions = createSelector(
   indicators => {
     if (!indicators || !indicators.length) return [];
     return indicators.map(i => ({
-      label: i.category,
+      label: i.alias,
       value: i.id.toString()
     }));
   }
@@ -160,10 +160,15 @@ export const getFiltersSelected = createSelector(
 );
 
 // Map the data from the API
-export const filterData = createSelector([getData], data => {
-  if (!data || isEmpty(data)) return null;
-  return data;
-});
+export const filterData = createSelector(
+  [getData, getFiltersSelected],
+  (data, filters) => {
+    if (!data || isEmpty(data)) return null;
+    return data.filter(
+      d => d.indicator_id === parseInt(filters.indicator.value, 10)
+    );
+  }
+);
 
 export const getChartData = createSelector([filterData], data => {
   if (!data) return null;

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -118,11 +118,11 @@ export const getIndicatorSelected = createSelector(
   [getIndicatorsOptions, getIndicator],
   (indicators, indicatorSelected) => {
     if (!indicators) return null;
-    if (!indicatorSelected) return indicators[0];
-    if (!indicatorSelected) {
-      const defaultIndicator = indicators.find(i => i.label === 'Heat');
-      return defaultIndicator || indicators[0];
-    }
+    if (!indicatorSelected) return null;
+    // if (!indicatorSelected) {
+    //   const defaultIndicator = indicators.find(i => i.label === 'Heat');
+    //   return defaultIndicator || indicators[0];
+    // }
     return indicators.find(i => indicatorSelected === i.value);
   }
 );
@@ -155,7 +155,8 @@ export const getFiltersSelected = createSelector(
 export const filterData = createSelector(
   [getData, getFiltersSelected],
   (data, filters) => {
-    if (!data || isEmpty(data) || !filters.indicator) return null;
+    if (!data || isEmpty(data)) return null;
+    if (!filters.indicator) return data;
     return data.filter(
       d => d.indicator_id === parseInt(filters.indicator.value, 10)
     );

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -44,21 +44,51 @@ const AXES_CONFIG = {
 
 // meta data for selectors
 const getLocations = state => state.locations || null;
+const getModels = state => state.models || null;
+const getScenarios = state => state.scenarios || null;
+
 const getLocation = state => state.location || null;
+const getModel = state => state.model || null;
 const getScenario = state => state.scenario || '31,32,33';
 
 // data for the graph
 const getData = state => state.data || null;
 
+// Selector options
 export const getLocationsOptions = createSelector([getLocations], locations => {
-  if (!locations) return null;
+  if (!locations || !locations.length) return [];
   return locations.map(l => ({
     label: l.name,
-    value: l.iso_code,
-    id: l.id
+    value: l.id.toString()
   }));
 });
 
+export const getModelsOptions = createSelector([getModels], models => {
+  if (!models || !models.length) return [];
+  return models.map(m => ({
+    label: m.full_name,
+    value: m.id.toString()
+  }));
+});
+
+export const getScenariosOptions = createSelector([getScenarios], scenarios => {
+  if (!scenarios || !scenarios.length) return [];
+  return scenarios.map(s => ({
+    label: s.name,
+    value: s.id.toString()
+  }));
+});
+
+export const getFiltersOptions = createSelector(
+  [getLocationsOptions, getModelsOptions, getScenariosOptions],
+  (locations, models, scenarios) => ({
+    locations,
+    models,
+    scenarios
+  })
+);
+
+// Selected values
 export const getLocationSelected = createSelector(
   [getLocationsOptions, getLocation],
   (locations, locationSelected) => {
@@ -68,13 +98,31 @@ export const getLocationSelected = createSelector(
   }
 );
 
-// Map the data from the API
-export const getScenarioSelected = createSelector(
-  [getScenario],
-  locationSelected => {
-    if (!locationSelected) return null;
-    return locationSelected;
+export const getModelSelected = createSelector(
+  [getModelsOptions, getModel],
+  (models, modelSelected) => {
+    if (!models) return null;
+    if (!modelSelected) return models[0];
+    return models.find(m => modelSelected === m.value);
   }
+);
+
+export const getScenarioSelected = createSelector(
+  [getScenariosOptions, getScenario],
+  (scenarios, scenarioSelected) => {
+    if (!scenarios) return null;
+    if (!scenarioSelected) return scenarios[0];
+    return scenarios.find(s => scenarioSelected === s.value);
+  }
+);
+
+export const getFiltersSelected = createSelector(
+  [getLocationSelected, getModelSelected, getScenarioSelected],
+  (location, model, scenario) => ({
+    location,
+    model,
+    scenario
+  })
 );
 
 // Map the data from the API
@@ -125,6 +173,6 @@ export const getChartConfig = createSelector([filterData], data => {
 export default {
   getChartData,
   getChartConfig,
-  getLocationsOptions,
-  getLocationSelected
+  getFiltersOptions,
+  getFiltersSelected
 };

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -65,7 +65,6 @@ export const getLocationSelected = createSelector(
   [getLocationsOptions, getLocation],
   (locations, locationSelected) => {
     if (!locations) return null;
-    if (!locationSelected) return locations[0];
     if (!locationSelected) {
       const defaultLocation = locations.find(l => l.label === 'World');
       return defaultLocation || locations[0];

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -101,15 +101,6 @@ export const getScenariosOptions = createSelector([getScenarios], scenarios => {
   }));
 });
 
-export const getScenarioSelected = createSelector(
-  [getScenariosOptions, getScenario],
-  (scenarios, scenarioSelected) => {
-    if (!scenarios) return null;
-    if (!scenarioSelected) return scenarios[0];
-    return scenarios.find(s => scenarioSelected === s.value);
-  }
-);
-
 export const getIndicatorsOptions = createSelector(
   [getIndicators, getModelSelected],
   (indicators, modelSelected) => {
@@ -152,16 +143,10 @@ export const getFiltersOptions = createSelector(
 );
 
 export const getFiltersSelected = createSelector(
-  [
-    getLocationSelected,
-    getModelSelected,
-    getScenarioSelected,
-    getIndicatorSelected
-  ],
-  (location, model, scenario, indicator) => ({
+  [getLocationSelected, getModelSelected, getIndicatorSelected],
+  (location, model, indicator) => ({
     location,
     model,
-    scenario,
     indicator
   })
 );

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-styles.scss
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-styles.scss
@@ -22,8 +22,8 @@
   font-size: $font-size-large;
   font-weight: $font-weight;
   color: $theme-color;
-  margin-bottom: 50px;
-  margin-top: 35px;
+  margin-bottom: 20px;
+  padding-top: 35px;
 }
 
 .tags {

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -11,28 +11,29 @@ import EmissionPathwayGraphComponent from './emission-pathway-graph-component';
 import {
   getChartData,
   getChartConfig,
-  getLocationsOptions,
-  getLocationSelected,
-  getScenarioSelected
+  getFiltersOptions,
+  getFiltersSelected
 } from './emission-pathway-graph-selectors';
 
 const actions = { ...modalActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data } = state.espTimeSeries;
-  const { currentLocation, scenario } = qs.parse(location.search);
+  const { currentLocation, scenario, model } = qs.parse(location.search);
   const espData = {
-    locations: state.espLocations.data,
     data,
+    locations: state.espLocations.data,
+    models: state.espModels.data,
+    scenarios: state.espScenarios.data,
     location: currentLocation,
+    model,
     scenario
   };
   return {
     data: getChartData(espData),
     config: getChartConfig(espData),
-    locationsOptions: getLocationsOptions(espData),
-    locationSelected: getLocationSelected(espData),
-    scenarioSelected: getScenarioSelected(espData),
+    filtersOptions: getFiltersOptions(espData),
+    filtersSelected: getFiltersSelected(espData),
     loading: state.espTimeSeries.loading || state.espLocations.loading
   };
 };

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -19,15 +19,19 @@ const actions = { ...modalActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data } = state.espTimeSeries;
-  const { currentLocation, scenario, model } = qs.parse(location.search);
+  const { currentLocation, scenario, model, indicator } = qs.parse(
+    location.search
+  );
   const espData = {
     data,
     locations: state.espLocations.data,
     models: state.espModels.data,
     scenarios: state.espScenarios.data,
+    indicators: state.espIndicators.data,
     location: currentLocation,
     model,
-    scenario
+    scenario,
+    indicator
   };
   return {
     data: getChartData(espData),
@@ -39,11 +43,8 @@ const mapStateToProps = (state, { location }) => {
 };
 
 class EmissionPathwayGraphContainer extends PureComponent {
-  handleLocationChange = location => {
-    this.updateUrlParam(
-      { name: 'currentLocation', value: location.value },
-      true
-    );
+  handleSelectorChange = (option, param, clear) => {
+    this.updateUrlParam({ name: param, value: option.value }, clear);
   };
 
   updateUrlParam(params, clear) {
@@ -54,7 +55,7 @@ class EmissionPathwayGraphContainer extends PureComponent {
   render() {
     return createElement(EmissionPathwayGraphComponent, {
       ...this.props,
-      handleLocationChange: this.handleLocationChange
+      handleSelectorChange: this.handleSelectorChange
     });
   }
 }

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -35,7 +35,12 @@ const mapStateToProps = (state, { location }) => {
     config: getChartConfig(espData),
     filtersOptions: getFiltersOptions(espData),
     filtersSelected: getFiltersSelected(espData),
-    loading: state.espTimeSeries.loading || state.espLocations.loading
+    loading:
+      state.espTimeSeries.loading ||
+      state.espLocations.loading ||
+      state.espModels.loading ||
+      state.espScenarios.loading ||
+      state.espIndicators.loading
   };
 };
 

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -19,9 +19,7 @@ const actions = { ...modalActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data } = state.espTimeSeries;
-  const { currentLocation, scenario, model, indicator } = qs.parse(
-    location.search
-  );
+  const { currentLocation, model, indicator } = qs.parse(location.search);
   const espData = {
     data,
     locations: state.espLocations.data,
@@ -30,7 +28,6 @@ const mapStateToProps = (state, { location }) => {
     indicators: state.espIndicators.data,
     location: currentLocation,
     model,
-    scenario,
     indicator
   };
   return {

--- a/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-styles.scss
+++ b/app/javascript/app/components/ndcs-autocomplete-search/ndcs-autocomplete-search-styles.scss
@@ -11,9 +11,9 @@
 .col2 {
   @extend %grid;
 
-  @include msGridColumns(50%, 50%);
+  @include msGridColumns(1fr, 1fr);
 
-  grid-template-columns: repeat(2, 50%);
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .search {

--- a/app/javascript/app/pages/country/country-styles.scss
+++ b/app/javascript/app/pages/country/country-styles.scss
@@ -11,7 +11,7 @@
 
 :global .sticky-outer-wrapper.sticky {
   .sticky-inner-wrapper {
-    z-index: 10;
+    z-index: 12;
     background-color: #1c3c59;
     background-image: url('../../assets/headers/home.jpg');
   }

--- a/app/javascript/app/pages/emission-pathways/emission-pathways-component.jsx
+++ b/app/javascript/app/pages/emission-pathways/emission-pathways-component.jsx
@@ -26,7 +26,7 @@ class EmissionPathways extends PureComponent {
           <div className={layout.content}>
             <Intro title="Emission Pathways" />
           </div>
-          <Sticky activeClass="sticky">
+          <Sticky activeClass="stickyEmissions">
             <AnchorNav
               links={anchorLinks}
               className={layout.content}

--- a/app/javascript/app/pages/emission-pathways/emission-pathways-component.jsx
+++ b/app/javascript/app/pages/emission-pathways/emission-pathways-component.jsx
@@ -4,6 +4,9 @@ import Header from 'components/header';
 import Intro from 'components/intro';
 import AnchorNav from 'components/anchor-nav';
 import Sticky from 'react-stickynode';
+import EspModelsProvider from 'providers/esp-models-provider';
+import EspScenariosProvider from 'providers/esp-scenarios-provider';
+import EspIndicatorsProvider from 'providers/esp-indicators-provider';
 
 import layout from 'styles/layout.scss';
 import styles from './emission-pathways-styles.scss';
@@ -14,6 +17,9 @@ class EmissionPathways extends PureComponent {
     const { route, anchorLinks } = this.props;
     return (
       <div>
+        <EspModelsProvider />
+        <EspScenariosProvider />
+        <EspIndicatorsProvider />
         <Header route={route}>
           <div className={layout.content}>
             <Intro title="Emission Pathways" />

--- a/app/javascript/app/pages/emission-pathways/emission-pathways-styles.scss
+++ b/app/javascript/app/pages/emission-pathways/emission-pathways-styles.scss
@@ -1,1 +1,10 @@
 @import '~styles/layout.scss';
+
+.section {
+  position: relative;
+}
+
+.sectionHash {
+  position: absolute;
+  top: -49px;
+}

--- a/app/javascript/app/pages/emission-pathways/emission-pathways-styles.scss
+++ b/app/javascript/app/pages/emission-pathways/emission-pathways-styles.scss
@@ -1,5 +1,13 @@
 @import '~styles/layout.scss';
 
+:global .stickyEmissions {
+  .sticky-inner-wrapper {
+    z-index: 12;
+    background-color: #81226b;
+    background-image: url('../../assets/headers/emission-pathways.jpg');
+  }
+}
+
 .section {
   position: relative;
 }

--- a/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-actions.js
+++ b/app/javascript/app/providers/esp-indicators-provider/esp-indicators-provider-actions.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 const fetchEspIndicatorsInit = createAction('fetchEspIndicatorsInit');
 const fetchEspIndicatorsReady = createAction('fetchEspIndicatorsReady');
 const fetchEspIndicatorsFail = createAction('fetchEspIndicatorsFail');
+const { ESP_API } = process.env;
 
 const fetchEspIndicators = createThunkAction(
   'fetchEspIndicators',
@@ -16,7 +17,7 @@ const fetchEspIndicators = createThunkAction(
       !espIndicators.loading
     ) {
       dispatch(fetchEspIndicatorsInit());
-      fetch('https://emissionspathways.org/api/v1/indicators')
+      fetch(`${ESP_API}/indicators`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
@@ -4,12 +4,17 @@ import isEmpty from 'lodash/isEmpty';
 
 const getEspLocationsInit = createAction('getEspLocationsInit');
 const getEspLocationsReady = createAction('getEspLocationsReady');
+const getEspLocationsFail = createAction('getEspLocationsFail');
 
 const getEspLocations = createThunkAction(
   'getEspLocations',
   () => (dispatch, state) => {
     const { espLocations } = state();
-    if (espLocations && isEmpty(espLocations.data)) {
+    if (
+      espLocations.data &&
+      isEmpty(espLocations.data) &&
+      !espLocations.loading
+    ) {
       dispatch(getEspLocationsInit());
       fetch('https://emissionspathways.org/api/v1/locations')
         .then(response => {
@@ -17,10 +22,15 @@ const getEspLocations = createThunkAction(
           throw Error(response.statusText);
         })
         .then(data => {
-          dispatch(getEspLocationsReady(data));
+          if (data) {
+            dispatch(getEspLocationsReady(data));
+          } else {
+            dispatch(getEspLocationsReady({}));
+          }
         })
         .catch(error => {
-          console.info(error);
+          console.warn(error);
+          dispatch(getEspLocationsFail());
         });
     }
   }

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 const getEspLocationsInit = createAction('getEspLocationsInit');
 const getEspLocationsReady = createAction('getEspLocationsReady');
 const getEspLocationsFail = createAction('getEspLocationsFail');
+const { ESP_API } = process.env;
 
 const getEspLocations = createThunkAction(
   'getEspLocations',
@@ -16,7 +17,7 @@ const getEspLocations = createThunkAction(
       !espLocations.loading
     ) {
       dispatch(getEspLocationsInit());
-      fetch('https://emissionspathways.org/api/v1/locations')
+      fetch(`${ESP_API}/locations`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-reducers.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
   loading: false,
   loaded: false,
-  data: []
+  data: {}
 };
 
 const setLoading = (loading, state) => ({ ...state, loading });
@@ -10,5 +10,6 @@ const setLoaded = (loaded, state) => ({ ...state, loaded });
 export default {
   getEspLocationsInit: state => setLoading(true, state),
   getEspLocationsReady: (state, { payload }) =>
-    setLoaded(true, setLoading(false, { ...state, data: payload }))
+    setLoaded(true, setLoading(false, { ...state, data: payload })),
+  getEspLocationsFail: state => setLoading(false, { ...state })
 };

--- a/app/javascript/app/providers/esp-models-provider/esp-models-provider-actions.js
+++ b/app/javascript/app/providers/esp-models-provider/esp-models-provider-actions.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 const fetchEspModelsInit = createAction('fetchEspModelsInit');
 const fetchEspModelsReady = createAction('fetchEspModelsReady');
 const fetchEspModelsFail = createAction('fetchEspModelsFail');
+const { ESP_API } = process.env;
 
 const fetchEspModels = createThunkAction(
   'fetchEspModels',
@@ -12,7 +13,7 @@ const fetchEspModels = createThunkAction(
     const { espModels } = state();
     if (espModels.data && isEmpty(espModels.data) && !espModels.loading) {
       dispatch(fetchEspModelsInit());
-      fetch('https://emissionspathways.org/api/v1/models')
+      fetch(`${ESP_API}/models`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
+++ b/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 const fetchEspScenariosInit = createAction('fetchEspScenariosInit');
 const fetchEspScenariosReady = createAction('fetchEspScenariosReady');
 const fetchEspScenariosFail = createAction('fetchEspScenariosFail');
+const { ESP_API } = process.env;
 
 const fetchEspScenarios = createThunkAction(
   'fetchEspScenarios',
@@ -16,7 +17,7 @@ const fetchEspScenarios = createThunkAction(
       !espScenarios.loading
     ) {
       dispatch(fetchEspScenariosInit());
-      fetch('https://emissionspathways.org/api/v1/scenarios')
+      fetch(`${ESP_API}/scenarios`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -7,7 +7,7 @@ const getEspTimeSeriesReady = createAction('getEspTimeSeriesReady');
 
 const getEspTimeSeries = createThunkAction(
   'getEspTimeSeries',
-  (location, scenario) => (dispatch, state) => {
+  (location, model, scenario) => (dispatch, state) => {
     const { espTimeSeries } = state();
     if (
       espTimeSeries &&
@@ -15,9 +15,10 @@ const getEspTimeSeries = createThunkAction(
       !espTimeSeries.loading
     ) {
       dispatch(getEspTimeSeriesInit());
-      fetch(
-        `https://emissionspathways.org/api/v1/time_series_values?location=${location}&scenario=${scenario}`
-      )
+      const query = `location=${location}${model
+        ? `&model=${model}`
+        : ''}${scenario ? `&scenario=${scenario}` : ''}`;
+      fetch(`https://emissionspathways.org/api/v1/time_series_values?${query}`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 
 const getEspTimeSeriesInit = createAction('getEspTimeSeriesInit');
 const getEspTimeSeriesReady = createAction('getEspTimeSeriesReady');
+const { ESP_API } = process.env;
 
 const getEspTimeSeries = createThunkAction(
   'getEspTimeSeries',
@@ -18,7 +19,7 @@ const getEspTimeSeries = createThunkAction(
       const query = `location=${location}${model
         ? `&model=${model}`
         : ''}${scenario ? `&scenario=${scenario}` : ''}`;
-      fetch(`https://emissionspathways.org/api/v1/time_series_values?${query}`)
+      fetch(`${ESP_API}/time_series_values?${query}`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -8,7 +8,7 @@ const { ESP_API } = process.env;
 
 const getEspTimeSeries = createThunkAction(
   'getEspTimeSeries',
-  (location, model, scenario) => (dispatch, state) => {
+  (location, model) => (dispatch, state) => {
     const { espTimeSeries } = state();
     if (
       espTimeSeries &&
@@ -16,9 +16,7 @@ const getEspTimeSeries = createThunkAction(
       !espTimeSeries.loading
     ) {
       dispatch(getEspTimeSeriesInit());
-      const query = `location=${location}${model
-        ? `&model=${model}`
-        : ''}${scenario ? `&scenario=${scenario}` : ''}`;
+      const query = `location=${location}${model ? `&model=${model}` : ''}`;
       fetch(`${ESP_API}/time_series_values?${query}`)
         .then(response => {
           if (response.ok) return response.json();

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -11,11 +11,12 @@ const getEspTimeSeries = createThunkAction(
     const { espTimeSeries } = state();
     if (
       espTimeSeries &&
-      (isEmpty(espTimeSeries.data) || !espTimeSeries.data[location.value])
+      isEmpty(espTimeSeries.data) &&
+      !espTimeSeries.loading
     ) {
       dispatch(getEspTimeSeriesInit());
       fetch(
-        `https://emissionspathways.org/api/v1/time_series_values?location=${location.id}&scenario=${scenario}`
+        `https://emissionspathways.org/api/v1/time_series_values?location=${location}&scenario=${scenario}`
       )
         .then(response => {
           if (response.ok) return response.json();

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-reducers.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
   loading: false,
   loaded: false,
-  data: []
+  data: {}
 };
 
 const setLoading = (loading, state) => ({ ...state, loading });
@@ -9,12 +9,6 @@ const setLoaded = (loaded, state) => ({ ...state, loaded });
 
 export default {
   getEspTimeSeriesInit: state => setLoading(true, state),
-  getEspTimeSeriesReady: (state, { payload }) => {
-    const newState = {
-      ...state,
-      data: payload
-    };
-
-    return setLoaded(true, setLoading(false, newState));
-  }
+  getEspTimeSeriesReady: (state, { payload }) =>
+    setLoaded(true, setLoading(false, { ...state, data: payload }))
 };

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
@@ -7,17 +7,17 @@ import reducers, { initialState } from './esp-time-series-provider-reducers';
 
 class EspTimeSeriesProvider extends PureComponent {
   componentDidMount() {
-    const { location, model, scenario, getEspTimeSeries } = this.props;
-    getEspTimeSeries(location, model, scenario);
+    const { location, model, getEspTimeSeries } = this.props;
+    getEspTimeSeries(location, model);
   }
 
   componentWillReceiveProps(nextProps) {
     if (
       nextProps.location !== this.props.location ||
-      nextProps.scenario !== this.props.scenario
+      nextProps.model !== this.props.model
     ) {
-      const { location, model, scenario, getEspTimeSeries } = nextProps;
-      getEspTimeSeries(location, model, scenario);
+      const { location, model, getEspTimeSeries } = nextProps;
+      getEspTimeSeries(location, model);
     }
   }
 
@@ -29,8 +29,7 @@ class EspTimeSeriesProvider extends PureComponent {
 EspTimeSeriesProvider.propTypes = {
   getEspTimeSeries: PropTypes.func.isRequired,
   location: PropTypes.string.isRequired,
-  model: PropTypes.string,
-  scenario: PropTypes.string
+  model: PropTypes.string
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
@@ -26,8 +26,8 @@ class EspTimeSeriesProvider extends PureComponent {
 
 EspTimeSeriesProvider.propTypes = {
   getEspTimeSeries: PropTypes.func.isRequired,
-  location: PropTypes.object.isRequired,
-  scenario: PropTypes.string
+  location: PropTypes.string.isRequired,
+  scenario: PropTypes.string.isRequired
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
@@ -7,7 +7,8 @@ import reducers, { initialState } from './esp-time-series-provider-reducers';
 
 class EspTimeSeriesProvider extends PureComponent {
   componentDidMount() {
-    this.props.getEspTimeSeries(this.props.location, this.props.scenario);
+    const { location, model, scenario, getEspTimeSeries } = this.props;
+    getEspTimeSeries(location, model, scenario);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -15,7 +16,8 @@ class EspTimeSeriesProvider extends PureComponent {
       nextProps.location !== this.props.location ||
       nextProps.scenario !== this.props.scenario
     ) {
-      this.props.getEspTimeSeries(nextProps.location, nextProps.scenario);
+      const { location, model, scenario, getEspTimeSeries } = nextProps;
+      getEspTimeSeries(location, model, scenario);
     }
   }
 
@@ -27,7 +29,8 @@ class EspTimeSeriesProvider extends PureComponent {
 EspTimeSeriesProvider.propTypes = {
   getEspTimeSeries: PropTypes.func.isRequired,
   location: PropTypes.string.isRequired,
-  scenario: PropTypes.string.isRequired
+  model: PropTypes.string,
+  scenario: PropTypes.string
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -284,12 +284,6 @@ export default [
             label: 'Models, Scenarios & Indicators',
             anchor: true,
             component: error
-          },
-          {
-            hash: 'stories',
-            label: 'Stories',
-            anchor: false,
-            component: error
           }
         ]
       },

--- a/app/javascript/app/styles/themes/dropdown/react-selectize.scss
+++ b/app/javascript/app/styles/themes/dropdown/react-selectize.scss
@@ -59,6 +59,8 @@ $height: 45px;
           width: 100%;
 
           .simple-value {
+            display: table;
+            table-layout: fixed;
             width: 100%;
           }
 

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,5 +1,6 @@
 // Note: You must restart bin/webpack-dev-server for changes to take effect
 
+const dotenv = require('dotenv').config(); // eslint-disable-line
 const merge = require('webpack-merge');
 const sharedConfig = require('./shared.js');
 const { settings, output } = require('./configuration.js');


### PR DESCRIPTION
A starting PR for the ESP filters. This adds the filters that are currently possible from the API, and filters the data a necessary:
- Add a models and indicators dropdown to view
- Filter data correctly based on selector choice
- Set defaults for locations, models, and indicators (indicators i currently disabled so that at least some data is visible).
- Add support for .env urls in the development environment
- Update providers to use .env variable

###ATTENTION: please add the 'ESP_API' key to you .env and give it a url (local or staging or whatever. I don't discriminate when it comes to APIs).

BONUS: Finally fix an annoying bug with 100% width and CSS grid on the dropdown selectors. Add fix for anchor links absolute positioning when scrolling.

NOTE: it seems that the data from the API is not what is expected by design. Year values are only until 2013 (or similar), there is very little data for most cases, and indicators very rarely match a model. It is possible that when applying an association between Models and Locations this will reduce the options more => leading to better data views, but I am skeptical. Please review with caution. We are still missing categories filtering also, which will only refine the empty data more.