### PR TITLE
Fix broken routes file

### DIFF
--- a/app/javascript/app/routes.js
+++ b/app/javascript/app/routes.js
@@ -441,45 +441,23 @@ export default [
             ]
           },
           {
-            hash: 'ndc-sdg-linkages',
-            label: 'NDC-SDG Linkages',
-            anchor: true,
-            component: NDCSDGLinkages
-          }
-        ]
-      },
-      {
-        path: '/ghg-emissions',
-        component: GHGEmissions,
-        exact: true,
-        label: 'GHG EMISSIONS',
-        headerImage: 'emissions'
-      },
-      {
-        path: '/ndc-search',
-        exact: true,
-        component: NDCSearch,
-        headerImage: 'ndc'
-      },
-      {
-        path: '/stories',
-        component: error,
-        exact: true,
-        nav: false,
-        label: 'STORIES'
-      },
-      {
-        path: '/about',
-        component: About,
-        nav: true,
-        label: 'ABOUT',
-        headerImage: 'about',
-        routes: [
-          {
             path: '/ndc-search',
             exact: true,
             component: NDCSearch,
             headerImage: 'ndc'
+          },
+          {
+            hash: 'ndc-sdg-linkages',
+            label: 'NDC-SDG Linkages',
+            anchor: true,
+            component: NDCSDGLinkages
+          },
+          {
+            path: '/ghg-emissions',
+            component: GHGEmissions,
+            exact: true,
+            label: 'GHG EMISSIONS',
+            headerImage: 'emissions'
           },
           {
             path: '/stories',


### PR DESCRIPTION
This PR modifies routes file to recover about nav link and to allow navigation through home page search box (NDC's content search was broken)  
The Pivotal ticket could be found [here](https://www.pivotaltracker.com/story/show/154355781).