### PR TITLE
Don't include empty indicators in sectoral information

### DIFF
--- a/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -83,21 +83,29 @@ export const parsedCategoriesWithSectors = createSelector(
         cat.sectors &&
           cat.sectors.length &&
           cat.sectors.map(sec => {
-            const definitions = cat.indicators.map(ind => {
-              const descriptions = countries.map(loc => {
+            const definitions = [];
+            cat.indicators.forEach(ind => {
+              const descriptions = [];
+              let hasValue = false;
+              countries.forEach(loc => {
                 const value = ind.locations[loc]
                   ? ind.locations[loc].find(v => v.sector_id === sec)
                   : null;
-                return {
-                  iso: loc,
-                  value: value ? value.value : '—'
-                };
+                if (value && value.value) {
+                  hasValue = true;
+                  descriptions.push({
+                    iso: loc,
+                    value: value.value
+                  });
+                }
               });
-              return {
-                title: ind.name,
-                slug: ind.slug,
-                descriptions
-              };
+              if (hasValue) {
+                definitions.push({
+                  title: ind.name,
+                  slug: ind.slug,
+                  descriptions
+                });
+              }
             });
             const parent =
               sectors[sec].parent_id && sectors[sectors[sec].parent_id];


### PR DESCRIPTION
Remove the empty indicators from the sectoral information:

Before: 
![image](https://user-images.githubusercontent.com/10500650/34299981-49780f42-e726-11e7-834a-a8717c74cf8b.png)


After
![image](https://user-images.githubusercontent.com/10500650/34299976-3f59e800-e726-11e7-90c9-76ca66627857.png)
