### PR TITLE
Add box-shadow and only show not selected items in graph legend

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -19,8 +19,7 @@ class LegendChart extends PureComponent {
       handleAdd,
       className
     } = this.props;
-    const shouldRenderMultiselect =
-      dataOptions && dataSelected && dataSelected.length !== dataOptions.length;
+    const shouldRenderMultiselect = dataOptions && dataSelected;
     return (
       <div className={cx(styles.tags, className)}>
         {config &&
@@ -40,7 +39,9 @@ class LegendChart extends PureComponent {
           ))}
         {shouldRenderMultiselect && (
           <MultiSelect
-            parentClassName={styles.tagSelector}
+            parentClassName={cx(styles.tagSelector, {
+              [styles.hidden]: dataOptions.length === dataSelected.length
+            })}
             values={dataSelected || []}
             options={dataOptions || []}
             onMultiValueChange={handleAdd}

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -8,7 +8,8 @@ import cx from 'classnames';
 import plusIcon from 'assets/icons/plus.svg';
 import styles from './legend-chart-styles.scss';
 
-class LegendChart extends PureComponent { // eslint-disable-line react/prefer-stateless-function
+class LegendChart extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
   render() {
     const {
       config,
@@ -18,6 +19,8 @@ class LegendChart extends PureComponent { // eslint-disable-line react/prefer-st
       handleAdd,
       className
     } = this.props;
+    const shouldRenderMultiselect =
+      dataOptions && dataSelected && dataSelected.length !== dataOptions.length;
     return (
       <div className={cx(styles.tags, className)}>
         {config &&
@@ -35,22 +38,20 @@ class LegendChart extends PureComponent { // eslint-disable-line react/prefer-st
               canRemove={config.columns.y.length > 1}
             />
           ))}
-        {dataOptions &&
-          dataSelected &&
-          dataSelected.length !==
-            dataOptions.length && (
-            <MultiSelect
-              parentClassName={styles.tagSelector}
-              values={dataSelected || []}
-              options={dataOptions || []}
-              onMultiValueChange={handleAdd}
-              hideResetButton
-              closeOnSelect
-              dropdownDirection={-1}
-            >
-              <Icon className={styles.plusIcon} icon={plusIcon} />
-            </MultiSelect>
-          )}
+        {shouldRenderMultiselect && (
+          <MultiSelect
+            parentClassName={styles.tagSelector}
+            values={dataSelected || []}
+            options={dataOptions || []}
+            onMultiValueChange={handleAdd}
+            hideResetButton
+            closeOnSelect
+            dropdownDirection={-1}
+            hideSelected
+          >
+            <Icon className={styles.plusIcon} icon={plusIcon} />
+          </MultiSelect>
+        )}
       </div>
     );
   }

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -19,7 +19,6 @@ class LegendChart extends PureComponent {
       handleAdd,
       className
     } = this.props;
-    const shouldRenderMultiselect = dataOptions && dataSelected;
     return (
       <div className={cx(styles.tags, className)}>
         {config &&
@@ -34,13 +33,14 @@ class LegendChart extends PureComponent {
                 id: column.value
               }}
               onRemove={handleRemove}
-              canRemove={config.columns.y.length > 1}
+              canRemove={config.columns.y.length > 0}
             />
           ))}
-        {shouldRenderMultiselect && (
+        {dataOptions && (
           <MultiSelect
             parentClassName={cx(styles.tagSelector, {
-              [styles.hidden]: dataOptions.length === dataSelected.length
+              [styles.hidden]:
+                !dataSelected || dataOptions.length === dataSelected.length
             })}
             values={dataSelected || []}
             options={dataOptions || []}

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -43,3 +43,7 @@
   width: 10px;
   height: 10px;
 }
+
+.hidden {
+  opacity: 0;
+}

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -36,7 +36,6 @@
     margin-right: -1px;
     border-radius: 4px;
     bottom: 28px !important;
-    box-shadow: none !important;
   }
 }
 

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -51,7 +51,8 @@ class Multiselect extends Component {
       filterOptions,
       label,
       parentClassName,
-      children
+      children,
+      hideSelected
     } = this.props;
     return (
       <div className={cx(styles.multiSelectWrapper, parentClassName)}>
@@ -75,12 +76,17 @@ class Multiselect extends Component {
             renderOption={option => {
               const className = option.isSelected ? selectedClassName : '';
               return (
-                <div
-                  className={cx(className, option.groupId ? styles.nested : '')}
-                >
-                  {option.label}
-                  {option.isSelected && <span className={styles.checked} />}
-                </div>
+                (!hideSelected || !option.isSelected) && (
+                  <div
+                    className={cx(
+                      className,
+                      option.groupId ? styles.nested : ''
+                    )}
+                  >
+                    {option.label}
+                    {option.isSelected && <span className={styles.checked} />}
+                  </div>
+                )
               );
             }}
             onValuesChange={handleChange}
@@ -110,7 +116,8 @@ Multiselect.propTypes = {
   handleChange: Proptypes.func,
   label: Proptypes.string,
   selectedLabel: Proptypes.string,
-  children: Proptypes.node
+  children: Proptypes.node,
+  hideSelected: Proptypes.bool
 };
 
 Multiselect.defaultProps = {

--- a/app/javascript/app/components/multiselect/multiselect.js
+++ b/app/javascript/app/components/multiselect/multiselect.js
@@ -10,14 +10,17 @@ export { default as styles } from './multiselect-styles';
 
 class MultiSelectContainer extends PureComponent {
   filterOptions = (options, something, search) => {
-    const optionsParsed = options.map(o => {
+    const optionsParsed = [];
+    options.forEach(o => {
       const isSelected = this.props.values.some(
         filter => o.value === filter.value
       );
-      return {
-        ...o,
-        isSelected
-      };
+      if (!this.props.hideSelected || !isSelected) {
+        optionsParsed.push({
+          ...o,
+          isSelected
+        });
+      }
     });
     return search
       ? optionsParsed.filter(
@@ -59,7 +62,8 @@ class MultiSelectContainer extends PureComponent {
 
 MultiSelectContainer.propTypes = {
   onMultiValueChange: Proptypes.func,
-  values: Proptypes.array
+  values: Proptypes.array,
+  hideSelected: Proptypes.bool
 };
 
 export default MultiSelectContainer;


### PR DESCRIPTION
- Add box-shadow to the selector
- Add a hideSelected prop to display only the values that are not selected
- Now is possible to remove all options to select the first one

![image](https://user-images.githubusercontent.com/9701591/33829823-1404f38c-de72-11e7-9ca5-126e7cddcf21.png)
