### PR TITLE
Include dots in lines for ghg

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -13,6 +13,7 @@ import {
 import TooltipChart from 'components/charts/tooltip-chart';
 import { format } from 'd3-format';
 import debounce from 'lodash/debounce';
+import isUndefined from 'lodash/isUndefined';
 
 const CustomizedXAxisTick = ({ x, y, payload }) => (
   <g transform={`translate(${x},${y})`}>
@@ -92,15 +93,21 @@ class ChartLine extends PureComponent {
             )}
           />
           {config.columns &&
-            config.columns.y.map(column => (
-              <Line
-                key={column.value}
-                dataKey={column.value}
-                dot={false}
-                stroke={config.theme[column.value].stroke || ''}
-                strokeWidth={2}
-              />
-            ))}
+            config.columns.y.map(column => {
+              const color = config.theme[column.value].stroke || '';
+              return (
+                <Line
+                  key={column.value}
+                  isAnimationActive={
+                    isUndefined(config.animation) ? true : config.animation
+                  }
+                  dot={{ strokeWidth: 0, fill: color, radius: 0.5 }}
+                  dataKey={column.value}
+                  stroke={color}
+                  strokeWidth={2}
+                />
+              );
+            })}
         </LineChart>
       </ResponsiveContainer>
     );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -273,7 +273,7 @@ export const getChartData = createSelector(
       data.forEach(d => {
         const yKey = getYColumnValue(d[breakBy.value]);
         const yData = d.emissions.find(e => e.year === x);
-        yItems[yKey] = yData.value * DATA_SCALE;
+        yItems[yKey] = yData.value ? yData.value * DATA_SCALE : null;
       });
       const item = {
         x,
@@ -300,6 +300,7 @@ export const getChartConfig = createSelector(
       axes: DEFAULT_AXES_CONFIG,
       theme,
       tooltip,
+      animation: false,
       columns: {
         x: [{ label: 'year', value: 'x' }],
         y: yColumnsChecked


### PR DESCRIPTION
This PR includes dots on the ghg emissions graph to avoid this:
![image](https://user-images.githubusercontent.com/10500650/34949225-d0caf03a-fa0f-11e7-93d2-a10740075efa.png)

This is how it looks now:
![image](https://user-images.githubusercontent.com/10500650/34949241-dbc7600e-fa0f-11e7-95a6-acb986cf0f04.png)

Bonus: new `animation` props is available on the line.

The dots appear once the line animation finish and I disabled it to avoid an intermediate state when nothing appears.
