### PR TITLE
Include list of right to left countries to ndc full text

### DIFF
--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -13,6 +13,8 @@ import Button from 'components/button';
 import Loading from 'components/loading';
 import NdcTranslationDisclaimer from 'components/ndcs/ndc-translation-disclaimer';
 
+import { isR2LWrittedLanguage } from 'utils';
+
 import layout from 'styles/layout.scss';
 import contentStyles from 'styles/themes/content.scss';
 import styles from './ndc-country-full-styles.scss';
@@ -30,7 +32,11 @@ class NDCCountryFull extends PureComponent {
                 <NdcTranslationDisclaimer className={styles.disclaimer} />
               )}
               <div
-                className={cx(contentStyles.content, styles.innerContent)}
+                className={cx(contentStyles.content, {
+                  [styles.innerContentRtl]: isR2LWrittedLanguage(
+                    content.language
+                  )
+                })}
                 dangerouslySetInnerHTML={{ __html: content.html }} // eslint-disable-line
               />
             </div>
@@ -114,6 +120,10 @@ NDCCountryFull.propTypes = {
   fetchCountryNDCFull: PropTypes.func,
   iso: PropTypes.string,
   loading: PropTypes.bool
+};
+
+NDCCountryFull.defaultProps = {
+  content: {}
 };
 
 export default NDCCountryFull;

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -58,3 +58,7 @@
   right: 0;
   z-index: 1;
 }
+
+.innerContentRtl {
+  direction: rtl;
+}

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -35,6 +35,11 @@ export function compareIndexByKey(attribute) {
   };
 }
 
+const r2lWrittedLanguages = ['AR'];
+export function isR2LWrittedLanguage(lang) {
+  return r2lWrittedLanguages.indexOf(lang) > -1;
+}
+
 export default {
   compareIndexByKey,
   deburrUpper,


### PR DESCRIPTION
Include whitelist of countries where the text direction is from right to left to fix this https://basecamp.com/1756858/projects/13795275/todos/337534990:

![image](https://user-images.githubusercontent.com/10500650/34938104-5df7cce0-f9e7-11e7-9ab0-7a51fe40e670.png)
