### PR TITLE
Sort sectors alphabetically by title

### DIFF
--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -108,7 +108,7 @@ export const parsedCategoriesWithSectors = createSelector(
               definitions
             };
           }),
-        'title'
+        ['parent.name', 'title']
       );
       return {
         title: cat.name,

--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { deburrUpper } from 'app/utils';
 import uniq from 'lodash/uniq';
+import sortBy from 'lodash/sortBy';
 import snakeCase from 'lodash/snakeCase';
 
 const getCountries = state => state.countries;
@@ -78,35 +79,37 @@ export const parsedCategoriesWithSectors = createSelector(
   (categories, sectors, countries) => {
     if (!categories) return null;
     return categories.map(cat => {
-      const sectorsParsed =
+      const sectorsParsed = sortBy(
         cat.sectors &&
-        cat.sectors.length &&
-        cat.sectors.map(sec => {
-          const definitions = cat.indicators.map(ind => {
-            const descriptions = countries.map(loc => {
-              const value = ind.locations[loc]
-                ? ind.locations[loc].find(v => v.sector_id === sec)
-                : null;
+          cat.sectors.length &&
+          cat.sectors.map(sec => {
+            const definitions = cat.indicators.map(ind => {
+              const descriptions = countries.map(loc => {
+                const value = ind.locations[loc]
+                  ? ind.locations[loc].find(v => v.sector_id === sec)
+                  : null;
+                return {
+                  iso: loc,
+                  value: value ? value.value : '—'
+                };
+              });
               return {
-                iso: loc,
-                value: value ? value.value : '—'
+                title: ind.name,
+                slug: ind.slug,
+                descriptions
               };
             });
+            const parent =
+              sectors[sec].parent_id && sectors[sectors[sec].parent_id];
             return {
-              title: ind.name,
-              slug: ind.slug,
-              descriptions
+              title: sectors[sec].name,
+              slug: snakeCase(sectors[sec].name),
+              parent,
+              definitions
             };
-          });
-          const parent =
-            sectors[sec].parent_id && sectors[sectors[sec].parent_id];
-          return {
-            title: sectors[sec].name,
-            slug: snakeCase(sectors[sec].name),
-            parent,
-            definitions
-          };
-        });
+          }),
+        'title'
+      );
       return {
         title: cat.name,
         slug: cat.slug,

--- a/app/javascript/app/components/ndcs-table/ndcs-table-component.jsx
+++ b/app/javascript/app/components/ndcs-table/ndcs-table-component.jsx
@@ -74,7 +74,7 @@ NDCTable.propTypes = {
   selectedCategory: PropTypes.object,
   indicators: PropTypes.array.isRequired,
   selectedIndicator: PropTypes.object,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.array,
   handleCategoryChange: PropTypes.func.isRequired,
   handleIndicatorChange: PropTypes.func.isRequired,
   handleSearchChange: PropTypes.func.isRequired


### PR DESCRIPTION
A while back we removed the alphabetical sorting because they asked us to use the order used in their files. But now they changed a bit their ideas and they want that for the Sectoral Information the sectors be sorted alphabetically. But only in that component and for the sectors, the overarching categories and the indicators are to be in the current order.

![image](https://user-images.githubusercontent.com/9701591/34204767-38624ba2-e580-11e7-8c1a-1e9cc9bfae02.png)


