### PR TITLE
Add overview model modal

### DIFF
--- a/app/javascript/app/components/emission-pathways-overview/emission-pathways-overview-component.jsx
+++ b/app/javascript/app/components/emission-pathways-overview/emission-pathways-overview-component.jsx
@@ -3,15 +3,15 @@ import Button from 'components/button';
 import PropTypes from 'prop-types';
 import startCase from 'lodash/startCase';
 import Loading from 'components/loading';
-
 import layout from 'styles/layout.scss';
 import cx from 'classnames';
+import ModalOverview from './modal-overview';
 import styles from './emission-pathways-overview-styles.scss';
 
 class EmissionPathwaysOverview extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { data, loading } = this.props;
+    const { data, fullData, modalTitle, loading, handleInfoClick } = this.props;
     return (
       <div className={styles.wrapper}>
         <div className={layout.content}>
@@ -26,11 +26,16 @@ class EmissionPathwaysOverview extends PureComponent {
               ))}
           </div>
           <div className={styles.col5}>
-            <Button className={(styles.col5, styles.seeAllButton)}>
+            <Button
+              className={(styles.col5, styles.seeAllButton)}
+              onClick={handleInfoClick}
+              color="plain"
+            >
               See all
             </Button>
           </div>
         </div>
+        <ModalOverview data={fullData} title={modalTitle} />
       </div>
     );
   }
@@ -38,7 +43,10 @@ class EmissionPathwaysOverview extends PureComponent {
 
 EmissionPathwaysOverview.propTypes = {
   data: PropTypes.object,
-  loading: PropTypes.bool
+  fullData: PropTypes.object,
+  modalTitle: PropTypes.string,
+  loading: PropTypes.bool,
+  handleInfoClick: PropTypes.func.isRequired
 };
 
 export default EmissionPathwaysOverview;

--- a/app/javascript/app/components/emission-pathways-overview/emission-pathways-overview.js
+++ b/app/javascript/app/components/emission-pathways-overview/emission-pathways-overview.js
@@ -1,11 +1,17 @@
+import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
+import Proptypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import Component from './emission-pathways-overview-component';
-import { parseArraysOverviewData } from './emission-pathways-overview-selectors';
+import {
+  selectOverviewData,
+  filterDataByBlackList,
+  getModalTitle
+} from './emission-pathways-overview-selectors';
+import { actions } from './modal-overview/modal-overview';
 
 const mapStateToProps = (state, { match, category }) => {
   const id = match.params.id;
-
   const categoryState = state[`esp${category}`];
   const categoryData = categoryState && categoryState.data;
   const stateWithId = {
@@ -13,10 +19,32 @@ const mapStateToProps = (state, { match, category }) => {
     category,
     categoryData
   };
+
   return {
-    data: parseArraysOverviewData(stateWithId),
+    fullData: filterDataByBlackList(stateWithId),
+    data: selectOverviewData(stateWithId),
+    modalTitle: getModalTitle(stateWithId),
     loading: state.espModels.loading
   };
 };
 
-export default withRouter(connect(mapStateToProps)(Component));
+class EmissionPathwaysOverviewContainer extends PureComponent {
+  handleInfoClick = () => {
+    this.props.toggleModalOverview({ open: true });
+  };
+
+  render() {
+    return createElement(Component, {
+      ...this.props,
+      handleInfoClick: this.handleInfoClick
+    });
+  }
+}
+
+EmissionPathwaysOverviewContainer.propTypes = {
+  toggleModalOverview: Proptypes.func.isRequired
+};
+
+export default withRouter(
+  connect(mapStateToProps, actions)(EmissionPathwaysOverviewContainer)
+);

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-actions.js
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-actions.js
@@ -1,0 +1,5 @@
+import { createAction } from 'redux-actions';
+
+const toggleModalOverview = createAction('toggleModalOverview');
+
+export default { toggleModalOverview };

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-component.jsx
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-component.jsx
@@ -1,0 +1,59 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'components/modal/modal-component';
+import ModalHeader from 'components/modal/modal-header-component';
+import NoContent from 'components/no-content';
+import startCase from 'lodash/startCase';
+import styles from './modal-overview-styles.scss';
+
+const MetadataProp = ({ title, children }) => (
+  <p className={styles.text}>
+    <span className={styles.textHighlight}>{startCase(title)}: </span>
+    {children}
+  </p>
+);
+
+MetadataProp.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node
+};
+
+class ModalOverview extends PureComponent {
+  constructor() {
+    super();
+    this.handleOnRequestClose = this.handleOnRequestClose.bind(this);
+  }
+
+  handleOnRequestClose() {
+    this.props.onRequestClose();
+  }
+
+  renderData() {
+    const { data } = this.props;
+    if (!data) return <NoContent />;
+    return Object.keys(data).map(key => (
+      <MetadataProp key={key} title={key}>
+        {data[key]}
+      </MetadataProp>
+    ));
+  }
+
+  render() {
+    const { isOpen, title } = this.props;
+    return (
+      <Modal isOpen={isOpen} onRequestClose={this.handleOnRequestClose}>
+        <ModalHeader title={title} />
+        {this.renderData()}
+      </Modal>
+    );
+  }
+}
+
+ModalOverview.propTypes = {
+  data: PropTypes.object,
+  title: PropTypes.string,
+  isOpen: PropTypes.bool.isRequired,
+  onRequestClose: PropTypes.func.isRequired
+};
+
+export default ModalOverview;

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-reducers.js
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-reducers.js
@@ -1,0 +1,12 @@
+export const initialState = {
+  isOpen: false
+};
+
+const toggleModalOverview = (state, { payload }) => ({
+  ...state,
+  isOpen: payload.open
+});
+
+export default {
+  toggleModalOverview
+};

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-styles.scss
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-styles.scss
@@ -1,0 +1,12 @@
+@import '~styles/layout.scss';
+
+.text {
+  font-size: $font-size;
+  line-height: $line-height-medium;
+  color: $theme-color;
+  margin-bottom: 5px;
+
+  &Highlight {
+    font-weight: $font-weight-bold;
+  }
+}

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-styles.scss
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview-styles.scss
@@ -2,7 +2,7 @@
 
 .text {
   font-size: $font-size;
-  line-height: $line-height-medium;
+  line-height: $line-height-modal;
   color: $theme-color;
   margin-bottom: 5px;
 

--- a/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview.js
+++ b/app/javascript/app/components/emission-pathways-overview/modal-overview/modal-overview.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import { withHandlers } from 'recompose';
+import actions from './modal-overview-actions';
+import reducers, { initialState } from './modal-overview-reducers';
+
+import Component from './modal-overview-component';
+
+const mapStateToProps = ({ modalESPOverview }) => ({
+  isOpen: modalESPOverview.isOpen
+});
+
+const includeActions = withHandlers({
+  onRequestClose: props => () => {
+    props.toggleModalOverview({ open: false });
+  }
+});
+
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(includeActions(Component));

--- a/app/javascript/app/components/modal-metadata/modal-metadata-styles.scss
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-styles.scss
@@ -7,7 +7,7 @@
 
 .text {
   font-size: $font-size;
-  line-height: $line-height-medium;
+  line-height: $line-height-modal;
   color: $theme-color;
   margin-bottom: 5px;
 

--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -59,7 +59,7 @@ CustomModal.defaultProps = {
       right: 'auto',
       bottom: 'auto',
       width: '770px',
-      padding: '30px',
+      padding: '35px 40px',
       maxHeight: '640px',
       height: 'calc(100vh - 100px)',
       border: 'none',

--- a/app/javascript/app/components/modal/modal-styles.scss
+++ b/app/javascript/app/components/modal/modal-styles.scss
@@ -8,9 +8,9 @@ $close-position: 25px;
 
 .header {
   background-color: $light-gray;
-  margin: -$modal-padding;
-  margin-bottom: $gutter-padding;
-  padding: $modal-padding;
+  margin: -$modal-padding -40px;
+  margin-bottom: 30px;
+  padding: $modal-padding 40px;
   padding-bottom: 0;
   min-height: 95px;
   border-bottom: solid 1px $border-color;
@@ -21,7 +21,7 @@ $close-position: 25px;
   font-weight: $font-weight;
   color: $theme-color;
   margin-top: 5px;
-  margin-bottom: $gutter-padding;
+  margin-bottom: 30px;
   padding-right: $gutter-padding + $close-position;
 }
 

--- a/app/javascript/app/components/tab/tab-styles.scss
+++ b/app/javascript/app/components/tab/tab-styles.scss
@@ -9,7 +9,7 @@
 .link {
   color: $theme-color;
   margin-right: 30px;
-  padding: 15px 0;
+  padding-bottom: 15px;
   text-decoration: none;
   position: relative;
   cursor: pointer;

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -62,6 +62,7 @@ import * as storiesComponent from 'components/stories';
 import * as countrySelectComponent from 'components/countries-select';
 import * as ghgEmissionsComponent from 'components/ghg-emissions';
 import * as modalMetadataComponent from 'components/modal-metadata';
+import * as modalESPOverviewComponent from 'components/emission-pathways-overview/modal-overview';
 import * as ndcCountryAccordion from 'components/ndcs-country-accordion';
 import * as countryGhgEmissionsMapComponent from 'components/country-ghg-map';
 import * as countryGhgEmissionsComponent from 'components/country-ghg-emissions';
@@ -75,6 +76,7 @@ const componentsReducers = {
   countrySelect: handleActions(countrySelectComponent),
   ghgEmissions: handleActions(ghgEmissionsComponent),
   modalMetadata: handleActions(modalMetadataComponent),
+  modalESPOverview: handleActions(modalESPOverviewComponent),
   ndcCountryAccordion: handleActions(ndcCountryAccordion),
   countryGhgEmissionsMap: handleActions(countryGhgEmissionsMapComponent),
   countryGhgEmissions: handleActions(countryGhgEmissionsComponent),

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -19,11 +19,12 @@ $font-weight-bold: 600;
 
 // line height
 $line-height-medium: 1.62;
+$line-height-modal: 26px;
 
 // Layout
 $max-width: 1210px;
 $gutter-padding: 15px;
-$modal-padding: 30px;
+$modal-padding: 35px;
 $navbar-height: 60px;
 $paragraph-max-width: 770px;
 


### PR DESCRIPTION
Modal displaying all the data from a model in ESP model show page:

- Create a modal overview component (a little bit different from the modal-metadata)
- Select and pass the data from the overview component
- Blacklist undesired attributes
- Pass the full name as the title
- Remove the Full name in the attributes as it is included in the title

![image](https://user-images.githubusercontent.com/9701591/33393914-fb81feca-d540-11e7-88f9-17776635789d.png)
