### PR TITLE
Fix/mutations in esp table

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -352,7 +352,7 @@ const addLinktoModelSelectedMetadata = createSelector(
     if (!model) return null;
     return {
       ...model,
-      Link: `/emissionpathways/models/${model.id}`
+      Link: `/emission-pathways/models/${model.id}`
     };
   }
 );
@@ -370,7 +370,7 @@ export const getScenariosSelectedMetadata = createSelector(
       scenariosMetadata.map(s => ({
         name: s.name,
         description: s.description,
-        Link: `/emissionpathways/scenarios/${s.id}`
+        Link: `/emission-pathways/scenarios/${s.id}`
       }))
     );
   }

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -43,32 +43,10 @@ export const getFullTextColumns = createSelector([getCategory], category => {
   }
 });
 
-export const flattenedData = createSelector(
-  [getData, getCategory],
-  (data, category) => {
-    if (!data || isEmpty(data)) return null;
-    const attributesWithObjects = {
-      models: [],
-      scenarios: ['model'],
-      indicators: ['model', 'category', 'subcategory']
-    };
-    const updatedData = data;
-    return updatedData.map(d => {
-      const flattenedD = d;
-      attributesWithObjects[category].forEach(a => {
-        if (Object.prototype.hasOwnProperty.call(d, a)) {
-          flattenedD[a] = d[a] && (d[a].name || d[a].full_name);
-        }
-      });
-      return flattenedD;
-    });
-  }
-);
-
 export const filteredDataBySearch = createSelector(
-  [flattenedData, getQuery],
+  [getData, getQuery],
   (data, query) => {
-    if (!data) return null;
+    if (!data || isEmpty(data)) return null;
     if (!query) return data;
     const updatedData = data;
     return updatedData.filter(d =>
@@ -135,14 +113,10 @@ export const filteredDataByFilters = createSelector(
     if (!data) return null;
     if (!filters) return data;
     let filteredData = data;
-    const availableSubcategories = [];
     Object.keys(filters).forEach(key => {
-      filteredData = filteredData.filter(d => {
-        if (key === 'category' && d[key] === filters[key]) {
-          availableSubcategories.push(d.subcategory);
-        }
-        return d[key] === undefined || d[key] === filters[key];
-      });
+      filteredData = filteredData.filter(
+        d => d[key] && (d[key] === filters[key] || d[key].name === filters[key])
+      );
     });
     return filteredData;
   }
@@ -155,8 +129,8 @@ export const getAvailableSubcategories = createSelector(
     if (!filters || !filters.category) return [];
     const availableSubcategories = [];
     data.forEach(d => {
-      if (d.category === filters.category) {
-        availableSubcategories.push(d.subcategory);
+      if (d.category.name === filters.category) {
+        availableSubcategories.push(d.subcategory.name);
       }
     });
     return uniq(availableSubcategories);

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -19,7 +19,8 @@ export const getDefaultColumns = createSelector([getCategory], category => {
         'full_name',
         'developed_by',
         'geographic_coverage',
-        'time_horizon'
+        'time_horizon',
+        'url'
       ];
     case 'scenarios':
       return ['model', 'name', 'geographic_coverage_country'];
@@ -190,7 +191,7 @@ export const renameDataColumns = createSelector(
         changes.forEach(change => {
           if (d[change.old]) {
             updatedD[change.new] = d[change.old];
-            delete updatedD[change.new];
+            delete updatedD[change.old];
           }
         });
         return updatedD;

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -5,6 +5,7 @@ import MultiSelect from 'components/multiselect';
 import cx from 'classnames';
 import { LineChart, Line } from 'recharts';
 import isArray from 'lodash/isArray';
+import isString from 'lodash/isString';
 
 import lowerCase from 'lodash/lowerCase';
 import 'react-virtualized/styles.css'; // only needs to be imported once
@@ -91,6 +92,9 @@ class SimpleTable extends PureComponent {
                     const { rowIndex, dataKey } = cell;
                     if (isArray(cellData)) {
                       cellData = cellData.join(', ');
+                    }
+                    if (cellData && !isString(cellData)) {
+                      cellData = cellData.name || cellData.full_name || '';
                     }
                     const titleLink = titleLinks && titleLinks[rowIndex];
                     if (trendLine && dataKey === trendLine) {


### PR DESCRIPTION
This PR fixes some crashes, wrong links and data disappearing in the ESP main page:
In ESP table Models in scenarios and Categories and subcategories in indicators were disappearing when the menu table was changed. Also, the graph was crashing sometimes due to a change in subcategories structure.

- Don't flatten objects {name: 'category name', id: 92} to 'category name' in the selector but pick the name in the table as is the presenter of the data
- Fix rename of developed_by attribute in models
- Fix links to model and scenario pages in info modal