### PR TITLE
Feature/graph only available models

### DIFF
--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-actions.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-actions.js
@@ -1,0 +1,37 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+
+const findAvailableModelsInit = createAction('findAvailableModelsInit');
+const findAvailableModelsReady = createAction('findAvailableModelsReady');
+const findAvailableModelsFail = createAction('findAvailableModelsFail');
+const { ESP_API } = process.env;
+
+const findAvailableModels = createThunkAction(
+  'findAvailableModels',
+  locationId => dispatch => {
+    dispatch(findAvailableModelsInit());
+    fetch(`${ESP_API}/models?location=${locationId}&time_series=true`)
+      .then(response => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then(data => {
+        if (data) {
+          dispatch(findAvailableModelsReady(data.map(d => d.id)));
+        } else {
+          dispatch(findAvailableModelsReady({}));
+        }
+      })
+      .catch(error => {
+        console.warn(error);
+        dispatch(findAvailableModelsFail());
+      });
+  }
+);
+
+export default {
+  findAvailableModels,
+  findAvailableModelsInit,
+  findAvailableModelsReady,
+  findAvailableModelsFail
+};

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-reducers.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-reducers.js
@@ -1,0 +1,15 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  modelIds: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+
+export default {
+  findAvailableModelsInit: state => setLoading(true, state),
+  findAvailableModelsReady: (state, { payload }) =>
+    setLoaded(true, setLoading(false, { ...state, modelIds: payload })),
+  findAvailableModelsFail: state => setLoading(false, { ...state })
+};

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-reducers.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
   loading: false,
   loaded: false,
-  modelIds: {}
+  locations: {}
 };
 
 const setLoading = (loading, state) => ({ ...state, loading });
@@ -10,6 +10,15 @@ const setLoaded = (loaded, state) => ({ ...state, loaded });
 export default {
   findAvailableModelsInit: state => setLoading(true, state),
   findAvailableModelsReady: (state, { payload }) =>
-    setLoaded(true, setLoading(false, { ...state, modelIds: payload })),
+    setLoaded(
+      true,
+      setLoading(false, {
+        ...state,
+        locations: {
+          ...state.locations,
+          [payload.locationId]: payload.modelIds
+        }
+      })
+    ),
   findAvailableModelsFail: state => setLoading(false, { ...state })
 };

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -40,6 +40,7 @@ const AXES_CONFIG = {
 
 // meta data for selectors
 const getLocations = state => state.locations || null;
+const getAvailableModelIds = state => state.availableModelIds || null;
 const getModels = state => state.models || null;
 const getScenarios = state => state.scenarios || null;
 const getIndicators = state => state.indicators || null;
@@ -73,14 +74,23 @@ export const getLocationSelected = createSelector(
   }
 );
 
-export const getModelsOptions = createSelector([getModels], models => {
-  if (!models || !models.length) return [];
-  return models.map(m => ({
-    label: m.abbreviation,
-    value: m.id.toString(),
-    scenarios: m.scenarios ? m.scenarios.map(s => s.id.toString()) : null
-  }));
-});
+export const getModelsOptions = createSelector(
+  [getModels, getAvailableModelIds],
+  (models, availableModelIds) => {
+    if (!models || !models.length) return [];
+    let availableModels = models;
+    if (!isEmpty(availableModelIds)) {
+      availableModels = models.filter(
+        m => availableModelIds.indexOf(m.id) > -1
+      );
+    }
+    return availableModels.map(m => ({
+      label: m.abbreviation,
+      value: m.id.toString(),
+      scenarios: m.scenarios ? m.scenarios.map(s => s.id.toString()) : null
+    }));
+  }
+);
 
 export const getModelSelected = createSelector(
   [getModelsOptions, getModel],

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -40,7 +40,7 @@ const AXES_CONFIG = {
 
 // meta data for selectors
 const getLocations = state => state.locations || null;
-const getAvailableModelIds = state => state.availableModelIds || null;
+const getAvailableLocationsModelIds = state => state.availableModelIds || null;
 const getModels = state => state.models || null;
 const getScenarios = state => state.scenarios || null;
 const getIndicators = state => state.indicators || null;
@@ -52,6 +52,14 @@ const getIndicator = state => state.indicator || null;
 
 // data for the graph
 const getData = state => state.data || null;
+
+const getAvailableModelIds = createSelector(
+  [getAvailableLocationsModelIds, getLocation],
+  (availableLocationModelIds, location) => {
+    if (!availableLocationModelIds || !location) return null;
+    return availableLocationModelIds[location];
+  }
+);
 
 // Selector options
 export const getLocationsOptions = createSelector([getLocations], locations => {

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -14,8 +14,10 @@ import {
   getFiltersOptions,
   getFiltersSelected
 } from './emission-pathway-graph-selectors';
+import ownActions from './emission-pathway-graph-actions';
+import reducers, { initialState } from './emission-pathway-graph-reducers';
 
-const actions = { ...modalActions };
+const actions = { ...modalActions, ...ownActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data } = state.espTimeSeries;
@@ -29,6 +31,7 @@ const mapStateToProps = (state, { location }) => {
     scenarios: state.espScenarios.data,
     indicators: state.espIndicators.data,
     location: currentLocation,
+    availableModelIds: state.espGraph.modelIds,
     model,
     indicator,
     scenario
@@ -63,6 +66,7 @@ class EmissionPathwayGraphContainer extends PureComponent {
       { name: param, value: option ? option.value : '' },
       clear
     );
+    this.props.findAvailableModels(option.value);
   };
 
   updateUrlParam(params, clear) {
@@ -81,9 +85,11 @@ class EmissionPathwayGraphContainer extends PureComponent {
 
 EmissionPathwayGraphContainer.propTypes = {
   history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired
+  location: PropTypes.object.isRequired,
+  findAvailableModels: PropTypes.func.isRequired
 };
 
+export { actions, reducers, initialState };
 export default withRouter(
   connect(mapStateToProps, actions)(EmissionPathwayGraphContainer)
 );

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -31,8 +31,8 @@ const mapStateToProps = (state, { location }) => {
     models: state.espModels.data,
     scenarios: state.espScenarios.data,
     indicators: state.espIndicators.data,
-    location: currentLocation,
-    availableModelIds: state.espGraph.modelIds,
+    location: currentLocation || WORLD_LOCATION_ID,
+    availableModelIds: state.espGraph.locations,
     model,
     indicator,
     scenario

--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import { WORLD_LOCATION_ID } from 'data/constants';
 
 import { actions as modalActions } from 'components/modal-metadata';
 
@@ -51,6 +52,11 @@ const mapStateToProps = (state, { location }) => {
 };
 
 class EmissionPathwayGraphContainer extends PureComponent {
+  componentDidMount() {
+    const { currentLocation } = qs.parse(this.props.location.search);
+    this.props.findAvailableModels(currentLocation || WORLD_LOCATION_ID);
+  }
+
   handleModelChange = model => {
     this.updateUrlParam([
       { name: 'model', value: model.value },
@@ -66,7 +72,9 @@ class EmissionPathwayGraphContainer extends PureComponent {
       { name: param, value: option ? option.value : '' },
       clear
     );
-    this.props.findAvailableModels(option.value);
+    if (param === 'currentLocation') {
+      this.props.findAvailableModels(option.value);
+    }
   };
 
   updateUrlParam(params, clear) {

--- a/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
+++ b/app/javascript/app/providers/esp-locations-provider/esp-locations-provider-actions.js
@@ -9,7 +9,7 @@ const { ESP_API } = process.env;
 
 const getEspLocations = createThunkAction(
   'getEspLocations',
-  (withTimeSeries) => (dispatch, state) => {
+  withTimeSeries => (dispatch, state) => {
     const { espLocations } = state();
     if (
       espLocations.data &&

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -68,6 +68,7 @@ import * as countryGhgEmissionsMapComponent from 'components/country-ghg-map';
 import * as countryGhgEmissionsComponent from 'components/country-ghg-emissions';
 import * as countrySDGLinkagesComponent from 'components/country-ndc-sdg-linkages';
 import * as countryNDCOverviewComponent from 'components/country-ndc-overview';
+import * as espGraphComponent from 'components/emission-pathway-graph';
 
 const componentsReducers = {
   map: handleActions(mapComponent),
@@ -81,6 +82,7 @@ const componentsReducers = {
   countryGhgEmissionsMap: handleActions(countryGhgEmissionsMapComponent),
   countryGhgEmissions: handleActions(countryGhgEmissionsComponent),
   countrySDGLinkages: handleActions(countrySDGLinkagesComponent),
+  espGraph: handleActions(espGraphComponent),
   countryNDCOverview: handleActions(countryNDCOverviewComponent)
 };
 


### PR DESCRIPTION
This PR filters the models that are available for each location in the ESP graph 🎸 

- Create an espGraph reducer and actions to fetch only the available models with time series data for each location. The responses are grouped by location to be able to cache them.
- Filter the models in the selector

![image](https://user-images.githubusercontent.com/9701591/33880387-c1b2c454-df31-11e7-896e-8d6502f68146.png)
