### PR TITLE
Fix/chart axes to zero

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -27,7 +27,7 @@ class ChartLine extends PureComponent {
   };
 
   render() {
-    const { config, data, height } = this.props;
+    const { config, data, height, domain } = this.props;
     return (
       <ResponsiveContainer height={height}>
         <LineChart
@@ -46,7 +46,7 @@ class ChartLine extends PureComponent {
             tickFormatter={tick => `${format('.2s')(tick)}t`}
             tickLine={false}
             tick={{ stroke: '#8f8fa1', strokeWidth: 0.5, fontSize: '13px' }}
-            domain={['auto', 'auto']}
+            domain={domain || ['auto', 'auto']}
           />
           <CartesianGrid vertical={false} />
           <Tooltip
@@ -76,7 +76,8 @@ ChartLine.propTypes = {
   config: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
   height: PropTypes.any.isRequired,
-  onMouseMove: PropTypes.func.isRequired
+  onMouseMove: PropTypes.func.isRequired,
+  domain: PropTypes.array
 };
 
 ChartLine.defaultProps = {

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -97,7 +97,7 @@ class ChartStackedArea extends PureComponent {
 
     const domain = {
       x: ['dataMin', 'dataMax'],
-      y: ['dataMin', 'dataMax']
+      y: [0, 'dataMax']
     };
 
     if (points.length > 0) {

--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -72,6 +72,7 @@ class CountryGhgEmissions extends PureComponent {
           {loading && <Loading light className={styles.loader} />}
           {!loading && (
             <ChartComponent
+              domain={[0, 'auto']}
               config={config}
               data={data}
               height="100%"

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -91,7 +91,7 @@ class GhgEmissions extends PureComponent {
             )}
           {data && config &&
             <div>
-              <ChartLine config={config} data={data} height={500} />
+              <ChartLine config={config} data={data} height={500} domain={[0, 'auto']} />
               <div className={styles.tags}>
                 {config.columns &&
                   config.columns.y.map(column => (

--- a/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table.js
+++ b/app/javascript/app/components/ndc-sdg-linkages-table/ndc-sdg-linkages-table.js
@@ -27,7 +27,7 @@ const mapStateToProps = (state, { location }) => {
 class NdcSdgLinkagesTableContainer extends PureComponent {
   updateUrlParam(param, clear) {
     const { history, location } = this.props;
-    history.replace(getLocationParamUpdated(location, param, clear));
+    history.push(getLocationParamUpdated(location, param, clear));
   }
 
   handleClickGoal = sdgNumber => {


### PR DESCRIPTION
Addresses two bugs:
- Allow domain to be set for the line chart components, and set to 0 when needs for charts
- Allow users to go back in their history when on the SDGs map tiles and lists