### PR TITLE
Add colour theme cache to charts config

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -285,6 +285,10 @@ export const getChartData = createSelector(
   }
 );
 
+// variable that caches chart elements assigned color
+// to avoid element color changing when the chart is updated
+let colorThemeCache = {};
+
 export const getChartConfig = createSelector(
   [filterData, getCalculationSelected],
   (data, calculationSelected) => {
@@ -298,6 +302,7 @@ export const getChartConfig = createSelector(
       yColumnsChecked,
       getColorPalette(BASE_COLORS, yColumnsChecked.length)
     );
+    colorThemeCache = { ...theme, ...colorThemeCache };
     const tooltip = getTooltipConfig(yColumnsChecked);
     let unit = DEFAULT_AXES_CONFIG.yLeft.unit;
     if (calculationSelected.value === CALCULATION_OPTIONS.PER_GDP.value) {
@@ -316,7 +321,7 @@ export const getChartConfig = createSelector(
     };
     return {
       axes,
-      theme,
+      theme: colorThemeCache,
       tooltip,
       columns: {
         x: [{ label: 'year', value: 'x' }],

--- a/app/javascript/app/components/emission-pathways/emission-pathway-graph/emission-pathway-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathway-graph/emission-pathway-graph-selectors.js
@@ -230,6 +230,10 @@ export const getChartData = createSelector([filterDataByIndicator], data => {
   return dataMapped;
 });
 
+// variable that caches chart elements assigned color
+// to avoid element color changing when the chart is updated
+let colorThemeCache = {};
+
 export const getChartConfig = createSelector(
   [filterDataByIndicator, getScenariosOptions],
   (data, scenarios) => {
@@ -245,10 +249,11 @@ export const getChartConfig = createSelector(
     });
     const yColumnsChecked = uniqBy(yColumns, 'value');
     const theme = getThemeConfig(yColumnsChecked, COLORS);
+    colorThemeCache = { ...theme, ...colorThemeCache };
     const tooltip = getTooltipConfig(yColumnsChecked);
     return {
       axes: AXES_CONFIG,
-      theme,
+      theme: colorThemeCache,
       tooltip,
       columns: {
         x: [{ label: 'year', value: 'x' }],

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -285,6 +285,10 @@ export const getChartData = createSelector(
   }
 );
 
+// variable that caches chart elements assigned color
+// to avoid element color changing when the chart is updated
+let colorThemeCache = {};
+
 export const getChartConfig = createSelector(
   [filterData, getBreakSelected],
   (data, breakBy) => {
@@ -295,10 +299,11 @@ export const getChartConfig = createSelector(
     }));
     const yColumnsChecked = uniqBy(yColumns, 'value');
     const theme = getThemeConfig(yColumnsChecked, CHART_COLORS);
+    colorThemeCache = { ...theme, ...colorThemeCache };
     const tooltip = getTooltipConfig(yColumnsChecked);
     return {
       axes: DEFAULT_AXES_CONFIG,
-      theme,
+      theme: colorThemeCache,
       tooltip,
       animation: false,
       columns: {


### PR DESCRIPTION
This PR allows chart elements will remember the colour they have been assigned avoiding changing its colour when they are added or removed from the graph.  
Initially this functionality was on [PR#388](https://github.com/Vizzuality/climate-watch/pull/388) but since this functionality does not affect my-CW branch another PR to `develop`  has been created.  

![legend-colors](https://user-images.githubusercontent.com/6906348/35911621-9d9527f6-0bfa-11e8-9203-fdcc941f4f1e.gif)
  