### PR TITLE
Responsive ghg page

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -101,7 +101,7 @@ class ChartLine extends PureComponent {
           <YAxis
             axisLine={false}
             tickLine={false}
-            tick={<CustomizedYAxisTick unit={unit} />}
+            tick={<CustomizedYAxisTick unit={espGraph && unit} />}
             domain={domain || ['0', 'auto']}
           >
             {espGraph && yAxisLabel}

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -7,6 +7,7 @@ import ButtonGroup from 'components/button-group';
 import MultiSelect from 'components/multiselect';
 import Chart from 'components/charts/chart';
 import ModalMetadata from 'components/modal-metadata';
+import { TabletPortraitOnly, TabletLandscape } from 'components/responsive';
 
 import styles from './ghg-emissions-styles.scss';
 
@@ -33,6 +34,17 @@ class GhgEmissions extends PureComponent {
       loading,
       activeFilterRegion
     } = this.props;
+
+    const renderButtonGroup = reverseDropdown => (
+      <ButtonGroup
+        className={styles.colEnd}
+        onInfoClick={handleInfoClick}
+        shareUrl="/embed/ghg-emissions"
+        analyticsGraphName="Ghg-emissions"
+        reverseDropdown={reverseDropdown}
+      />
+    );
+
     return (
       <div>
         <h2 className={styles.title}>Global Historical Emissions</h2>
@@ -69,12 +81,7 @@ class GhgEmissions extends PureComponent {
             options={filters || []}
             onMultiValueChange={handleFilterChange}
           />
-          <ButtonGroup
-            className={styles.colEnd}
-            onInfoClick={handleInfoClick}
-            shareUrl="/embed/ghg-emissions"
-            analyticsGraphName="Ghg-emissions"
-          />
+          <TabletLandscape>{renderButtonGroup()}</TabletLandscape>
         </div>
         <Chart
           className={styles.chartWrapper}
@@ -86,6 +93,9 @@ class GhgEmissions extends PureComponent {
           height={500}
           loading={loading}
         />
+        <TabletPortraitOnly>
+          <div className={styles.buttonGroup}>{renderButtonGroup(true)}</div>
+        </TabletPortraitOnly>
         <ModalMetadata />
       </div>
     );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -5,11 +5,24 @@ $min-height: 500px;
 .col4 {
   @extend %grid;
 
-  @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr);
-
-  grid-template-columns: repeat(5, 1fr);
   align-items: end;
   margin-bottom: 15px;
+
+  @include msGridColumns(1fr, 1fr);
+
+  grid-template-columns: repeat(2, 1fr);
+  grid-row-gap: 1em;
+
+  @media #{$tablet-landscape} {
+    @include msGridColumns(1fr, 1fr, 1fr, 1fr, 1fr);
+
+    grid-template-columns: repeat(5, 1fr);
+  }
+}
+
+.buttonGroup {
+  display: inline-block;
+  padding-bottom: 30px;
 }
 
 .colEnd {
@@ -27,5 +40,8 @@ $min-height: 500px;
 .chartWrapper {
   position: relative;
   min-height: $min-height;
-  padding-bottom: 50px;
+
+  @media #{$tablet-landscape} {
+    padding-bottom: 50px;
+  }
 }

--- a/app/javascript/app/components/simple-menu/simple-menu-styles.scss
+++ b/app/javascript/app/components/simple-menu/simple-menu-styles.scss
@@ -53,6 +53,10 @@
         .arrowIcon {
           transform: rotate(0deg);
         }
+
+        &::after {
+          bottom: -15px;
+        }
       }
     }
   }
@@ -74,6 +78,15 @@
     .button {
       &.active::after {
         bottom: -3px;
+      }
+    }
+
+    &.reverse {
+      .links {
+        bottom: 45px;
+        left: 0;
+        right: initial;
+        top: initial;
       }
     }
   }


### PR DESCRIPTION
- Show y axis with SI format (4800000 => 4.8Gt)
- Reorder filters and button group on tablet
- Fix shared dropdown menu in button group (reverse is now opening upwards)

![image](https://user-images.githubusercontent.com/9701591/35807740-ece03cf6-0a83-11e8-9271-c46b2c89a9f0.png)
![image](https://user-images.githubusercontent.com/9701591/35807766-02154a62-0a84-11e8-9280-e94a060589ce.png)
