### PR TITLE
Fix/correct gwp filtering

### DIFF
--- a/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -161,9 +161,12 @@ export const filterData = createSelector(
   [getData, getSourceSelected, getCalculationSelected, getFiltersSelected],
   (data, sourceSelected, calculation, filters) => {
     if (!data || !data.length) return [];
-    const filteredData = sortEmissionsByValue(
+    let filteredData = sortEmissionsByValue(
       data.filter(d => filters.map(f => f.label).indexOf(d.sector.trim()) >= 0)
     );
+    // If the data has the AR4 version (latest) we only want to display that data to avoid duplicates
+    const hasAR4 = filteredData.some(d => d.gwp === 'AR4');
+    if (hasAR4) filteredData = filteredData.filter(d => d.gwp === 'AR4');
     if (calculation.value !== 'ABSOLUTE_VALUE') {
       const dataGrouped = groupBy(
         flatten(filteredData.map(d => d.emissions)),

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -19,21 +19,6 @@ module HistoricalEmissions
       filters(records, params)
     end
 
-    def self.filter_gwp(params)
-      if params[:gwp]
-        where(gwp_id: params[:gwp])
-      else
-        ar4_id = HistoricalEmissions::Gwp.find_by(name: 'AR4').try(:id)
-        ar2_id = HistoricalEmissions::Gwp.find_by(name: 'AR2').try(:id)
-
-        if where(gwp_id: ar4_id).exists?
-          where(gwp_id: ar4_id)
-        else
-          where(gwp_id: ar2_id)
-        end
-      end
-    end
-
     private_class_method def self.filters(records, params)
       unless params[:location].blank?
         records = records.where(
@@ -49,7 +34,7 @@ module HistoricalEmissions
         records = records.where(k => {id: params[v].split(',')}) if params[v]
       end
 
-      records = records.filter_gwp(params)
+      records = records.where(gwp_id: params[:gwp]) if params[:gwp]
 
       records
     end

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -48,7 +48,7 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
       )
     }
 
-    it 'when filtering by location, source, and gas, return 1 record' do
+    it 'when filtering by location, source, and gas, return 2 records' do
       get(
         :index,
         params: {
@@ -59,8 +59,7 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
       )
       parsed_body = JSON.parse(response.body)
       expect(response).to be_success
-      expect(parsed_body.length).to eq(1)
-      expect(parsed_body.first['gwp']).to eq('AR4')
+      expect(parsed_body.length).to eq(2)
     end
 
     it 'returns results for the correct gwp' do


### PR DESCRIPTION
In Historical Ghg emissions graph, we were not able to choose between AR2 and AR4. This was happening because we were filtering it in the backend.

- Remove the filter in the backend
- Add a filter in the frontend for countries Ghg emissions

![image](https://user-images.githubusercontent.com/9701591/34354749-be115fae-ea30-11e7-89dd-d8c2c35361a1.png)
