### PR TITLE
Add ordering of indicators and categories (indc)

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -26,7 +26,8 @@ module Api
           all
 
         categories = ::Indc::Category.
-          includes(:category_type)
+          includes(:category_type).
+          order(:order)
 
         if params[:filter]
           categories = categories.where(
@@ -53,7 +54,8 @@ module Api
             :labels, :source, :categories,
             values: [:sector, :label, :location]
           ).
-          where(id: categories.flat_map(&:indicator_ids).uniq)
+          where(id: categories.flat_map(&:indicator_ids).uniq).
+          order(:order)
 
         if location_list
           indicators = indicators.where(

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -71,7 +71,7 @@ class ImportIndc
       name: name,
       slug: Slug.create(name),
       category_type: category_type,
-      order: index*10
+      order: index * 10
     }
   end
 
@@ -81,7 +81,7 @@ class ImportIndc
       slug: indicator[:column_name],
       description: indicator[:definition],
       source: @sources_index[indicator[:source]],
-      order: index*10
+      order: index * 10
     }
   end
 

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -66,20 +66,22 @@ class ImportIndc
       to_h
   end
 
-  def category_attributes(name, category_type)
+  def category_attributes(name, category_type, index)
     {
       name: name,
       slug: Slug.create(name),
-      category_type: category_type
+      category_type: category_type,
+      order: index*10
     }
   end
 
-  def indicator_attributes(indicator)
+  def indicator_attributes(indicator, index)
     {
       name: indicator[:long_name],
       slug: indicator[:column_name],
       description: indicator[:definition],
-      source: @sources_index[indicator[:source]]
+      source: @sources_index[indicator[:source]],
+      order: index*10
     }
   end
 
@@ -119,8 +121,8 @@ class ImportIndc
       map { |m| m[:"#{category_type.name}_category"] }.
       select(&:itself).
       uniq.
-      each do |name|
-        Indc::Category.create!(category_attributes(name, category_type))
+      each_with_index do |name, index|
+        Indc::Category.create!(category_attributes(name, category_type, index))
       end
   end
 
@@ -189,8 +191,8 @@ class ImportIndc
       map { |r| [[r[:column_name], r[:source]], r] }.
       uniq(&:first).
       map(&:second).
-      each do |indicator|
-        Indc::Indicator.create!(indicator_attributes(indicator))
+      each_with_index do |indicator, index|
+        Indc::Indicator.create!(indicator_attributes(indicator, index))
       end
   end
 

--- a/db/migrate/20171121155022_add_order_to_indc_indicators.rb
+++ b/db/migrate/20171121155022_add_order_to_indc_indicators.rb
@@ -1,0 +1,5 @@
+class AddOrderToIndcIndicators < ActiveRecord::Migration[5.1]
+  def change
+    add_column :indc_indicators, :order, :integer
+  end
+end

--- a/db/migrate/20171121155026_add_order_to_indc_categories.rb
+++ b/db/migrate/20171121155026_add_order_to_indc_categories.rb
@@ -1,0 +1,5 @@
+class AddOrderToIndcCategories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :indc_categories, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109140033) do
+ActiveRecord::Schema.define(version: 20171121155026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20171109140033) do
     t.text "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order"
     t.index ["category_type_id"], name: "index_indc_categories_on_category_type_id"
     t.index ["parent_id"], name: "index_indc_categories_on_parent_id"
     t.index ["slug", "category_type_id"], name: "index_indc_categories_on_slug_and_category_type_id", unique: true
@@ -106,6 +107,7 @@ ActiveRecord::Schema.define(version: 20171109140033) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order"
     t.index ["slug"], name: "index_indc_indicators_on_slug", unique: true
     t.index ["source_id"], name: "index_indc_indicators_on_source_id"
   end


### PR DESCRIPTION
This PR adds an order column to indc_indicators and indc_categories, which is
populated on import. This is to explicity set the ordering of these to the order
they appear in the indc metadata file.