### PR TITLE
Fix/url link in esp table

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
@@ -85,10 +85,12 @@ export const titleLinks = createSelector(
   [getFilteredData, getCategoryName],
   (data, category) => {
     if (!data || isEmpty(data) || category === 'indicators') return null;
-    return data.map(d => ({
-      fieldName: 'name',
-      url: `/emission-pathways/scenarios/${d.id}`
-    }));
+    return data.map(d => [
+      {
+        columnName: 'name',
+        url: `/emission-pathways/scenarios/${d.id}`
+      }
+    ]);
   }
 );
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -65,15 +65,21 @@ export const titleLinks = createSelector(
   [getCategory, getData],
   (categoryName, data) => {
     if (!data || isEmpty(data) || !categoryName) return null;
-    const categoryId = {
-      models: 'full_name',
-      scenarios: 'name'
+    const linkInfo = {
+      models: [
+        { columnName: 'full_name', linkToId: true },
+        { columnName: 'url' }
+      ],
+      scenarios: [{ columnName: 'name', linkToId: true }],
+      indicators: []
     };
     const updatedData = data;
-    return updatedData.map(d => ({
-      fieldName: categoryId[categoryName],
-      url: `${categoryName}/${d.id}`
-    }));
+    return updatedData.map(d =>
+      linkInfo[categoryName].map(l => ({
+        columnName: l.columnName,
+        url: l.linkToId ? `${categoryName}/${d.id}` : 'self'
+      }))
+    );
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
@@ -109,10 +109,12 @@ export const getFilteredData = createSelector(
 
 export const getTitleLinks = createSelector([getFilteredData], data => {
   if (!data || isEmpty(data)) return null;
-  return data.map(d => ({
-    fieldName: 'country',
-    url: `country/${d.iso}`
-  }));
+  return data.map(d => [
+    {
+      columnName: 'country',
+      url: `country/${d.iso}`
+    }
+  ]);
 });
 
 export const removeIsoFromData = createSelector([getFilteredData], data => {

--- a/app/javascript/app/components/table/cell-renderer-component.jsx
+++ b/app/javascript/app/components/table/cell-renderer-component.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { LineChart, Line } from 'recharts';
+import isArray from 'lodash/isArray';
+import isString from 'lodash/isString';
+
+import 'react-virtualized/styles.css'; // only needs to be imported once
+import { NavLink } from 'react-router-dom';
+
+const renderTrendLine = chartData => {
+  const dataValues =
+    chartData && chartData.split(',').map(v => ({ value: parseFloat(v) }));
+  return (
+    <LineChart width={70} height={35} data={dataValues}>
+      <Line dot={false} dataKey="value" stroke="#113750" strokeWidth={2} />
+    </LineChart>
+  );
+};
+
+const sanitizeCellData = cellData => {
+  if (isArray(cellData)) {
+    return cellData.join(', ');
+  }
+  if (cellData && !isString(cellData)) {
+    return cellData.name || cellData.full_name || '';
+  }
+  return cellData;
+};
+
+const cellRenderer = ({
+  props: { parseHtml, titleLinks, trendLine },
+  cell
+}) => {
+  let { cellData } = cell;
+  const { rowIndex, dataKey } = cell;
+  cellData = sanitizeCellData(cellData);
+  // check for Trendline
+  if (trendLine && dataKey === trendLine) {
+    return renderTrendLine(cellData);
+  }
+  // check for TitleLink
+  const titleLink =
+    titleLinks &&
+    titleLinks[rowIndex] &&
+    titleLinks[rowIndex].find(t => t.columnName === dataKey);
+  if (titleLink) {
+    return titleLink.url === 'self' ? (
+      <a target="_blank" href={cellData}>
+        {cellData}
+      </a>
+    ) : (
+      <NavLink to={titleLink.url}>{cellData}</NavLink>
+    );
+  }
+  // render Html or finally cellData
+  return parseHtml ? (
+    <div dangerouslySetInnerHTML={{ __html: cellData }} />
+  ) : (
+    cellData || ''
+  );
+};
+
+cellRenderer.propTypes = {
+  cell: PropTypes.object.isRequired,
+  props: PropTypes.shape({
+    titleLinks: PropTypes.array, // [ [ {columnName: 'title field name in the table', url:'/destination-url' or 'self'}, ... ] ]
+    trendLine: PropTypes.string, // 'field name of the trend line column'
+    parseHtml: PropTypes.bool
+  })
+};
+
+export default cellRenderer;

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -96,12 +96,21 @@ class SimpleTable extends PureComponent {
                     if (cellData && !isString(cellData)) {
                       cellData = cellData.name || cellData.full_name || '';
                     }
-                    const titleLink = titleLinks && titleLinks[rowIndex];
                     if (trendLine && dataKey === trendLine) {
                       return renderTrendLine(cellData);
                     }
-                    if (titleLink && dataKey === titleLink.fieldName) {
-                      return <NavLink to={titleLink.url}>{cellData}</NavLink>;
+                    const titleLink =
+                      titleLinks &&
+                      titleLinks[rowIndex] &&
+                      titleLinks[rowIndex].find(t => t.columnName === dataKey);
+                    if (titleLink) {
+                      return titleLink.url === 'self' ? (
+                        <a target="_blank" href={cellData}>
+                          {cellData}
+                        </a>
+                      ) : (
+                        <NavLink to={titleLink.url}>{cellData}</NavLink>
+                      );
                     }
                     return parseHtml ? (
                       <div dangerouslySetInnerHTML={{ __html: cellData }} />
@@ -130,7 +139,7 @@ SimpleTable.propTypes = {
   sortBy: PropTypes.string.isRequired,
   sortDirection: PropTypes.string.isRequired,
   handleSortChange: PropTypes.func.isRequired,
-  titleLinks: PropTypes.array, // {fieldName: 'title field name in the table', url:'/destination-url-for-the-link'}
+  titleLinks: PropTypes.array, // [ [ {columnName: 'title field name in the table', url:'/destination-url' or 'self'}, ... ] ]
   trendLine: PropTypes.string, // 'field name of the trend line column'
   fullTextColumns: PropTypes.array, // 'Columns with full text, no ellipsis'
   parseHtml: PropTypes.bool


### PR DESCRIPTION
The URL attribute in the ESP main table (section models) needed a hyperlink. I needed to change the structure of the titleLinks prop.
It was:
```
[ {fieldName: 'model', url: 'model/82' }, ... ]
```
and now it is:
```
[
  [ { columnName: 'model', url: 'model/82' },
   { columnName: 'url', url: 'self' } (url === 'self' uses an external link to the cell data)
 ]
  , ...
]
```

Also, some big refactor and extraction of the cell renderer of the table was done

![image](https://user-images.githubusercontent.com/9701591/35149907-38843ec4-fd18-11e7-8e92-88bb10ad9218.png)
