### PR TITLE
Improve ndc sdg import

### DIFF
--- a/app/lib/text_normalizer.rb
+++ b/app/lib/text_normalizer.rb
@@ -1,0 +1,13 @@
+module TextNormalizer
+  def self.normalize(string)
+    operations = [
+      lambda { |s| s.gsub(160.chr('UTF-8'), 32.chr) },
+      lambda { |s| s.squish }
+    ]
+
+    operations.reduce(string) do |s, operation|
+      operation.call(s)
+    end
+  end
+end
+

--- a/app/lib/text_normalizer.rb
+++ b/app/lib/text_normalizer.rb
@@ -1,8 +1,8 @@
 module TextNormalizer
   def self.normalize(string)
     operations = [
-      lambda { |s| s.gsub(160.chr('UTF-8'), 32.chr) },
-      lambda { |s| s.squish }
+      ->(s) { s.gsub(160.chr('UTF-8'), 32.chr) },
+      ->(s) { s.squish }
     ]
 
     operations.reduce(string) do |s, operation|
@@ -10,4 +10,3 @@ module TextNormalizer
     end
   end
 end
-

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -1,7 +1,12 @@
+require 'csv'
+
 class ImportNdcSdgTargets
   NDC_SDG_TARGETS = "#{CW_FILES_PREFIX}sdgs/ndc_sdg_targets.csv"
 
+
   def call
+    @failed_lines = [];
+
     cleanup
     import_ndc_sdg_targets(S3CSVReader.read(NDC_SDG_TARGETS))
   end
@@ -16,9 +21,15 @@ class ImportNdcSdgTargets
 
   def import_ndc_sdg_targets(content)
     content.each.with_index(2) do |row|
+      row[:indc_text] = TextNormalizer.normalize(row[:indc_text])
       ndc = ndc(row)
       target = target(row)
-      next unless ndc && target
+
+      unless ndc && target
+        @failed_lines.append(row)
+        next
+      end
+
       indc_text = row[:indc_text]
       starts_at = ndc.full_text.downcase.index(indc_text.downcase)
       ends_at = starts_at + indc_text.length - 1 if starts_at
@@ -33,6 +44,15 @@ class ImportNdcSdgTargets
         ends_at: ends_at
       )
       import_ndc_target_sectors(row, ndc_target)
+    end
+
+    if @failed_lines.length > 0
+      CSV.open("#{Rails.root}/tmp/ndc_sdg_targets_failed_rows.csv", 'wb') do |csv|
+        csv << @failed_lines.first.headers
+        @failed_lines.each do |line|
+          csv << line
+        end
+      end
     end
   end
 

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -3,9 +3,8 @@ require 'csv'
 class ImportNdcSdgTargets
   NDC_SDG_TARGETS = "#{CW_FILES_PREFIX}sdgs/ndc_sdg_targets.csv"
 
-
   def call
-    @failed_lines = [];
+    @failed_lines = []
 
     cleanup
     import_ndc_sdg_targets(S3CSVReader.read(NDC_SDG_TARGETS))
@@ -46,7 +45,7 @@ class ImportNdcSdgTargets
       import_ndc_target_sectors(row, ndc_target)
     end
 
-    if @failed_lines.length > 0
+    unless @failed_lines.empty?
       CSV.open("#{Rails.root}/tmp/ndc_sdg_targets_failed_rows.csv", 'wb') do |csv|
         csv << @failed_lines.first.headers
         @failed_lines.each do |line|

--- a/app/services/import_ndc_texts.rb
+++ b/app/services/import_ndc_texts.rb
@@ -36,6 +36,7 @@ class ImportNdcTexts
 
     file = s3.get_object(bucket: bucket_name, key: object.key)
     html_content = html_content_with_resolved_image_paths(file.body.read)
+    html_content = TextNormalizer.normalize(html_content)
     Ndc.create!(
       location: location,
       full_text: html_content,


### PR DESCRIPTION
Ndc texts and linkage texts will have:
- the non-breaking space character replaced by a normal space
- grouped whitespace characters replaced by a single space (0x20) character.
These two features lay a foundation for us to handle special cases like these in the future.

Also adds a feature to the linkages import: lines in `ndc_sdg_targets.csv` that didn't import will be dumped to `rails_root/tmp/ndc_sdg_targets_failed_rows.csv`.