### PR TITLE
Fix dropdown collapse after nav simple menu clicking

### DIFF
--- a/app/javascript/app/components/simple-menu/simple-menu-component.jsx
+++ b/app/javascript/app/components/simple-menu/simple-menu-component.jsx
@@ -73,6 +73,7 @@ class SimpleMenu extends PureComponent {
           className={styles.link}
           activeClassName={styles.active}
           to={option.path}
+          onClick={this.handleLinkClick}
         >
           {this.renderInsideLink(option)}
         </NavLink>


### PR DESCRIPTION
This PR adds a call to the function to handle click event inside an element of the ``<SimpleMenu />`` component. That way simple menu dropdown gets collapsed/closed when triggering the navigation to the desired path. 
