### PR TITLE
Filter by model in esp table instead of model_abbreviation

### DIFF
--- a/app/javascript/app/components/emission-pathways-table/emission-pathways-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways-table/emission-pathways-table-component.jsx
@@ -48,7 +48,7 @@ class EmissionPathwaysTable extends PureComponent {
     return FILTERS_BY_CATEGORY[category].map(field => (
       <Dropdown
         key={field}
-        label={startCase(field === 'model_abbreviation' ? 'model' : field)}
+        label={startCase(field)}
         placeholder={`Filter by ${startCase(field)}`}
         options={filterOptions ? filterOptions[field] : []}
         onValueChange={selected =>

--- a/app/javascript/app/components/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways-table/emission-pathways-table-selectors.js
@@ -44,7 +44,7 @@ export const flattenedData = createSelector(
       const flattenedD = d;
       attributesWithObjects[category].forEach(a => {
         if (Object.prototype.hasOwnProperty.call(d, a)) {
-          flattenedD[a] = d[a] && d[a].name;
+          flattenedD[a] = d[a] && (d[a].name || d[a].full_name);
         }
       });
       return flattenedD;

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -125,7 +125,7 @@ export const ESP_BLACKLIST = {
 
 export const FILTERS_BY_CATEGORY = {
   models: ['license', 'time_horizon', 'time_step'],
-  scenarios: ['model_abbreviation'],
+  scenarios: ['model'],
   indicators: ['category']
 };
 


### PR DESCRIPTION
In the ESP table scenarios were filtered by model abbreviation. We changed the ESP endpoint to return model: {full_name: <FULL_NAME>, id: <ID>}
- FIlter scenarios by model name
![image](https://user-images.githubusercontent.com/9701591/34353965-6302398a-ea2b-11e7-9fd1-2df77400f135.png)
