### PR TITLE
Defaults to filtering by AR4 when there's no gwp defined

### DIFF
--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -20,8 +20,11 @@ module HistoricalEmissions
     end
 
     def self.filter_gwp(params)
-      selected_gwp = params[:gwp] ||
-        HistoricalEmissions::Gwp.where(name: 'AR4').first
+      selected_gwp =
+        params[:gwp] ||
+        HistoricalEmissions::Gwp.find_by(name: 'AR4') ||
+        HistoricalEmissions::Gwp.find_by(name: 'AR2')
+
       where(historical_emissions_gwps: {id: selected_gwp})
     end
 
@@ -32,7 +35,7 @@ module HistoricalEmissions
         )
       end
 
-      records = records.filter_gwp(params)
+      # records = records.filter_gwp(params)
 
       {
         historical_emissions_gases: :gas,

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -19,6 +19,12 @@ module HistoricalEmissions
       filters(records, params)
     end
 
+    def self.filter_gwp(params)
+      selected_gwp = params[:gwp] ||
+        HistoricalEmissions::Gwp.where(name: 'AR4').first
+      where(historical_emissions_gwps: {id: selected_gwp})
+    end
+
     private_class_method def self.filters(records, params)
       unless params[:location].blank?
         records = records.where(
@@ -26,11 +32,12 @@ module HistoricalEmissions
         )
       end
 
+      records = records.filter_gwp(params)
+
       {
         historical_emissions_gases: :gas,
         historical_emissions_data_sources: :source,
-        historical_emissions_sectors: :sector,
-        historical_emissions_gwps: :gwp
+        historical_emissions_sectors: :sector
       }.each do |k, v|
         records = records.where(k => {id: params[v].split(',')}) if params[v]
       end

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -1,6 +1,68 @@
 require 'rails_helper'
 
 describe Api::V1::HistoricalEmissionsController, type: :controller do
+
+  context do
+    let(:location) {FactoryGirl.create(:location)}
+    let(:data_source) {FactoryGirl.create(:historical_emissions_data_source)}
+    let(:gas) {FactoryGirl.create(:historical_emissions_gas)}
+    let(:gwp2) {FactoryGirl.create(:historical_emissions_gwp, name: 'AR2')}
+    let(:gwp4) {FactoryGirl.create(:historical_emissions_gwp, name: 'AR4')}
+    let(:sector) {FactoryGirl.create(:historical_emissions_sector,
+                                  data_source: data_source)}
+    let!(:some_historical_emissions_records) {
+      FactoryGirl.create(:historical_emissions_record,
+        data_source: data_source,
+        sector: sector,
+        gas: gas,
+        gwp: gwp2,
+        location: location
+      )
+      FactoryGirl.create(:historical_emissions_record,
+        data_source: data_source,
+        sector: sector,
+        gas: gas,
+        gwp: gwp4,
+        location: location
+      )
+    }
+
+    let(:data_source2) {FactoryGirl.create(:historical_emissions_data_source)}
+    let!(:record_with_just_ar2) {
+      FactoryGirl.create(:historical_emissions_record,
+        data_source: data_source2,
+        sector: sector,
+        gas: gas,
+        gwp: gwp2,
+        location: location
+      )
+    }
+
+    it 'when filtering by location, source, and gas, return 1 record' do
+      get :index, params: {source: data_source.id, gas: gas.id,
+                           location: location.id}
+      parsed_body = JSON.parse(response.body)
+      expect(response).to be_success
+      expect(parsed_body.length).to eq(1)
+    end
+
+    it 'returns results for the correct gwp' do
+      get :index, params: {source: data_source.id, gas: gas.id,
+                           location: location.id, gwp: gwp2.id}
+      parsed_body = JSON.parse(response.body)
+      expect(response).to be_success
+      expect(parsed_body.length).to eq(1)
+    end
+
+    it 'returns the AR2 record when no AR4 is present' do
+      get :index, params: {source: data_source2.id, gas: gas.id,
+                           location: location.id}
+      parsed_body = JSON.parse(response.body)
+      expect(response).to be_success
+      expect(parsed_body.length).to eq(1)
+    end
+  end
+
   context do
     let!(:some_historical_emissions_records) {
       data_source = FactoryGirl.create(:historical_emissions_data_source)

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -60,6 +60,7 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)
+      expect(parsed_body.first['gwp']).to eq('AR4')
     end
 
     it 'returns results for the correct gwp' do
@@ -75,6 +76,7 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)
+      expect(parsed_body.first['gwp']).to eq('AR2')
     end
 
     it 'returns the AR2 record when no AR4 is present' do
@@ -89,6 +91,7 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)
+      expect(parsed_body.first['gwp']).to eq('AR2')
     end
   end
 

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -3,33 +3,43 @@ require 'rails_helper'
 describe Api::V1::HistoricalEmissionsController, type: :controller do
 
   context do
-    let(:location) {FactoryGirl.create(:location)}
-    let(:data_source) {FactoryGirl.create(:historical_emissions_data_source)}
-    let(:gas) {FactoryGirl.create(:historical_emissions_gas)}
-    let(:gwp2) {FactoryGirl.create(:historical_emissions_gwp, name: 'AR2')}
-    let(:gwp4) {FactoryGirl.create(:historical_emissions_gwp, name: 'AR4')}
-    let(:sector) {FactoryGirl.create(:historical_emissions_sector,
-                                  data_source: data_source)}
+    let(:location) { FactoryGirl.create(:location) }
+    let(:data_source) { FactoryGirl.create(:historical_emissions_data_source) }
+    let(:gas) { FactoryGirl.create(:historical_emissions_gas) }
+    let(:gwp2) { FactoryGirl.create(:historical_emissions_gwp, name: 'AR2') }
+    let(:gwp4) { FactoryGirl.create(:historical_emissions_gwp, name: 'AR4') }
+    let(:sector) do
+      FactoryGirl.create(
+        :historical_emissions_sector,
+        data_source: data_source
+      )
+    end
+
     let!(:some_historical_emissions_records) {
-      FactoryGirl.create(:historical_emissions_record,
-        data_source: data_source,
-        sector: sector,
-        gas: gas,
-        gwp: gwp2,
-        location: location
-      )
-      FactoryGirl.create(:historical_emissions_record,
-        data_source: data_source,
-        sector: sector,
-        gas: gas,
-        gwp: gwp4,
-        location: location
-      )
+      [
+        FactoryGirl.create(
+          :historical_emissions_record,
+          data_source: data_source,
+          sector: sector,
+          gas: gas,
+          gwp: gwp2,
+          location: location
+        ),
+        FactoryGirl.create(
+          :historical_emissions_record,
+          data_source: data_source,
+          sector: sector,
+          gas: gas,
+          gwp: gwp4,
+          location: location
+        )
+      ]
     }
 
-    let(:data_source2) {FactoryGirl.create(:historical_emissions_data_source)}
+    let(:data_source2) { FactoryGirl.create(:historical_emissions_data_source) }
     let!(:record_with_just_ar2) {
-      FactoryGirl.create(:historical_emissions_record,
+      FactoryGirl.create(
+        :historical_emissions_record,
         data_source: data_source2,
         sector: sector,
         gas: gas,
@@ -39,24 +49,43 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
     }
 
     it 'when filtering by location, source, and gas, return 1 record' do
-      get :index, params: {source: data_source.id, gas: gas.id,
-                           location: location.id}
+      get(
+        :index,
+        params: {
+          source: data_source.id,
+          gas: gas.id,
+          location: location.iso_code3
+        }
+      )
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)
     end
 
     it 'returns results for the correct gwp' do
-      get :index, params: {source: data_source.id, gas: gas.id,
-                           location: location.id, gwp: gwp2.id}
+      get(
+        :index,
+        params: {
+          source: data_source.id,
+          gas: gas.id,
+          location: location.iso_code3,
+          gwp: gwp2.id
+        }
+      )
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)
     end
 
     it 'returns the AR2 record when no AR4 is present' do
-      get :index, params: {source: data_source2.id, gas: gas.id,
-                           location: location.id}
+      get(
+        :index,
+        params: {
+          source: data_source2.id,
+          gas: gas.id,
+          location: location.iso_code3
+        }
+      )
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
       expect(parsed_body.length).to eq(1)

--- a/spec/factories/historical_emissions_gwps.rb
+++ b/spec/factories/historical_emissions_gwps.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :historical_emissions_gwp,
           class: 'HistoricalEmissions::Gwp' do
-    name 'MyText'
+    name 'AR4'
   end
 end


### PR DESCRIPTION
When requesting historical emissions data we should default to GWP of AR4 when there's no param for GWP. This will fix an issue on the front end of double counting data.