### PR TITLE
Add category name to filter to avoid conflicts

### DIFF
--- a/app/javascript/app/components/emission-pathways-table/emission-pathways-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways-table/emission-pathways-table-component.jsx
@@ -52,7 +52,7 @@ class EmissionPathwaysTable extends PureComponent {
         placeholder={`Filter by ${startCase(field)}`}
         options={filterOptions ? filterOptions[field] : []}
         onValueChange={selected =>
-          handleFilterChange(field, selected && selected.value)}
+          handleFilterChange(field, categoryName, selected && selected.value)}
         value={selectedFields ? selectedFields[field] : null}
       />
     ));

--- a/app/javascript/app/components/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways-table/emission-pathways-table-selectors.js
@@ -83,12 +83,24 @@ export const titleLinks = createSelector(
   }
 );
 
-const getSelectedFields = createSelector([getSearch], search => {
-  if (!search) return null;
-  const selectedFields = search;
-  delete selectedFields.search;
-  return selectedFields;
-});
+const getSelectedFields = createSelector(
+  [getSearch, getCategory],
+  (search, category) => {
+    if (!search) return null;
+    let selectedFields = search;
+    const selectedKeys = Object.keys(selectedFields).filter(k =>
+      k.startsWith(category)
+    );
+    selectedFields = pick(selectedFields, selectedKeys);
+
+    const fieldsWithoutPrefix = {};
+    Object.keys(selectedFields).forEach(k => {
+      const keyWithoutPrefix = k.replace(`${category}-`, '');
+      fieldsWithoutPrefix[keyWithoutPrefix] = selectedFields[k];
+    });
+    return fieldsWithoutPrefix;
+  }
+);
 
 export const getSelectedFieldOptions = createSelector(
   [getSelectedFields],

--- a/app/javascript/app/components/emission-pathways-table/emission-pathways-table.js
+++ b/app/javascript/app/components/emission-pathways-table/emission-pathways-table.js
@@ -39,8 +39,11 @@ class EmissionPathwaysTableComponent extends PureComponent {
     this.updateUrlParam({ name: 'search', value: query });
   };
 
-  handleFilterChange = (filterName, value) => {
-    this.updateUrlParam({ name: filterName, value });
+  handleFilterChange = (filterName, categoryName, value) => {
+    this.updateUrlParam({
+      name: `${categoryName.toLowerCase()}-${filterName}`,
+      value
+    });
   };
 
   updateUrlParam(param) {


### PR DESCRIPTION
We had conflicts when filtering the ESP table. e. g: When filtering categories in indicators table scenarios where filtered too by the same categories as they had also the categories field. 

- Add a category- prefix to the URL param: 'scenarios-categories' and filter only by the selected category field