### PR TITLE
Fix/model category not showing

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -113,7 +113,7 @@ export const getModelsOptions = createSelector(
     models.forEach(m => {
       if (availableModels.indexOf(m.id) > -1) {
         modelOptions.push({
-          label: m.abbreviation,
+          label: m.full_name,
           value: m.id,
           scenarios: m.scenario_ids
         });

--- a/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table-selectors.js
@@ -59,20 +59,6 @@ export const filterDataByBlackList = createSelector(
   }
 );
 
-export const flattenedData = createSelector([filterDataByBlackList], data => {
-  if (!data || isEmpty(data)) return null;
-  const attributesWithObjects = ['model', 'category', 'subcategory'];
-  return data.map(d => {
-    const flattenedD = d;
-    attributesWithObjects.forEach(a => {
-      if (Object.prototype.hasOwnProperty.call(d, a)) {
-        flattenedD[a] = d[a] && d[a].name;
-      }
-    });
-    return flattenedD;
-  });
-});
-
 export const defaultColumns = createSelector(getCategoryName, category => {
   const categoryDefaultColumns = {
     scenarios: ['name', 'category', 'description'],
@@ -95,7 +81,7 @@ export const titleLinks = createSelector(
 );
 
 export default {
-  flattenedData,
+  filterDataByBlackList,
   defaultColumns,
   titleLinks
 };

--- a/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table.js
@@ -2,7 +2,7 @@ import { PureComponent, createElement } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import {
-  flattenedData,
+  filterDataByBlackList,
   defaultColumns,
   titleLinks
 } from './emission-pathways-model-table-selectors';
@@ -22,7 +22,7 @@ const mapStateToProps = (state, { category, match }) => {
   };
 
   return {
-    data: flattenedData(EspData),
+    data: filterDataByBlackList(EspData),
     defaultColumns: defaultColumns(EspData),
     titleLinks: titleLinks(EspData),
     category,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table-menu/emission-pathways-table-menu-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table-menu/emission-pathways-table-menu-component.jsx
@@ -17,7 +17,12 @@ class EmissionPathwaysTableMenu extends PureComponent {
           role="menubar"
           tabIndex={-1}
         >
-          <AnchorNav useRoutes links={routeLinks} theme={anchorNavLightTheme} />
+          <AnchorNav
+            useRoutes
+            links={routeLinks}
+            theme={anchorNavLightTheme}
+            className={styles.noPaddingLeft}
+          />
           <span className={styles.butonDetail}>
             Want to have your model in Climate Watch?
           </span>

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table-menu/emission-pathways-table-menu-styles.scss
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table-menu/emission-pathways-table-menu-styles.scss
@@ -45,3 +45,7 @@
   margin-top: 25px; // To fix IE margin top button grid
   -ms-grid-column: 7 !important; // To fix IE grid position
 }
+
+.noPaddingLeft {
+  padding-left: 0;
+}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -61,28 +61,6 @@ export const filteredDataBySearch = createSelector(
   }
 );
 
-export const titleLinks = createSelector(
-  [getCategory, getData],
-  (categoryName, data) => {
-    if (!data || isEmpty(data) || !categoryName) return null;
-    const linkInfo = {
-      models: [
-        { columnName: 'full_name', linkToId: true },
-        { columnName: 'url' }
-      ],
-      scenarios: [{ columnName: 'name', linkToId: true }],
-      indicators: []
-    };
-    const updatedData = data;
-    return updatedData.map(d =>
-      linkInfo[categoryName].map(l => ({
-        columnName: l.columnName,
-        url: l.linkToId ? `${categoryName}/${d.id}` : 'self'
-      }))
-    );
-  }
-);
-
 const getSelectedFields = createSelector(
   [getSearch, getCategory],
   (search, category) => {
@@ -126,6 +104,28 @@ export const filteredDataByFilters = createSelector(
       );
     });
     return filteredData;
+  }
+);
+
+export const titleLinks = createSelector(
+  [getCategory, filteredDataByFilters],
+  (categoryName, data) => {
+    if (!data || isEmpty(data) || !categoryName) return null;
+    const linkInfo = {
+      models: [
+        { columnName: 'full_name', linkToId: true },
+        { columnName: 'url' }
+      ],
+      scenarios: [{ columnName: 'name', linkToId: true }],
+      indicators: []
+    };
+    const updatedData = data;
+    return updatedData.map(d =>
+      linkInfo[categoryName].map(l => ({
+        columnName: l.columnName,
+        url: l.linkToId ? `${categoryName}/${d.id}` : 'self'
+      }))
+    );
   }
 );
 


### PR DESCRIPTION
This PR fixes a couple of bugs in ESP:

- The "Category" column in the Scenario table on the model page should show data
https://www.pivotaltracker.com/story/show/154931835
![image](https://user-images.githubusercontent.com/9701591/35856170-73ab9670-0b35-11e8-9f6e-97e07a18d5a2.png)

- Scenario links in scenario table are linking to the wrong scenario
https://www.pivotaltracker.com/story/show/154931809
![image](https://user-images.githubusercontent.com/9701591/35856196-8aad636c-0b35-11e8-87fb-781a4a12b6a8.png)

- On the Model Dropdown in ESP graph include full name of the model instead of the abbreviation
https://www.pivotaltracker.com/story/show/154931672
![image](https://user-images.githubusercontent.com/9701591/35856206-929fb35e-0b35-11e8-88cf-76a479997daa.png)


