### PR TITLE
Add color to tags on legend-chart

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -28,9 +28,9 @@ class LegendChart extends PureComponent {
           config.columns.y.map(column => (
             <Tag
               className={styles.tag}
-              key={`${column.value}${column.labe}`}
+              key={`${column.value}${column.label}`}
               label={column.label}
-              color={column.color}
+              color={config.theme[column.value].fill}
               onRemove={() => handleRemove(column.label)}
               canRemove={config.columns.y.length > 1}
             />


### PR DESCRIPTION
Updates colour data consumption of tags on legend-chart to adapt to new `<Tag />` component API.    

![screen shot 2018-02-06 at 17 48 16](https://user-images.githubusercontent.com/6906348/35871986-f6e85a02-0b65-11e8-8b9d-3380420e1d74.png)

Initially this functionality was on [PR#388](https://github.com/Vizzuality/climate-watch/pull/388) but that PR had changes that belonged to different branches so it has been split in various PR's.