### PR TITLE
Use parseFloat to allow float values in the tooltip

### DIFF
--- a/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -290,7 +290,7 @@ export const getChartData = createSelector([filterDataByIndicator], data => {
     const yValues = {};
     const groupedByScenario = groupBy(groupByYear[x], 'scenario_id');
     Object.keys(groupedByScenario).forEach(i => {
-      yValues[`y${i}`] = parseInt(groupedByScenario[i][0].value, 10);
+      yValues[`y${i}`] = parseFloat(groupedByScenario[i][0].value);
     });
     dataMapped.push({
       x,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/34572989-3cc58ad4-f173-11e7-8d18-9527d8127120.png)
Decimals are showing now in ESP graph