### PR TITLE
Export actions correctly to import them in reducers

### DIFF
--- a/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
+++ b/app/javascript/app/providers/esp-scenarios-provider/esp-scenarios-provider-actions.js
@@ -2,12 +2,12 @@ import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
 
-const fetchEspScenariosInit = createAction('fetchEspScenariosInit');
-const fetchEspScenariosReady = createAction('fetchEspScenariosReady');
-const fetchEspScenariosFail = createAction('fetchEspScenariosFail');
+export const fetchEspScenariosInit = createAction('fetchEspScenariosInit');
+export const fetchEspScenariosReady = createAction('fetchEspScenariosReady');
+export const fetchEspScenariosFail = createAction('fetchEspScenariosFail');
 const { ESP_API } = process.env;
 
-const fetchEspScenarios = createThunkAction(
+export const fetchEspScenarios = createThunkAction(
   'fetchEspScenarios',
   () => (dispatch, state) => {
     const { espScenarios } = state();


### PR DESCRIPTION
Scenarios were not being displayed due to the change of importing the actions in the espScenario reducer. Now the graph is working too.