### PR TITLE
Feature/stories images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'aws-sdk', '~> 2'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'oj'
 gem 'scenic'
-gem 'simple-rss'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'aws-sdk', '~> 2'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'oj'
 gem 'scenic'
+gem 'simple-rss'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,6 @@ GEM
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-    simple-rss (1.3.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -291,7 +290,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scenic
   selenium-webdriver
-  simple-rss
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    simple-rss (1.3.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -290,6 +291,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scenic
   selenium-webdriver
+  simple-rss
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -305,4 +307,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/javascript/app/components/stories/stories-actions.js
+++ b/app/javascript/app/components/stories/stories-actions.js
@@ -1,64 +1,24 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 
-import image1 from 'assets/news/1.png';
-import image2 from 'assets/news/2.png';
-import image3 from 'assets/news/3.jpg';
-import image4 from 'assets/news/4.jpg';
-// import image5 from 'assets/news/5.jpg';
-import image6 from 'assets/news/6.jpg';
-
 const fetchStoriesInit = createAction('fetchStoriesInit');
 const fetchStoriesReady = createAction('fetchStoriesReady');
 const fetchStoriesFail = createAction('fetchStoriesFail');
 
-const stories = [
-  {
-    id: 1,
-    title: 'Got Climate Questions? Climate Watch Has Answers',
-    image: image6,
-    link:
-      '//www.wri.org/blog/2017/11/got-climate-questions-climate-watch-has-answers'
-  },
-  {
-    id: 2,
-    title:
-      'This Interactive Chart Explains World’s Top 10 Emitters, and How They’ve Changed',
-    image: image2,
-    link:
-      '//www.wri.org/blog/2017/04/interactive-chart-explains-worlds-top-10-emitters-and-how-theyve-changed'
-  },
-  {
-    id: 3,
-    title:
-      'RELEASE: Climate Watch: Powerful New Platform Offers Comprehensive Data for Climate Action',
-    image: image1,
-    link:
-      '//www.wri.org/news/2017/11/release-climate-watch-powerful-new-platform-offers-comprehensive-data-climate-action'
-  },
-  {
-    id: 4,
-    title:
-      '6 Things You Never Knew About Indonesia’s Emissions and Local Climate Action',
-    image: image3,
-    link:
-      '//www.wri.org/blog/2016/06/6-things-you-never-knew-about-indonesias-emissions-and-local-climate-action'
-  },
-  {
-    id: 5,
-    title:
-      '3 New Ways to Explore Links Between Climate and Sustainable Development',
-    image: image4,
-    link:
-      '//www.wri.org/blog/2017/12/3-new-ways-explore-links-between-climate-and-sustainable-development'
-  }
-];
-
 const fetchStories = createThunkAction('fetchStories', () => dispatch => {
   dispatch(fetchStoriesInit());
-  setTimeout(() => {
-    dispatch(fetchStoriesReady(stories));
-  }, 400);
+  fetch('/api/v1/stories')
+    .then(response => {
+      if (response.ok) return response.json();
+      throw Error(response.statusText);
+    })
+    .then(data => {
+      dispatch(fetchStoriesReady(data));
+    })
+    .catch(error => {
+      console.info(error);
+      dispatch(fetchStoriesFail());
+    });
 });
 
 export default {

--- a/app/javascript/app/components/stories/stories-component.jsx
+++ b/app/javascript/app/components/stories/stories-component.jsx
@@ -13,9 +13,9 @@ class Stories extends PureComponent {
         <div className={styles.grid}>
           {stories.map(story => (
             <a
-              key={story.id}
+              key={story.link}
               className={styles.story}
-              style={{ backgroundImage: `url(${story.image})` }}
+              style={{ backgroundImage: `url(${story.background_image_url})` }}
               href={story.link}
               target="_blank"
               rel="noopener noreferrer"

--- a/app/serializers/api/v1/story_serializer.rb
+++ b/app/serializers/api/v1/story_serializer.rb
@@ -4,7 +4,6 @@ module Api
       attribute :title
       attribute :link
       attribute :background_image_url
-      attribute :image
       attribute :tags
       attribute :published_at
     end

--- a/app/serializers/api/v1/story_serializer.rb
+++ b/app/serializers/api/v1/story_serializer.rb
@@ -4,6 +4,8 @@ module Api
       attribute :title
       attribute :link
       attribute :background_image_url
+      attribute :image
+      attribute :tags
       attribute :published_at
     end
   end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -1,6 +1,5 @@
 class ImportStories
   require 'rss'
-  require 'simple-rss'
   require 'open-uri'
 
   def call(reset = false)
@@ -24,7 +23,6 @@ class ImportStories
     url = 'http://www.wri.org/blog/rss2.xml'
     rss = open(url)
     feed = RSS::Parser.parse(rss, false)
-    #feed = SimpleRSS.parse rss
     puts "Channel Title: #{feed.channel.title}"
     feed.items.each do |item|
       title = item.title
@@ -33,7 +31,7 @@ class ImportStories
                                           published_at: published_at)
       story.description = item.description
       story.link = item.link
-      story.image = item.enclosure
+      story.background_image_url = item.enclosure ? item.enclosure.url : ''
       story.tags = item.category ? item.category.content : ''
       story.save
     end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -15,6 +15,10 @@ class ImportStories
     Story.delete_all
   end
 
+  def tags()
+
+  end
+
   def import_stories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'
@@ -27,12 +31,10 @@ class ImportStories
       published_at = item.pubDate
       story = Story.find_or_initialize_by(title: title,
                                           published_at: published_at)
-
       story.description = item.description
-      debugger
       story.link = item.link
       story.image = item.enclosure
-      story.tags = item.category.split(",")
+      story.tags = item.category ? item.category.content : ''
       story.save
     end
     puts "#{Story.count - existing} new stories"

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -22,16 +22,16 @@ class ImportStories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'
     rss = open(url)
-    feed = RSS::Parser.parse(rss, false)
+    feed = RSS::Parser.parse(rss)
     link_sanitizer = Rails::Html::LinkSanitizer.new
     puts "Channel Title: #{feed.channel.title}"
     feed.items.each do |item|
       title = link_sanitizer.sanitize(item.title)
       published_at = item.pubDate
-      story = Story.find_or_initialize_by(id: id,
+      story = Story.find_or_initialize_by(title: title,
                                           published_at: published_at)
       story.description = item.description
-      story.link = item.link.split(/href="|">/)[1]
+      story.link = "http://www.wri.org#{item.link.split(/href="|">/)[1]}"
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
       story.tags = item.category ? item.category.content : ''
       story.save

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -16,9 +16,9 @@ class ImportStories
 
   def import_stories
     existing = Story.count
-    url = 'http://feeds.feedburner.com/WRI_News_and_Views.rss'
+    url = 'http://www.wri.org/blog/rss2.xml'
     rss = open(url)
-    feed = RSS::Parser.parse(rss)
+    feed = RSS::Parser.parse(rss, false)
     puts "Channel Title: #{feed.channel.title}"
     feed.items.each do |item|
       title = item.title
@@ -28,6 +28,7 @@ class ImportStories
 
       story.description = item.description
       story.link = item.link
+      debugger
       story.image = item.enclosure
       story.tags = item.category
       story.save

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -1,5 +1,6 @@
 class ImportStories
   require 'rss'
+  require 'simple-rss'
   require 'open-uri'
 
   def call(reset = false)
@@ -19,6 +20,7 @@ class ImportStories
     url = 'http://www.wri.org/blog/rss2.xml'
     rss = open(url)
     feed = RSS::Parser.parse(rss, false)
+    #feed = SimpleRSS.parse rss
     puts "Channel Title: #{feed.channel.title}"
     feed.items.each do |item|
       title = item.title
@@ -27,10 +29,10 @@ class ImportStories
                                           published_at: published_at)
 
       story.description = item.description
-      story.link = item.link
       debugger
+      story.link = item.link
       story.image = item.enclosure
-      story.tags = item.category
+      story.tags = item.category.split(",")
       story.save
     end
     puts "#{Story.count - existing} new stories"

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -14,10 +14,6 @@ class ImportStories
     Story.delete_all
   end
 
-  def tags()
-
-  end
-
   def import_stories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -23,14 +23,15 @@ class ImportStories
     url = 'http://www.wri.org/blog/rss2.xml'
     rss = open(url)
     feed = RSS::Parser.parse(rss, false)
+    link_sanitizer = Rails::Html::LinkSanitizer.new
     puts "Channel Title: #{feed.channel.title}"
     feed.items.each do |item|
-      title = item.title
+      title = link_sanitizer.sanitize(item.title)
       published_at = item.pubDate
       story = Story.find_or_initialize_by(title: title,
                                           published_at: published_at)
       story.description = item.description
-      story.link = item.link
+      story.link = item.link.split(/href="|">/)[1]
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
       story.tags = item.category ? item.category.content : ''
       story.save

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -28,7 +28,7 @@ class ImportStories
     feed.items.each do |item|
       title = link_sanitizer.sanitize(item.title)
       published_at = item.pubDate
-      story = Story.find_or_initialize_by(title: title,
+      story = Story.find_or_initialize_by(id: id,
                                           published_at: published_at)
       story.description = item.description
       story.link = item.link.split(/href="|">/)[1]

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -28,6 +28,8 @@ class ImportStories
 
       story.description = item.description
       story.link = item.link
+      story.image = item.enclosure
+      story.tags = item.category
       story.save
     end
     puts "#{Story.count - existing} new stories"

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -26,8 +26,7 @@ class ImportStories
       published_at = item.pubDate
       story = Story.find_or_initialize_by(title: title,
                                           published_at: published_at)
-      story.description = item.description
-      story.link = "http://www.wri.org#{item.link.split(/href="|">/)[1]}"
+      story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
       story.tags = item.category ? item.category.content : ''
       story.save

--- a/db/migrate/20180121203501_add_details_to_stories.rb
+++ b/db/migrate/20180121203501_add_details_to_stories.rb
@@ -1,0 +1,6 @@
+class AddDetailsToStories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :stories, :image, :string
+    add_column :stories, :tags, :string
+  end
+end

--- a/db/migrate/20180123085343_remove_image_from_stories.rb
+++ b/db/migrate/20180123085343_remove_image_from_stories.rb
@@ -1,0 +1,5 @@
+class RemoveImageFromStories < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :stories, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121155026) do
+ActiveRecord::Schema.define(version: 20180121203501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,6 +305,8 @@ ActiveRecord::Schema.define(version: 20171121155026) do
     t.string "link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
+    t.string "tags"
   end
 
   create_table "timeline_documents", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180121203501) do
+ActiveRecord::Schema.define(version: 20180123085343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,7 +305,6 @@ ActiveRecord::Schema.define(version: 20180121203501) do
     t.string "link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "image"
     t.string "tags"
   end
 


### PR DESCRIPTION
This PR updates rss feed feature. It displays latest stories from the WRI blog on the home page.  
In the import process the stories get stored in CW data base with this columns:   
title, description, tags, background_image_url, link, published_at.  
As for now we are just using in the front end **title**, **background_image_url** and **link**  

Some changes have been requested to Christian Aldridge to avoid some xml data sanitazion and manipulation on the import process:   

**Changes requested**
*There are some xml fields that are sending html tags (title and link), I'm sanitizing the title and extracting the href from the link and attaching it to the domain (to generate a URL) but it would be nice to receive the actual content and the URL to avoid possible bugs in edge cases.*

*We are receiving the blog post original image URL, sometimes this image is quite big. Would be nice if you can send instead the resized image that you're using in the blogpost
blogpost: http://www.wri.org/blog/2017/11/how-cities-can-harness-good-and-avoid-bad-new-mobility-movement
original image: http://www.wri.org/sites/default/files/6870785251_9ddaed1a67_o.jpg
resized image: http://www.wri.org/sites/default/files/styles/large/public/6870785251_9ddaed1a67_o.jpg?itok=ilpIkdK2*

