### PR TITLE
Include iframe resizer in contained version

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   def index
     @data = {}
     @actual_path = request.original_fullpath
+    @is_contained = @actual_path.include?('contained')
     @is_production = Rails.env.production?
     response.headers['X-FRAME-OPTIONS'] = 'ALLOWALL'
     render 'index'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,11 @@
     <%= stylesheet_link_tag 'application', media: 'all',
       'data-turbolinks-track': 'reload' %>
     <script><%= raw "window.__data = #{@data.to_json};" %></script>
+
+    <% if @is_contained %>
+      <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@3.5.1/js/iframeResizer.contentWindow.min.js"></script>
+    <% end %>
+
     <% if @is_production %>
       <%= stylesheet_pack_tag 'main' %>
     <% end %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13544,7 +13544,6 @@
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1"


### PR DESCRIPTION
As a request by the NDCP here https://basecamp.com/1756858/projects/13795275/messages/75409428 this Pr includes the [iframe-resizer content window](https://github.com/davidjbradshaw/iframe-resizer/blob/master/js/iframeResizer.contentWindow.js) library only for the contained version.