### PR TITLE
Make all dropdowns searchable again

### DIFF
--- a/app/javascript/app/components/dropdown/dropdown-component.jsx
+++ b/app/javascript/app/components/dropdown/dropdown-component.jsx
@@ -24,8 +24,7 @@ class Dropdown extends PureComponent {
       dark,
       blueBorder,
       className,
-      disabled,
-      searchable
+      disabled
     } = this.props;
     const arrow = this.props.white ? dropdownArrowWhite : dropdownArrow;
     return (
@@ -45,9 +44,7 @@ class Dropdown extends PureComponent {
             ref={el => {
               this.selectorElement = el;
             }}
-            className={cx(className, disabled, {
-              [styles.searchable]: searchable
-            })}
+            className={cx(className, disabled)}
             renderToggleButton={() => <Icon icon={arrow} />}
             {...this.props}
           />
@@ -69,12 +66,7 @@ Dropdown.propTypes = {
   hasSearch: PropTypes.bool,
   disabled: PropTypes.bool,
   blueBorder: PropTypes.bool,
-  selectorRef: PropTypes.func,
-  searchable: PropTypes.bool.isRequired
-};
-
-Dropdown.defaultProps = {
-  searchable: false
+  selectorRef: PropTypes.func
 };
 
 export default themr('Dropdown', styles)(Dropdown);

--- a/app/javascript/app/components/dropdown/dropdown-styles.scss
+++ b/app/javascript/app/components/dropdown/dropdown-styles.scss
@@ -1,15 +1,5 @@
 @import '~styles/settings.scss';
 
-:global .resizable-input {
-  display: none;
-}
-
-.searchable {
-  :global .resizable-input {
-    display: initial;
-  }
-}
-
 .dropdownWrapper {
   width: 100%;
 }


### PR DESCRIPTION
Searchable prop is not working as desired for the dropdown. Is killing the search in all of them. We should find another solution. 

![image](https://user-images.githubusercontent.com/9701591/35989794-6fad8938-0d02-11e8-8e71-e00a3dc42861.png)
