### PR TITLE
Fetch available models and show them

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import EspLocationsProvider from 'providers/esp-locations-provider';
+import EspModelsProvider from 'providers/esp-models-provider';
+import EspScenariosProvider from 'providers/esp-scenarios-provider';
 import EspIndicatorsProvider from 'providers/esp-indicators-provider';
 import EspTimeSeriesProvider from 'providers/esp-time-series-provider';
 import ButtonGroup from 'components/button-group';
@@ -35,6 +37,8 @@ class EmissionPathwayGraph extends PureComponent {
     return (
       <div className={styles.wrapper}>
         <div className={layout.content}>
+          <EspModelsProvider />
+          <EspScenariosProvider />
           <EspIndicatorsProvider />
           <EspLocationsProvider withTimeSeries />
           {needsTimeSeries && (
@@ -43,7 +47,7 @@ class EmissionPathwayGraph extends PureComponent {
               model={filtersSelected.model.value}
             />
           )}
-          <div className={styles.col4}>
+          <div className={styles.col5}>
             <h2 className={styles.title}>Emission Pathways</h2>
             <ButtonGroup
               className={styles.colEnd}
@@ -52,7 +56,7 @@ class EmissionPathwayGraph extends PureComponent {
               analyticsGraphName="Emission pathway"
             />
           </div>
-          <div className={styles.col4}>
+          <div className={styles.col5}>
             <Dropdown
               label="Country/Region"
               options={filtersOptions.locations}
@@ -65,6 +69,7 @@ class EmissionPathwayGraph extends PureComponent {
               label="Model"
               options={filtersOptions.models}
               onValueChange={handleModelChange}
+              disabled={filtersLoading.location}
               value={filtersSelected.model}
               hideResetButton
             />

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -67,7 +67,7 @@ export const getLocationsOptions = createSelector([getLocations], locations => {
   }));
 });
 
-export const getLocationSelected = createSelector(
+const getLocationSelected = createSelector(
   [getLocationsOptions, getLocation],
   (locations, locationSelected) => {
     if (!locations) return null;
@@ -79,14 +79,36 @@ export const getLocationSelected = createSelector(
   }
 );
 
-export const getModelsOptions = createSelector([getModels], models => {
-  if (!models || !models.length) return [];
-  return models.map(m => ({
-    label: m.abbreviation,
-    value: m.id,
-    scenarios: m.scenario_ids
-  }));
-});
+const getavailableModels = createSelector(
+  [state => state.availableModels, getLocationSelected],
+  (availableModels, location) => {
+    if (isEmpty(availableModels) || !location) return null;
+    return availableModels[location.value];
+  }
+);
+
+export const getModelsOptions = createSelector(
+  [getModels, getavailableModels],
+  (models, availableModels) => {
+    if (
+      !models ||
+      !models.length ||
+      !availableModels ||
+      isEmpty(availableModels)
+    ) { return []; }
+    const modelOptions = [];
+    models.forEach(m => {
+      if (availableModels.indexOf(m.id) > -1) {
+        modelOptions.push({
+          label: m.abbreviation,
+          value: m.id,
+          scenarios: m.scenario_ids
+        });
+      }
+    });
+    return modelOptions;
+  }
+);
 
 export const getModelSelected = createSelector(
   [getModelsOptions, getModel],

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -79,7 +79,7 @@ const getLocationSelected = createSelector(
   }
 );
 
-const getavailableModels = createSelector(
+const getAvailableModels = createSelector(
   [state => state.availableModels, getLocationSelected],
   (availableModels, location) => {
     if (isEmpty(availableModels) || !location) return null;
@@ -88,14 +88,16 @@ const getavailableModels = createSelector(
 );
 
 export const getModelsOptions = createSelector(
-  [getModels, getavailableModels],
+  [getModels, getAvailableModels],
   (models, availableModels) => {
     if (
       !models ||
       !models.length ||
       !availableModels ||
       isEmpty(availableModels)
-    ) { return []; }
+    ) {
+      return [];
+    }
     const modelOptions = [];
     models.forEach(m => {
       if (availableModels.indexOf(m.id) > -1) {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-styles.scss
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-styles.scss
@@ -8,7 +8,7 @@ $min-height: 450px;
   padding-bottom: 50px;
 }
 
-.col4 {
+.col5 {
   @extend %grid;
 
   @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr);
@@ -26,8 +26,9 @@ $min-height: 450px;
   font-size: $font-size-large;
   font-weight: $font-weight;
   color: $theme-color;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   padding-top: 35px;
+  grid-column: 1/5;
 }
 
 .chartWrapper {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -38,6 +38,7 @@ const mapStateToProps = (state, { location }) => {
     scenarios: state.espScenarios.data,
     indicators: state.espIndicators.data,
     location: currentLocation,
+    availableModels: state.espGraph.locations,
     model,
     indicator,
     scenario,
@@ -66,6 +67,15 @@ const mapStateToProps = (state, { location }) => {
 };
 
 class EmissionPathwayGraphContainer extends PureComponent {
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.filtersSelected.location !== this.props.filtersSelected.location
+    ) {
+      const currentLocation = this.props.filtersSelected.location;
+      this.props.findAvailableModels(currentLocation.value);
+    }
+  }
+
   handleModelChange = model => {
     const { location } = this.props.filtersSelected;
     const params = [
@@ -115,7 +125,8 @@ EmissionPathwayGraphContainer.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   filtersSelected: PropTypes.object.isRequired,
-  toggleModalOverview: PropTypes.func.isRequired
+  toggleModalOverview: PropTypes.func.isRequired,
+  findAvailableModels: PropTypes.func.isRequired
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -62,11 +62,19 @@ const mapStateToProps = (state, { location }) => {
       state.espLocations.loading ||
       state.espModels.loading ||
       state.espScenarios.loading ||
-      state.espIndicators.loading
+      state.espIndicators.loading ||
+      state.espGraph.loading
   };
 };
 
 class EmissionPathwayGraphContainer extends PureComponent {
+  componentDidMount() {
+    const { location } = this.props.filtersSelected;
+    if (location) {
+      this.props.findAvailableModels(location);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if (
       prevProps.filtersSelected.location !== this.props.filtersSelected.location

--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -5,6 +5,7 @@ import NDCMap from 'components/ndcs/ndcs-map';
 import GhgEmissionsGraph from 'components/ghg-emissions';
 import GHGCountryEmissions from 'components/country/country-ghg';
 import NdcSdgLinkagesContent from 'components/ndc-sdg/ndc-sdg-linkages-content';
+import EmissionPathwaysGraph from 'components/emission-pathways/emission-pathways-graph';
 
 export default [
   {
@@ -25,6 +26,11 @@ export default [
   {
     path: '/embed/ndcs-sdg',
     component: NdcSdgLinkagesContent,
+    exact: true
+  },
+  {
+    path: '/embed/emission-pathways',
+    component: EmissionPathwaysGraph,
     exact: true
   },
   {


### PR DESCRIPTION
We were offering all the models to select before. Now only the models who have timeseries for that locations are displayed.
The actions and reducers of espGraph were already there from a previous commit.

![image](https://user-images.githubusercontent.com/9701591/35153388-a5aec538-fd26-11e7-9271-1d39c89d1b4e.png)
