### PR TITLE
Hide t in the yaxis and label unless absolute value is selected

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -8,7 +8,8 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  ResponsiveContainer
+  ResponsiveContainer,
+  Label
 } from 'recharts';
 import TooltipChart from 'components/charts/tooltip-chart';
 import { format } from 'd3-format';
@@ -31,7 +32,7 @@ const CustomizedXAxisTick = ({ x, y, payload }) => (
   </g>
 );
 
-const CustomizedYAxisTick = ({ index, x, y, payload }) => (
+const CustomizedYAxisTick = ({ index, x, y, payload, unit }) => (
   <g transform={`translate(${x},${y})`}>
     <text
       x="0"
@@ -45,7 +46,7 @@ const CustomizedYAxisTick = ({ index, x, y, payload }) => (
       {index === 0 && payload.value >= 0 ? (
         '0'
       ) : (
-        `${format('.2s')(payload.value)}t`
+        `${format(unit ? '.2r' : '.2s')(payload.value)}${unit ? '' : 't'}`
       )}
     </text>
   </g>
@@ -64,7 +65,22 @@ class ChartLine extends PureComponent {
   };
 
   render() {
-    const { config, data, height, domain } = this.props;
+    const { config, data, height, domain, espGraph } = this.props;
+    const unit =
+      config && config.axes && config.axes.yLeft && config.axes.yLeft.unit
+        ? config.axes.yLeft.unit
+        : null;
+    const yAxisLabel = (
+      <Label
+        position="top"
+        offset={20}
+        content={() => (
+          <text x="8" y="20">
+            {unit}
+          </text>
+        )}
+      />
+    );
     return (
       <ResponsiveContainer height={height}>
         <LineChart
@@ -81,9 +97,12 @@ class ChartLine extends PureComponent {
           <YAxis
             axisLine={false}
             tickLine={false}
-            tick={<CustomizedYAxisTick unit={'CO2e'} />}
+            tick={<CustomizedYAxisTick unit={unit} />}
             domain={domain || ['0', 'auto']}
-          />
+          >
+            {espGraph && yAxisLabel}
+          </YAxis>
+
           <CartesianGrid vertical={false} />
           <Tooltip
             isAnimationActive={false}
@@ -124,7 +143,8 @@ CustomizedYAxisTick.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   index: PropTypes.number,
-  payload: PropTypes.object
+  payload: PropTypes.object,
+  unit: PropTypes.string
 };
 
 ChartLine.propTypes = {
@@ -132,12 +152,14 @@ ChartLine.propTypes = {
   data: PropTypes.array.isRequired,
   height: PropTypes.any.isRequired,
   onMouseMove: PropTypes.func.isRequired,
-  domain: PropTypes.array
+  domain: PropTypes.array,
+  espGraph: PropTypes.bool.isRequired
 };
 
 ChartLine.defaultProps = {
   height: '100%',
-  onMouseMove: () => {}
+  onMouseMove: () => {},
+  espGraph: false
 };
 
 export default ChartLine;

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -90,9 +90,13 @@ class ChartLine extends PureComponent {
         >
           <XAxis
             dataKey="x"
+            scale="linear"
+            type="number"
             tick={<CustomizedXAxisTick />}
+            domain={domain || ['0', 'auto']}
             padding={{ left: 15, right: 20 }}
             tickSize={8}
+            interval="preserveStartEnd"
           />
           <YAxis
             axisLine={false}

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -6,13 +6,17 @@ import cx from 'classnames';
 import styles from './tooltip-chart-styles.scss';
 
 class TooltipChart extends PureComponent {
-  getTotal = (keys, data) => {
+  getFormat() {
+    return this.props.forceTwoDecimals ? '.2f' : '.2s';
+  }
+
+  getTotal = (keys, data, unitIsCo2) => {
     if (!keys || !data) return '';
     let total = 0;
     keys.forEach(key => {
       if (data.payload[key.value]) total += data.payload[key.value];
     });
-    return `${format('.3s')(total)}t`;
+    return `${format(this.getFormat())(total)}${unitIsCo2 ? 't' : ''}`;
   };
 
   render() {
@@ -20,7 +24,7 @@ class TooltipChart extends PureComponent {
 
     const unit =
       config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
-
+    const unitIsCo2 = unit === 'CO<sub>2</sub>e';
     return (
       <div className={styles.tooltip}>
         <div className={styles.tooltipHeader}>
@@ -35,7 +39,9 @@ class TooltipChart extends PureComponent {
         {showTotal && (
           <div className={cx(styles.label, styles.labelTotal)}>
             <p>TOTAL</p>
-            <p>{this.getTotal(config.columns.y, content.payload[0])}</p>
+            <p>
+              {this.getTotal(config.columns.y, content.payload[0], unitIsCo2)}
+            </p>
           </div>
         )}
         {content &&
@@ -60,7 +66,13 @@ class TooltipChart extends PureComponent {
                     </p>
                   </div>
                   <p className={styles.labelValue}>
-                    {y.payload ? `${format('.3s')(y.payload[y.dataKey])}t` : ''}
+                    {y.payload ? (
+                      `${format(this.getFormat())(
+                        y.payload[y.dataKey]
+                      )}${unitIsCo2 ? 't' : ''}`
+                    ) : (
+                      ''
+                    )}
                   </p>
                 </div>
               ) : null)
@@ -74,7 +86,8 @@ class TooltipChart extends PureComponent {
 TooltipChart.propTypes = {
   content: Proptypes.object,
   config: Proptypes.object,
-  showTotal: Proptypes.bool
+  showTotal: Proptypes.bool,
+  forceTwoDecimals: Proptypes.bool
 };
 
 export default TooltipChart;


### PR DESCRIPTION
- We don't want to show t in the y-axis and the tooltip of the country GHG and GHG graphs
Some code from the ESP branch was copied to avoid conflicts
![image](https://user-images.githubusercontent.com/9701591/35512748-1d4e897a-0501-11e8-857d-e8f2913c7d0c.png)
