### PR TITLE
Fix/indicators in model and scenario pages

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import remove from 'lodash/remove';
 import pick from 'lodash/pick';
+import uniq from 'lodash/uniq';
 import { ESP_BLACKLIST } from 'data/constants';
 
 const getCategoryName = state =>
@@ -19,6 +20,9 @@ const getSelectedIds = createSelector(
   [getModelDataById, getCategoryName],
   (data, category) => {
     if (!data || !category) return null;
+    if (category === 'indicators') {
+      return uniq(data.indicator_ids) || null;
+    }
     return data[category].map(i => i.id) || null;
   }
 );

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
@@ -48,7 +48,7 @@ const getScenarioTrendData = createSelector(
 
 const getIndicatorIds = createSelector(getScenarioData, data => {
   if (!data) return null;
-  return data.indicators.map(i => i.id) || null;
+  return uniq(data.indicator_ids) || null;
 });
 
 const scenarioIndicatorsData = createSelector(
@@ -180,7 +180,7 @@ export const filterDataByBlackList = createSelector(
 );
 
 export const defaultColumns = () => [
-  'alias',
+  'name',
   'category',
   'subcategory',
   'trend'

--- a/app/javascript/app/pages/ndc-sdg/ndc-sdg-component.jsx
+++ b/app/javascript/app/pages/ndc-sdg/ndc-sdg-component.jsx
@@ -30,7 +30,8 @@ class NdcSdg extends PureComponent {
             <div className={headerTheme.headerGrid}>
               <Intro
                 title="NDC-SDG Linkages"
-                description="Identify potential alignment between the targets, actions, policies measures and needs in countries’ Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs)."
+                description={`Identify potential alignment between the targets, actions, policies measures and needs in countries
+                ’Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs).`}
               />
               <AutocompleteSearch />
             </div>


### PR DESCRIPTION
The backend changed the indicators relationship with the models and scenarios.
Now the indicators in those responses come as indicator_ids.

- Adapt selectors to new responses

Right now you can only try in staging => replace data for staging in the ESP_API in the .env

Extra:
- Change alias in indicators to name. As alias is empty now
- Fix line too long