### PR TITLE
Feature/filter stories by tag

### DIFF
--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -2,12 +2,28 @@ module Api
   module V1
     class StoriesController < ApiController
       def index
-        stories = Story.limit(stories_limit).order(:published_at)
-
+        stories = storiesFilter(params[:tags])
         render json: stories, each_serializer: Api::V1::StorySerializer
       end
 
       private
+
+      def storiesFilter tags
+        taggedStories = taggedStories(tags)
+        return taggedStories if taggedStories.length >= 5
+        moreStories = untaggedStories
+        return (taggedStories + moreStories).first(5) if taggedStories
+        return moreStories
+      end
+
+      def taggedStories tags
+        tagsArray = tags.split(',')
+        Story.where("tags && ARRAY[?]::varchar[]", tagsArray).order(published_at: :desc).limit(stories_limit)
+      end
+
+      def untaggedStories
+        Story.order(published_at: :desc).limit(stories_limit)
+      end
 
       def stories_limit
         params[:limit] || 5

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -2,26 +2,28 @@ module Api
   module V1
     class StoriesController < ApiController
       def index
-        stories = storiesFilter(params[:tags])
+        stories = stories_filter(params[:tags])
         render json: stories, each_serializer: Api::V1::StorySerializer
       end
 
       private
 
-      def storiesFilter tags
-        taggedStories = taggedStories(tags)
-        return taggedStories if taggedStories.length >= 5
-        moreStories = untaggedStories
-        return (taggedStories + moreStories).first(5) if taggedStories
-        return moreStories
+      def stories_filter(tags)
+        tagged_stories = tagged_stories(tags)
+        return tagged_stories if tagged_stories.length >= 5
+        more_stories = untagged_stories
+        return (tagged_stories + more_stories).first(5) if tagged_stories
+        more_stories
       end
 
-      def taggedStories tags
-        tagsArray = tags.split(',')
-        Story.where("tags && ARRAY[?]::varchar[]", tagsArray).order(published_at: :desc).limit(stories_limit)
+      def tagged_stories(tags)
+        tags_array = tags.split(',')
+        # rubocop:disable LineLength
+        Story.where('tags && ARRAY[?]::varchar[]', tags_array).order(published_at: :desc).limit(stories_limit)
+        # rubocop:enable LineLength
       end
 
-      def untaggedStories
+      def untagged_stories
         Story.order(published_at: :desc).limit(stories_limit)
       end
 

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -2,33 +2,8 @@ module Api
   module V1
     class StoriesController < ApiController
       def index
-        stories = stories_filter(params[:tags])
+        stories = Story.stories_filter(params[:tags], params[:limit])
         render json: stories, each_serializer: Api::V1::StorySerializer
-      end
-
-      private
-
-      def stories_filter(tags)
-        tagged_stories = tagged_stories(tags)
-        return tagged_stories if tagged_stories.length >= 5
-        more_stories = untagged_stories
-        return (tagged_stories + more_stories).first(5) if tagged_stories
-        more_stories
-      end
-
-      def tagged_stories(tags)
-        tags_array = tags.split(',')
-        # rubocop:disable LineLength
-        Story.where('tags && ARRAY[?]::varchar[]', tags_array).order(published_at: :desc).limit(stories_limit)
-        # rubocop:enable LineLength
-      end
-
-      def untagged_stories
-        Story.order(published_at: :desc).limit(stories_limit)
-      end
-
-      def stories_limit
-        params[:limit] || 5
       end
     end
   end

--- a/app/javascript/app/components/stories/stories-actions.js
+++ b/app/javascript/app/components/stories/stories-actions.js
@@ -5,9 +5,11 @@ const fetchStoriesInit = createAction('fetchStoriesInit');
 const fetchStoriesReady = createAction('fetchStoriesReady');
 const fetchStoriesFail = createAction('fetchStoriesFail');
 
+const TAGS = ['NDC', 'ndcsdg', 'esp', 'climate watch'];
+
 const fetchStories = createThunkAction('fetchStories', () => dispatch => {
   dispatch(fetchStoriesInit());
-  fetch('/api/v1/stories')
+  fetch(`/api/v1/stories?tags=${TAGS}`)
     .then(response => {
       if (response.ok) return response.json();
       throw Error(response.statusText);

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,10 +1,10 @@
 class Story < ApplicationRecord
-  def self.stories_filter(tags, limit = 5)
+  def self.stories_filter(tags, limit=5)
     tags_array = tags.split(',') if tags
     tagged_stories = tagged_stories(tags_array, limit)
-    return tagged_stories if tagged_stories.length >= 5
+    return tagged_stories if tagged_stories.length >= limit.to_i
     more_stories = not_tagged_by(tags_array, limit)
-    return (tagged_stories + more_stories).first(5) if tagged_stories
+    return (tagged_stories + more_stories).first(limit.to_i) if tagged_stories
     more_stories
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,5 +1,5 @@
 class Story < ApplicationRecord
-  def self.stories_filter(tags, limit=5)
+  def self.stories_filter(tags, limit = 5)
     tags_array = tags.split(',') if tags
     tagged_stories = tagged_stories(tags_array, limit)
     return tagged_stories if tagged_stories.length >= limit.to_i

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,2 +1,20 @@
 class Story < ApplicationRecord
+  def self.stories_filter(tags, limit = 5)
+    tagged_stories = tagged_stories(tags, limit)
+    return tagged_stories if tagged_stories.length >= 5
+    more_stories = untagged_stories(limit)
+    return (tagged_stories + more_stories).first(5) if tagged_stories
+    more_stories
+  end
+
+  def self.tagged_stories(tags, limit)
+    tags_array = tags.split(',')
+    Story.where('tags && ARRAY[?]::varchar[]', tags_array).
+      order(published_at: :desc).
+      limit(limit)
+  end
+
+  def self.untagged_stories(limit)
+    Story.order(published_at: :desc).limit(limit)
+  end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,20 +1,22 @@
 class Story < ApplicationRecord
   def self.stories_filter(tags, limit = 5)
-    tagged_stories = tagged_stories(tags, limit)
+    tags_array = tags.split(',')
+    tagged_stories = tagged_stories(tags_array, limit)
     return tagged_stories if tagged_stories.length >= 5
-    more_stories = untagged_stories(limit)
+    more_stories = not_tagged_by(tags_array, limit)
     return (tagged_stories + more_stories).first(5) if tagged_stories
     more_stories
   end
 
   def self.tagged_stories(tags, limit)
-    tags_array = tags.split(',')
-    Story.where('tags && ARRAY[?]::varchar[]', tags_array).
+    Story.where('tags && ARRAY[?]::varchar[]', tags).
       order(published_at: :desc).
       limit(limit)
   end
 
-  def self.untagged_stories(limit)
-    Story.order(published_at: :desc).limit(limit)
+  def self.not_tagged_by(tags, limit)
+    Story.where('NOT tags && ARRAY[?]::varchar[] OR tags IS NULL', tags).
+      order(published_at: :desc).
+      limit(limit)
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,10 +1,13 @@
 class Story < ApplicationRecord
-  def self.stories_filter(tags, limit = 5)
-    tags_array = tags.split(',') if tags
+  def self.stories_filter(tags, limit)
+    tags_array = tags.try(:split, ',')
+    limit = limit.try(:to_i) || 5
+
     tagged_stories = tagged_stories(tags_array, limit)
-    return tagged_stories if tagged_stories.length >= limit.to_i
+    return tagged_stories if tagged_stories.length >= limit
+
     more_stories = not_tagged_by(tags_array, limit)
-    return (tagged_stories + more_stories).first(limit.to_i) if tagged_stories
+    return (tagged_stories + more_stories).first(limit) if tagged_stories
     more_stories
   end
 
@@ -15,7 +18,7 @@ class Story < ApplicationRecord
   end
 
   def self.not_tagged_by(tags, limit)
-    Story.where('NOT tags && ARRAY[?]::varchar[] OR tags IS NULL', tags).
+    Story.where('(NOT tags && ARRAY[?]::varchar[]) OR tags IS NULL', tags).
       order(published_at: :desc).
       limit(limit)
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,6 +1,6 @@
 class Story < ApplicationRecord
   def self.stories_filter(tags, limit = 5)
-    tags_array = tags.split(',')
+    tags_array = tags.split(',') if tags
     tagged_stories = tagged_stories(tags_array, limit)
     return tagged_stories if tagged_stories.length >= 5
     more_stories = not_tagged_by(tags_array, limit)

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -14,11 +14,6 @@ class ImportStories
     Story.delete_all
   end
 
-  def filterByTag tags
-    allowedTags = ["climatewatch", "ndcsdg", "esp", "ndc"]
-    return tags if allowedTags.any? { |allowedTag| tags.downcase.include? allowedTag } 
-  end
-
   def import_stories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'
@@ -33,8 +28,8 @@ class ImportStories
                                           published_at: published_at)
       story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
-      story.tags = item.category ? filterByTag(item.category.content) : nil
-      story.save if story.tags
+      story.tags = item.category ? item.category.content.split(',') : nil
+      story.save 
     end
     puts "#{Story.count - existing} new stories"
   end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -29,7 +29,7 @@ class ImportStories
                                           published_at: published_at)
       story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
-      story.tags = item.category ? item.category.content.split(',') : nil
+      story.tags = item.category ? item.category.content.split(',').map(&:strip) : nil
       story.save
     end
     # rubocop:enable AbcSize

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -14,6 +14,11 @@ class ImportStories
     Story.delete_all
   end
 
+  def filterByTag tags
+    allowedTags = ["climatewatch", "ndcsdg", "esp", "ndc"]
+    return tags if allowedTags.any? { |allowedTag| tags.downcase.include? allowedTag } 
+  end
+
   def import_stories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'
@@ -28,8 +33,8 @@ class ImportStories
                                           published_at: published_at)
       story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
-      story.tags = item.category ? item.category.content : ''
-      story.save
+      story.tags = item.category ? filterByTag(item.category.content) : nil
+      story.save if story.tags
     end
     puts "#{Story.count - existing} new stories"
   end

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -14,6 +14,7 @@ class ImportStories
     Story.delete_all
   end
 
+  # rubocop:disable AbcSize
   def import_stories
     existing = Story.count
     url = 'http://www.wri.org/blog/rss2.xml'
@@ -29,8 +30,9 @@ class ImportStories
       story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
       story.background_image_url = item.enclosure ? item.enclosure.url : ''
       story.tags = item.category ? item.category.content.split(',') : nil
-      story.save 
+      story.save
     end
+    # rubocop:enable AbcSize
     puts "#{Story.count - existing} new stories"
   end
 end

--- a/db/migrate/20180208091437_remove_tags_from_stories.rb
+++ b/db/migrate/20180208091437_remove_tags_from_stories.rb
@@ -1,0 +1,5 @@
+class RemoveTagsFromStories < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :stories, :tags, :string
+  end
+end

--- a/db/migrate/20180208091529_add_tags_to_stories.rb
+++ b/db/migrate/20180208091529_add_tags_to_stories.rb
@@ -1,0 +1,5 @@
+class AddTagsToStories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :stories, :tags, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123085343) do
+ActiveRecord::Schema.define(version: 20180208091529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,7 +305,7 @@ ActiveRecord::Schema.define(version: 20180123085343) do
     t.string "link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "tags"
+    t.string "tags", default: [], array: true
   end
 
   create_table "timeline_documents", force: :cascade do |t|

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe Story, type: :model do
   describe '#tagged_stories' do
     it 'should return one story' do
-      FactoryGirl.create(:story, tags:['NDC'])
+      FactoryGirl.create(:story, tags: ['NDC'])
       expect(Story.tagged_stories('NDC, esp, climate watch', 5)).to have(1).items
     end
 
     it 'should not return any story' do
-      FactoryGirl.create(:story, tags:['OP23'])
+      FactoryGirl.create(:story, tags: ['OP23'])
       expect(Story.tagged_stories('NDC, esp', 5)).to have(0).items
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,27 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Story, type: :model do
+  before(:each) do
+    FactoryGirl.create(:story, tags: ['NDC'])
+    FactoryGirl.create(:story, tags: ['NDC', 'esp'])
+    FactoryGirl.create(:story, tags: ['OP23'])
+    FactoryGirl.create(:story, tags: nil)
+  end
   describe '#tagged_stories' do
-    it 'should return one story' do
-      FactoryGirl.create(:story, tags: ['NDC'])
-      expect(Story.tagged_stories('NDC, esp, climate watch', 5)).to have(1).items
-    end
-
-    it 'should not return any story' do
-      FactoryGirl.create(:story, tags: ['OP23'])
-      expect(Story.tagged_stories('NDC, esp', 5)).to have(0).items
+    it 'should return two stories' do
+      expect(Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)).to have(2).items
     end
   end
 
   describe '#untagged_stories' do
-    it 'should return no story' do
-      FactoryGirl.create(:story)
-      expect(Story.untagged_stories(0)).to have(0).items
-    end
-
-    it 'should return one story' do
-      FactoryGirl.create(:story)
-      expect(Story.untagged_stories(1)).to have(1).items
+    it 'should return 2 stories' do
+      expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(2).items
     end
   end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Story, type: :model do
+  describe '#tagged_stories' do
+    it 'should return one story' do
+      FactoryGirl.create(:story, tags:['NDC'])
+      expect(Story.tagged_stories('NDC, esp, climate watch', 5)).to have(1).items
+    end
+
+    it 'should not return any story' do
+      FactoryGirl.create(:story, tags:['OP23'])
+      expect(Story.tagged_stories('NDC, esp', 5)).to have(0).items
+    end
+  end
+
+  describe '#untagged_stories' do
+    it 'should return no story' do
+      FactoryGirl.create(:story)
+      expect(Story.untagged_stories(0)).to have(0).items
+    end
+
+    it 'should return one story' do
+      FactoryGirl.create(:story)
+      expect(Story.untagged_stories(1)).to have(1).items
+    end
+  end
+end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Story, type: :model do
     FactoryGirl.create(:story, tags: %w[NDC])
     FactoryGirl.create(:story, tags: %w[NDC esp])
     FactoryGirl.create(:story, tags: %w[OP23])
+    FactoryGirl.create(:story, tags: %w[OP])
     FactoryGirl.create(:story, tags: nil)
   end
   describe '#tagged_stories' do
@@ -15,7 +16,13 @@ RSpec.describe Story, type: :model do
 
   describe '#untagged_stories' do
     it 'should return 2 stories' do
-      expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(2).items
+      expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(3).items
+    end
+  end
+
+  describe '#stories_filter' do
+    it 'should return 5 stories' do
+      expect(Story.stories_filter('NDC, esp, climate watch', 5)).to have(5).items
     end
   end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Story, type: :model do
   before(:each) do
-    FactoryGirl.create(:story, tags: ['NDC'])
-    FactoryGirl.create(:story, tags: ['NDC', 'esp'])
-    FactoryGirl.create(:story, tags: ['OP23'])
+    FactoryGirl.create(:story, tags: %w[NDC])
+    FactoryGirl.create(:story, tags: %w[NDC esp])
+    FactoryGirl.create(:story, tags: %w[OP23])
     FactoryGirl.create(:story, tags: nil)
   end
   describe '#tagged_stories' do


### PR DESCRIPTION
This PR allows filtering Stories received from WRI RSS feed.   
We are using tags received from the feed to filter which stories are going to be displayed on the home page.  
Selected tags are defined on the request to the API at ``app/javascript/app/components/stories/stories-actions.js``   
On the import to the data base we are importing all stories to avoid having less than five stories on the home page in case that there are not enough stories with the desired tags (actually that is what happens).   
Bandcamp thread can be checked [here](https://basecamp.com/1756858/projects/13795275/todos/333348992)