### PR TITLE
Fix/esp graph comments

### DIFF
--- a/app/javascript/app/components/charts/chart/chart-component.jsx
+++ b/app/javascript/app/components/charts/chart/chart-component.jsx
@@ -8,7 +8,8 @@ import NoContent from 'components/no-content';
 
 import styles from './chart-styles.scss';
 
-class Chart extends PureComponent { // eslint-disable-line react/prefer-stateless-function
+class Chart extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
   render() {
     const {
       className,
@@ -19,34 +20,29 @@ class Chart extends PureComponent { // eslint-disable-line react/prefer-stateles
       data,
       config,
       height,
-      targetParam
+      targetParam,
+      customMessage
     } = this.props;
     const ChartComponent = type === 'line' ? LineChart : ChartStackedArea;
+    let message = 'No data available';
+    const noData = !data || !data.length;
+    if (customMessage) message = customMessage;
+    else if (!dataSelected || !dataSelected.length) { message = 'No data selected'; }
     return (
       <div className={className}>
         {loading && <Loading light className={styles.loader} />}
-        {!loading &&
-          (!data || !data.length) && (
-            <NoContent
-              message={
-                dataSelected && dataSelected.length ? (
-                  'No data available'
-                ) : (
-                  'No data selected'
-                )
-              }
-              className={styles.noContent}
-              minHeight={height}
-              icon
-            />
-          )
-        }
-        {!loading && data && data.length > 0 && config &&
-          <ChartComponent
-            {...this.props}
+        {!loading && noData && (
+          <NoContent
+            message={message}
+            className={styles.noContent}
+            minHeight={height}
+            icon
           />
-        }
-        {!loading && dataOptions &&
+        )}
+        {!loading &&
+        noData &&
+        config && <ChartComponent {...this.props} />}
+        {!loading && dataOptions && (
           <LegendChart
             className={styles.legend}
             config={config}
@@ -54,7 +50,7 @@ class Chart extends PureComponent { // eslint-disable-line react/prefer-stateles
             dataSelected={dataSelected}
             targetParam={targetParam}
           />
-        }
+        )}
       </div>
     );
   }
@@ -68,11 +64,9 @@ Chart.propTypes = {
   dataSelected: PropTypes.array,
   data: PropTypes.array,
   config: PropTypes.object,
-  height: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ]),
-  targetParam: PropTypes.string
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  targetParam: PropTypes.string,
+  customMessage: PropTypes.string
 };
 
 Chart.defaultProps = {

--- a/app/javascript/app/components/charts/chart/chart-component.jsx
+++ b/app/javascript/app/components/charts/chart/chart-component.jsx
@@ -25,15 +25,15 @@ class Chart extends PureComponent {
     } = this.props;
     const ChartComponent = type === 'line' ? LineChart : ChartStackedArea;
     let message = 'No data available';
-    const noData = !data || !data.length;
+    const hasData = data && data.length > 0;
     if (customMessage) message = customMessage;
-    else if (!dataSelected || !dataSelected.length) {
+    else if (!dataSelected || !dataSelected.length > 0) {
       message = 'No data selected';
     }
     return (
       <div className={className}>
         {loading && <Loading light className={styles.loader} />}
-        {!loading && noData && (
+        {!loading && !hasData && (
           <NoContent
             message={message}
             className={styles.noContent}
@@ -41,7 +41,7 @@ class Chart extends PureComponent {
             icon
           />
         )}
-        {!loading && noData && config && <ChartComponent {...this.props} />}
+        {!loading && hasData && config && <ChartComponent {...this.props} />}
         {!loading && dataOptions && (
           <LegendChart
             className={styles.legend}

--- a/app/javascript/app/components/charts/chart/chart-component.jsx
+++ b/app/javascript/app/components/charts/chart/chart-component.jsx
@@ -27,7 +27,9 @@ class Chart extends PureComponent {
     let message = 'No data available';
     const noData = !data || !data.length;
     if (customMessage) message = customMessage;
-    else if (!dataSelected || !dataSelected.length) { message = 'No data selected'; }
+    else if (!dataSelected || !dataSelected.length) {
+      message = 'No data selected';
+    }
     return (
       <div className={className}>
         {loading && <Loading light className={styles.loader} />}
@@ -39,9 +41,7 @@ class Chart extends PureComponent {
             icon
           />
         )}
-        {!loading &&
-        noData &&
-        config && <ChartComponent {...this.props} />}
+        {!loading && noData && config && <ChartComponent {...this.props} />}
         {!loading && dataOptions && (
           <LegendChart
             className={styles.legend}

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -10,13 +10,13 @@ class TooltipChart extends PureComponent {
     return this.props.forceTwoDecimals ? '.2f' : '.2s';
   }
 
-  getTotal = (keys, data) => {
+  getTotal = (keys, data, unitIsCo2) => {
     if (!keys || !data) return '';
     let total = 0;
     keys.forEach(key => {
       if (data.payload[key.value]) total += data.payload[key.value];
     });
-    return `${format(this.getFormat())(total)}t`;
+    return `${format(this.getFormat())(total)}${unitIsCo2 ? 't' : ''}`;
   };
 
   render() {
@@ -24,7 +24,7 @@ class TooltipChart extends PureComponent {
 
     const unit =
       config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
-
+    const unitIsCo2 = unit === 'CO<sub>2</sub>e';
     return (
       <div className={styles.tooltip}>
         <div className={styles.tooltipHeader}>
@@ -39,7 +39,9 @@ class TooltipChart extends PureComponent {
         {showTotal && (
           <div className={cx(styles.label, styles.labelTotal)}>
             <p>TOTAL</p>
-            <p>{this.getTotal(config.columns.y, content.payload[0])}</p>
+            <p>
+              {this.getTotal(config.columns.y, content.payload[0], unitIsCo2)}
+            </p>
           </div>
         )}
         {content &&
@@ -65,7 +67,9 @@ class TooltipChart extends PureComponent {
                   </div>
                   <p className={styles.labelValue}>
                     {y.payload ? (
-                      `${format(this.getFormat())(y.payload[y.dataKey])}t`
+                      `${format(this.getFormat())(
+                        y.payload[y.dataKey]
+                      )}${unitIsCo2 ? 't' : ''}`
                     ) : (
                       ''
                     )}

--- a/app/javascript/app/components/dropdown/dropdown-component.jsx
+++ b/app/javascript/app/components/dropdown/dropdown-component.jsx
@@ -37,7 +37,11 @@ class Dropdown extends PureComponent {
             ref={el => {
               this.selectorElement = el;
             }}
-            className={cx(this.props.className, this.props.disabled)}
+            className={cx(
+              this.props.className,
+              this.props.disabled,
+              styles.noScrollParent
+            )}
             renderToggleButton={() => <Icon icon={arrow} />}
             {...this.props}
           />

--- a/app/javascript/app/components/dropdown/dropdown-styles.scss
+++ b/app/javascript/app/components/dropdown/dropdown-styles.scss
@@ -11,3 +11,7 @@
   color: $theme-color;
   margin-bottom: 4px;
 }
+
+.noScrollParent {
+  overscroll-behavior: contain; /* stylelint-disable-line property-no-unknown */
+}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -57,7 +57,7 @@ class EmissionPathwayGraph extends PureComponent {
               label="Country/Region"
               options={filtersOptions.locations}
               onValueChange={option =>
-                handleSelectorChange(option, 'currentLocation', true)}
+                handleSelectorChange(option, 'currentLocation')}
               value={filtersSelected.location}
               hideResetButton
             />
@@ -105,6 +105,7 @@ class EmissionPathwayGraph extends PureComponent {
             data={data}
             dataOptions={filtersOptions.scenarios}
             dataSelected={filtersSelected.scenarios}
+            customMessage={'No data available for that indicator'}
             height={500}
             loading={loading}
             targetParam="scenario"

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
+import uniq from 'lodash/uniq';
 import groupBy from 'lodash/groupBy';
 import remove from 'lodash/remove';
 import pick from 'lodash/pick';
@@ -149,10 +150,9 @@ const getIndicatorsWithData = createSelector(
     if (!data || !indicators || !indicators.length || !modelSelected) {
       return null;
     }
-    const indicatorsWithData = data.map(d => d.indicator_id);
-    return uniqBy(
-      indicators.filter(i => i.name && indicatorsWithData.indexOf(i.id) > -1),
-      'name'
+    const indicatorsWithData = uniq(data.map(d => d.indicator_id));
+    return indicators.filter(
+      i => i.name && indicatorsWithData.indexOf(i.id) > -1
     );
   }
 );

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -230,7 +230,7 @@ export const getIndicatorSelected = createSelector(
   (indicators, indicatorSelected) => {
     if (!indicators) return null;
     if (!indicatorSelected) {
-      const defaultIndicator = indicators.find(i => i.label === 'Heat');
+      const defaultIndicator = indicators.find(i => i.label === 'CO');
       return defaultIndicator || indicators[0];
     }
     return indicators.find(i => indicatorSelected === i.value);


### PR DESCRIPTION
These are some necessary and requested fixes for the ESP graph:

https://basecamp.com/1756858/projects/13795275/todos/335337561
- Don't automatically select the first indicator available. Instead, show a 'No data available for that indicator' if the user changed the location and that indicator is not available.

https://basecamp.com/1756858/projects/13795275/todos/335318464
- Add a suffix 't' to the data on the tooltip only if the unit is CO2
- Change default indicator to CO2

https://basecamp.com/1756858/projects/12901811/todos/339051146#comment_592478153
- Not all indicators were being displayed. There was a unique by name filter in one selector. Now all the indicators with data are being displayed.

Extra:
- Stop scrolling of parent elements if child element has finished scrolling