### PR TITLE
Fix x axis scale

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -74,6 +74,7 @@ class ChartLine extends PureComponent {
         >
           <XAxis
             dataKey="x"
+            scale="linear"
             tick={<CustomizedXAxisTick />}
             padding={{ left: 15, right: 20 }}
             tickSize={8}


### PR DESCRIPTION
In ESP graph X axis was not showing a correct scale when some years were missing. Now is linear:
![image](https://user-images.githubusercontent.com/9701591/35236226-da4908da-ffa6-11e7-847d-ad4a735fa951.png)
