### PR TITLE
Feature/tabs in modals

### DIFF
--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions.js
@@ -92,7 +92,8 @@ class CountryGhgEmissionsContainer extends PureComponent {
 
     if (source) {
       this.props.setModalMetadata({
-        slug: source,
+        slugs: [source, 'ndc_quantification'],
+        title: 'Greenhouse Gas Emissions and Emissions Targets',
         open: true
       });
     }

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions.js
@@ -93,7 +93,7 @@ class CountryGhgEmissionsContainer extends PureComponent {
     if (source) {
       this.props.setModalMetadata({
         slugs: [source, 'ndc_quantification'],
-        title: 'Greenhouse Gas Emissions and Emissions Targets',
+        customTitle: 'Greenhouse Gas Emissions and Emissions Targets',
         open: true
       });
     }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -183,7 +183,7 @@ class GhgEmissionsContainer extends PureComponent {
     const { source } = this.props.sourceSelected;
     if (source) {
       this.props.setModalMetadata({
-        slugs: [source],
+        slugs: source,
         open: true
       });
     }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -183,7 +183,7 @@ class GhgEmissionsContainer extends PureComponent {
     const { source } = this.props.sourceSelected;
     if (source) {
       this.props.setModalMetadata({
-        slug: source,
+        slugs: [source],
         open: true
       });
     }

--- a/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
@@ -22,13 +22,14 @@ const fetchModalMetaData = createThunkAction(
   'fetchModalMetaDataData',
   slugs => (dispatch, state) => {
     const { modalMetadata } = state();
-    const someSlugDataIsMissing = slugs.some(slug => !modalMetadata.data[slug]);
-    const someSlugDataHasError = slugs.some(
+    const slugsDataMissing = slugs.filter(slug => !modalMetadata.data[slug]);
+    const slugsDataHasError = slugs.filter(
       slug => modalMetadata.data[slug] === 'error'
     );
-    if (someSlugDataIsMissing || someSlugDataHasError) {
+    const slugsToFetch = slugsDataMissing.concat(slugsDataHasError);
+    if (slugsToFetch.length > 0) {
       dispatch(fetchModalMetaDataInit());
-      const promises = slugs.map(slug =>
+      const promises = slugsToFetch.map(slug =>
         fetch(`/api/v1/metadata/${slug.toLowerCase()}`).then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
@@ -10,7 +10,11 @@ const setModalMetadata = createThunkAction(
   'setModalMetadata',
   payload => dispatch => {
     dispatch(setModalMetadataParams(payload));
-    if (payload.slugs) dispatch(fetchModalMetaData(payload.slugs));
+    let slugs = payload.slugs;
+    if (slugs) {
+      if (typeof slugs === 'string') slugs = [slugs];
+      dispatch(fetchModalMetaData(slugs));
+    }
   }
 );
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
@@ -2,6 +2,10 @@ import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 
 const setModalMetadataParams = createAction('setModalMetadataParams');
+
+// Requires payload params:
+// slugs: array of slugs to fetch
+// customTitle: custom title if there is more than one slug
 const setModalMetadata = createThunkAction(
   'setModalMetadata',
   payload => dispatch => {

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Modal, { ModalHeader } from 'components/modal';
+import Modal from 'components/modal/modal-component';
+import ModalHeader from 'components/modal/modal-header-component';
 import Loading from 'components/loading';
 import NoContent from 'components/no-content';
 
@@ -19,14 +20,25 @@ MetadataProp.propTypes = {
 };
 
 class ModalMetadata extends PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      selectedIndex: 0
+    };
+  }
+
   getContent() {
-    if (this.props.loading) {
+    const { data, loading } = this.props;
+
+    if (loading) {
       return <Loading className={styles.loadingContainer} />;
     }
-    if (!this.props.data) return <NoContent />;
-    if (this.props.data === 'error') {
+    if (!data) return <NoContent />;
+    if (data === 'error') {
       return <NoContent message="There was an error getting the metadata" />;
     }
+
+    const selectedIndexData = data[this.state.selectedIndex];
     const {
       learn_more_link,
       source_organization,
@@ -39,10 +51,10 @@ class ModalMetadata extends PureComponent {
       date_of_content,
       summary_of_licenses,
       terms_of_service_link
-    } = this.props.data;
+    } = selectedIndexData;
 
     return (
-      <div className={styles.textContainer}>
+      <div key={selectedIndexData.source} className={styles.textContainer}>
         {technical_title && (
           <MetadataProp title="Title">{technical_title}</MetadataProp>
         )}
@@ -91,10 +103,17 @@ class ModalMetadata extends PureComponent {
   }
 
   render() {
-    const { onRequestClose, isOpen, title } = this.props;
+    const { onRequestClose, isOpen, title, tabTitles } = this.props;
     return (
       <Modal isOpen={isOpen} onRequestClose={onRequestClose}>
-        {title && <ModalHeader title={title} />}
+        {title && (
+          <ModalHeader
+            title={title}
+            tabTitles={tabTitles}
+            selectedIndex={this.state.selectedIndex}
+            handleTabIndexChange={i => this.setState({ selectedIndex: i })}
+          />
+        )}
         {this.getContent()}
       </Modal>
     );
@@ -103,7 +122,8 @@ class ModalMetadata extends PureComponent {
 
 ModalMetadata.propTypes = {
   title: PropTypes.string,
-  data: PropTypes.object,
+  tabTitles: PropTypes.array,
+  data: PropTypes.array,
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -25,6 +25,7 @@ class ModalMetadata extends PureComponent {
     this.state = {
       selectedIndex: 0
     };
+    this.handleOnRequestClose = this.handleOnRequestClose.bind(this);
   }
 
   getContent() {
@@ -102,10 +103,15 @@ class ModalMetadata extends PureComponent {
     );
   }
 
+  handleOnRequestClose() {
+    this.setState({ selectedIndex: 0 });
+    this.props.onRequestClose();
+  }
+
   render() {
-    const { onRequestClose, isOpen, title, tabTitles } = this.props;
+    const { isOpen, title, tabTitles } = this.props;
     return (
-      <Modal isOpen={isOpen} onRequestClose={onRequestClose}>
+      <Modal isOpen={isOpen} onRequestClose={this.handleOnRequestClose}>
         {title && (
           <ModalHeader
             title={title}

--- a/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
@@ -2,7 +2,7 @@ export const initialState = {
   loaded: false,
   loading: false,
   isOpen: false,
-  title: 'Metadata info modal',
+  title: '',
   active: '',
   data: {}
 };
@@ -10,18 +10,25 @@ export const initialState = {
 const setModalMetadataParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
-  active: payload.slug
+  active: payload.slugs,
+  title: payload.title || state.title
 });
 
 const setLoading = (state, loading) => ({ ...state, loading });
 const setLoaded = (state, loaded) => ({ ...state, loaded });
-const setData = (state, { slug, data }) => ({
-  ...state,
-  data: {
-    ...state.data,
-    [slug]: data
-  }
-});
+const setData = (state, { slugs, data }) => {
+  let slugData = {};
+  slugs.forEach((slug, i) => {
+    slugData = { ...slugData, [slug]: data[i] };
+  });
+  return {
+    ...state,
+    data: {
+      ...state.data,
+      ...slugData
+    }
+  };
+};
 
 export default {
   setModalMetadataParams,

--- a/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
@@ -2,8 +2,8 @@ export const initialState = {
   loaded: false,
   loading: false,
   isOpen: false,
-  title: '',
-  active: '',
+  customTitle: '',
+  active: [],
   data: {}
 };
 
@@ -11,7 +11,7 @@ const setModalMetadataParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
   active: payload.slugs,
-  title: payload.title || state.title
+  customTitle: payload.customTitle || state.title
 });
 
 const setLoading = (state, loading) => ({ ...state, loading });

--- a/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
@@ -10,7 +10,7 @@ export const initialState = {
 const setModalMetadataParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
-  active: payload.slugs,
+  active: typeof payload.slugs === 'string' ? [payload.slugs] : payload.slugs,
   customTitle: payload.customTitle || state.title
 });
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
@@ -3,7 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 
 const getData = state => state.data || null;
 const getActive = state => state.active || null;
-export const getModalTitle = state => state.title || null;
+const getTitle = state => state.customTitle || '';
 
 export const getModalData = createSelector(
   [getData, getActive],
@@ -11,10 +11,18 @@ export const getModalData = createSelector(
     if (isEmpty(data) || !active) return null;
     if (active.every(d => data[d])) {
       return active.length > 1
-        ? Object.keys(data).map(source => data[source])
+        ? active.map(source => data[source])
         : [data[active]];
     }
     return null;
+  }
+);
+
+export const getModalTitle = createSelector(
+  [getTitle, getModalData],
+  (customTitle, data) => {
+    if (!data || isEmpty(data)) return null;
+    return data.length > 1 ? customTitle : data[0].title;
   }
 );
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
@@ -1,24 +1,30 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 
-export const getData = state => state.data || null;
-export const getActive = state => state.active || null;
+const getData = state => state.data || null;
+const getActive = state => state.active || null;
+export const getModalTitle = state => state.title || null;
 
 export const getModalData = createSelector(
   [getData, getActive],
   (data, active) => {
     if (isEmpty(data) || !active) return null;
-    if (data[active]) return data[active];
+    if (active.every(d => data[d])) {
+      return active.length > 1
+        ? Object.keys(data).map(source => data[source])
+        : [data[active]];
+    }
     return null;
   }
 );
 
-export const getModalTitle = createSelector(
+export const getTabTitles = createSelector(
   getModalData,
-  data => (data ? data.title : '')
+  data => (data && data.length > 1 ? data.map(d => d.title) : null)
 );
 
 export default {
   getModalTitle,
-  getModalData
+  getModalData,
+  getTabTitles
 };

--- a/app/javascript/app/components/modal-metadata/modal-metadata.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata.js
@@ -5,12 +5,17 @@ import actions from './modal-metadata-actions';
 import reducers, { initialState } from './modal-metadata-reducers';
 
 import ModalMetadataComponent from './modal-metadata-component';
-import { getModalTitle, getModalData } from './modal-metadata-selectors';
+import {
+  getModalTitle,
+  getTabTitles,
+  getModalData
+} from './modal-metadata-selectors';
 
 const mapStateToProps = ({ modalMetadata }) => ({
   isOpen: modalMetadata.isOpen,
   loading: modalMetadata.loading,
   title: getModalTitle(modalMetadata),
+  tabTitles: getTabTitles(modalMetadata),
   data: getModalData(modalMetadata)
 });
 

--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -1,25 +1,11 @@
 import React, { PureComponent } from 'react';
 import Modal from 'react-modal';
 import PropTypes from 'prop-types';
-
 import Button from 'components/button';
 import Icon from 'components/icon';
 
 import closeIcon from 'assets/icons/sidebar-close.svg';
-
 import styles from './modal-styles.scss';
-
-export const ModalHeader = ({ title, children }) => (
-  <div className={styles.header}>
-    {title && <h2 className={styles.headerTitle}>{title}</h2>}
-    {children}
-  </div>
-);
-
-ModalHeader.propTypes = {
-  title: PropTypes.string,
-  children: PropTypes.node
-};
 
 class CustomModal extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function

--- a/app/javascript/app/components/modal/modal-header-component.jsx
+++ b/app/javascript/app/components/modal/modal-header-component.jsx
@@ -5,13 +5,6 @@ import Tab from 'components/tab';
 import styles from './modal-styles.scss';
 
 class ModalHeader extends PureComponent {
-  constructor() {
-    super();
-    this.state = {
-      selectedIndex: 0
-    };
-  }
-
   render() {
     const {
       title,

--- a/app/javascript/app/components/modal/modal-header-component.jsx
+++ b/app/javascript/app/components/modal/modal-header-component.jsx
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Tab from 'components/tab';
+
+import styles from './modal-styles.scss';
+
+class ModalHeader extends PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      selectedIndex: 0
+    };
+  }
+
+  render() {
+    const {
+      title,
+      tabTitles,
+      children,
+      selectedIndex,
+      handleTabIndexChange
+    } = this.props;
+    return (
+      <div className={styles.header}>
+        {title && <h2 className={styles.headerTitle}>{title}</h2>}
+        {tabTitles && (
+          <Tab
+            options={tabTitles}
+            selectedIndex={selectedIndex}
+            handleTabIndexChange={handleTabIndexChange}
+          />
+        )}
+        {children}
+      </div>
+    );
+  }
+}
+
+ModalHeader.propTypes = {
+  title: PropTypes.string,
+  tabTitles: PropTypes.array,
+  selectedIndex: PropTypes.number,
+  handleTabIndexChange: PropTypes.func,
+  children: PropTypes.node
+};
+
+export default ModalHeader;

--- a/app/javascript/app/components/modal/modal.js
+++ b/app/javascript/app/components/modal/modal.js
@@ -1,5 +1,0 @@
-import Component from './modal-component';
-
-export { ModalHeader } from './modal-component';
-
-export default Component;

--- a/app/javascript/app/components/tab/tab-component.jsx
+++ b/app/javascript/app/components/tab/tab-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 import styles from './tab-styles.scss';
 
@@ -9,19 +10,20 @@ class Tab extends PureComponent {
     const { options, selectedIndex, handleTabIndexChange } = this.props;
     return (
       <div className={styles.tab}>
-        <div className="nav-tab">
-          {options.map((option, i) => (
-            <a
-              key={option}
-              className={selectedIndex === i ? '-active' : ''}
-              onClick={() => handleTabIndexChange(i)}
-              role="menuitem"
-              tabIndex={-1}
-            >
-              {option}
-            </a>
-          ))}
-        </div>
+        {options.map((option, i) => (
+          <a
+            key={option}
+            className={cx([
+              styles.link,
+              { [styles.linkActive]: selectedIndex === i }
+            ])}
+            onClick={() => handleTabIndexChange(i)}
+            role="menuitem"
+            tabIndex={-1}
+          >
+            {option}
+          </a>
+        ))}
       </div>
     );
   }

--- a/app/javascript/app/components/tab/tab-component.jsx
+++ b/app/javascript/app/components/tab/tab-component.jsx
@@ -1,0 +1,36 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './tab-styles.scss';
+
+class Tab extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const { options, selectedIndex, handleTabIndexChange } = this.props;
+    return (
+      <div className={styles.tab}>
+        <div className="nav-tab">
+          {options.map((option, i) => (
+            <a
+              key={option}
+              className={selectedIndex === i ? '-active' : ''}
+              onClick={() => handleTabIndexChange(i)}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              {option}
+            </a>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+Tab.propTypes = {
+  options: PropTypes.array.isRequired,
+  selectedIndex: PropTypes.number.isRequired,
+  handleTabIndexChange: PropTypes.func.isRequired
+};
+
+export default Tab;

--- a/app/javascript/app/components/tab/tab-styles.scss
+++ b/app/javascript/app/components/tab/tab-styles.scss
@@ -1,0 +1,1 @@
+@import '~styles/layout.scss';

--- a/app/javascript/app/components/tab/tab-styles.scss
+++ b/app/javascript/app/components/tab/tab-styles.scss
@@ -1,1 +1,27 @@
 @import '~styles/layout.scss';
+
+.tab {
+  display: flex;
+  align-items: center;
+  margin-top: 15px;
+}
+
+.link {
+  color: $theme-color;
+  margin-right: 30px;
+  padding: 15px 0;
+  text-decoration: none;
+  position: relative;
+  cursor: pointer;
+
+  &Active::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $theme-secondary;
+    width: 100%;
+    height: 4px;
+  }
+}

--- a/app/javascript/app/components/tab/tab.js
+++ b/app/javascript/app/components/tab/tab.js
@@ -1,0 +1,3 @@
+import Component from './tab-component';
+
+export default Component;

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -14,7 +14,7 @@ class VulnerabilityGraph extends PureComponent {
   handleInfoClick = slug => {
     const { setModalMetadata } = this.props;
     setModalMetadata({
-      slug,
+      slugs: [slug],
       open: true
     });
   };


### PR DESCRIPTION
Modals could show only one metadata source at a time. There were some cases (i.e country GHG emissions) where we needed to display two different sources in tabs with a custom title.

- [x] Add tabs to the modal header
- [x] Add custom title to tab provided as a param to setModalMetadataParams

![image](https://user-images.githubusercontent.com/9701591/32835403-420836f2-ca06-11e7-8cbf-9694b0e9b462.png)

---
Some working info modals: country GHG emissions, GHG emissions page