### PR TITLE
ESP - Remove indicators,  add get in touch button, custom message for graph

### DIFF
--- a/app/javascript/app/components/charts/chart/chart-component.jsx
+++ b/app/javascript/app/components/charts/chart/chart-component.jsx
@@ -70,7 +70,7 @@ Chart.propTypes = {
   config: PropTypes.object,
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   targetParam: PropTypes.string,
-  customMessage: PropTypes.string
+  customMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 };
 
 Chart.defaultProps = {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -16,6 +16,29 @@ import styles from './emission-pathways-graph-styles.scss';
 
 class EmissionPathwayGraph extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
+  renderCustomMessage() {
+    const { filtersSelected, handleClearSelection } = this.props;
+    const getName = attribute =>
+      filtersSelected[attribute] && filtersSelected[attribute].label;
+    const unavailableIndicatorName = getName('indicator')
+      ? ` , ${getName('indicator')}`
+      : '';
+    return (
+      <span>
+        {`${getName('location')} doesn't have any data for ${getName(
+          'model'
+        )}${unavailableIndicatorName}. `}
+        <button
+          onClick={handleClearSelection}
+          type="button"
+          className={styles.clearButton}
+        >
+          Clear Selection
+        </button>
+      </span>
+    );
+  }
+
   render() {
     const {
       data,
@@ -37,6 +60,7 @@ class EmissionPathwayGraph extends PureComponent {
       filtersLoading.indicators ||
       filtersLoading.timeseries ||
       filtersLoading.models;
+
     return (
       <div className={styles.wrapper}>
         <div className={layout.content}>
@@ -116,7 +140,7 @@ class EmissionPathwayGraph extends PureComponent {
             domain={domain}
             dataOptions={filtersOptions.scenarios}
             dataSelected={filtersSelected.scenarios}
-            customMessage={'No data available for that indicator'}
+            customMessage={this.renderCustomMessage()}
             height={600}
             loading={loading}
             error={error}
@@ -161,7 +185,8 @@ EmissionPathwayGraph.propTypes = {
   filtersSelected: PropTypes.object,
   handleSelectorChange: PropTypes.func,
   handleInfoClick: PropTypes.func,
-  handleModelChange: PropTypes.func
+  handleModelChange: PropTypes.func,
+  handleClearSelection: PropTypes.func
 };
 
 export default EmissionPathwayGraph;

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -108,7 +108,7 @@ export const getModelsOptions = createSelector(
       !availableModels ||
       isEmpty(availableModels)
     ) {
-      return [];
+      return null;
     }
     const modelOptions = [];
     models.forEach(m => {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-styles.scss
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-styles.scss
@@ -65,3 +65,11 @@ $min-height: 450px;
 .noContent {
   min-height: $min-height;
 }
+
+.clearButton {
+  color: $theme-color;
+  border-bottom: 1px solid $theme-secondary;
+  vertical-align: bottom;
+  font-size: 1em;
+  cursor: pointer;
+}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -69,7 +69,7 @@ const mapStateToProps = (state, { location }) => {
     filtersSelected,
     modalData: getModalData(espData),
     error: providers.some(p => state[p].error),
-    loading: providers.some(p => state[p].loading) || filtersSelected.model
+    loading: providers.some(p => state[p].loading) || !filtersSelected.model
   };
 };
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -116,6 +116,14 @@ class EmissionPathwayGraphContainer extends PureComponent {
     this.updateUrlParam(params, clear);
   };
 
+  handleClearSelection = () => {
+    const { location } = this.props.filtersSelected;
+    this.updateUrlParam(
+      { name: 'currentLocation', value: location.value },
+      true
+    );
+  };
+
   updateUrlParam(params, clear) {
     const { history, location } = this.props;
     history.replace(getLocationParamUpdated(location, params, clear));
@@ -130,7 +138,8 @@ class EmissionPathwayGraphContainer extends PureComponent {
       ...this.props,
       handleInfoClick: this.handleInfoClick,
       handleModelChange: this.handleModelChange,
-      handleSelectorChange: this.handleSelectorChange
+      handleSelectorChange: this.handleSelectorChange,
+      handleClearSelection: this.handleClearSelection
     });
   }
 }

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -54,6 +54,7 @@ const mapStateToProps = (state, { location }) => {
     'espIndicators',
     'espGraph'
   ];
+  const filtersSelected = getFiltersSelected(espData);
   return {
     data: getChartData(espData),
     domain: getChartXDomain(espData),
@@ -65,10 +66,10 @@ const mapStateToProps = (state, { location }) => {
       indicators: state.espIndicators.loading
     },
     filtersOptions: getFiltersOptions(espData),
-    filtersSelected: getFiltersSelected(espData),
+    filtersSelected,
     modalData: getModalData(espData),
     error: providers.some(p => state[p].error),
-    loading: providers.some(p => state[p].loading)
+    loading: providers.some(p => state[p].loading) || filtersSelected.model
   };
 };
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-model-table/emission-pathways-model-table.js
@@ -11,10 +11,8 @@ import Component from './emission-pathways-model-table-component';
 const mapStateToProps = (state, { category, match }) => {
   const { id } = match.params;
   const espModelsData = state.espModels && state.espModels.data;
-  const espIndicatorsData = state.espIndicators && state.espIndicators.data;
   const espScenariosData = state.espScenarios && state.espScenarios.data;
   const EspData = {
-    espIndicatorsData,
     espScenariosData,
     espModelsData,
     category,
@@ -23,13 +21,10 @@ const mapStateToProps = (state, { category, match }) => {
 
   return {
     data: filterDataByBlackList(EspData),
-    defaultColumns: defaultColumns(EspData),
+    defaultColumns,
     titleLinks: titleLinks(EspData),
     category,
-    loading:
-      state.espModels.loading ||
-      state.espScenarios.loading ||
-      state.espIndicators.loading
+    loading: state.espModels.loading || state.espScenarios.loading
   };
 };
 

--- a/app/javascript/app/components/no-content/no-content-component.jsx
+++ b/app/javascript/app/components/no-content/no-content-component.jsx
@@ -15,7 +15,7 @@ const NoContent = ({ className, message, icon, minHeight }) => (
 NoContent.propTypes = {
   icon: PropTypes.bool,
   className: PropTypes.string,
-  message: PropTypes.string,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   minHeight: PropTypes.number
 };
 

--- a/app/javascript/app/pages/emission-pathways-model/emission-pathways-model-component.jsx
+++ b/app/javascript/app/pages/emission-pathways-model/emission-pathways-model-component.jsx
@@ -7,7 +7,6 @@ import Sticky from 'react-stickynode';
 import { renderRoutes } from 'react-router-config';
 import EspModelsProvider from 'providers/esp-models-provider';
 import EspScenariosProvider from 'providers/esp-scenarios-provider';
-import EspIndicatorsProvider from 'providers/esp-indicators-provider';
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import layout from 'styles/layout.scss';
 import styles from './emission-pathways-model-styles.scss';
@@ -20,7 +19,6 @@ class EmissionPathwaysModel extends PureComponent {
       <div>
         <EspModelsProvider />
         <EspScenariosProvider />
-        <EspIndicatorsProvider />
         <div>
           <Header route={route}>
             <div className={layout.content}>

--- a/app/javascript/app/routes/app-routes/emission-pathways-model-routes/emission-pathways-model-routes.js
+++ b/app/javascript/app/routes/app-routes/emission-pathways-model-routes/emission-pathways-model-routes.js
@@ -1,34 +1,14 @@
 import { createElement } from 'react';
-import { Redirect } from 'react-router-dom';
-
 import EmissionPathwaysModelTable from 'components/emission-pathways/emission-pathways-model-table';
 
 export default [
   {
-    path: '/emission-pathways/models/:id/scenarios',
+    path: '/emission-pathways/models/:id',
     label: 'Scenarios',
     anchor: true,
     component: () =>
       createElement(EmissionPathwaysModelTable, {
         category: 'Scenarios'
-      })
-  },
-  {
-    path: '/emission-pathways/models/:id/indicators',
-    label: 'Indicators',
-    anchor: true,
-    component: () =>
-      createElement(EmissionPathwaysModelTable, {
-        category: 'Indicators'
-      })
-  },
-  {
-    path: '/emission-pathways/models/:id',
-    label: 'emission-pathways-model',
-    exact: true,
-    component: ({ match }) =>
-      createElement(Redirect, {
-        to: `/emission-pathways/models/${match.params.id}/scenarios`
       })
   }
 ];

--- a/app/javascript/app/routes/app-routes/emission-pathways-model-sections/emission-pathways-model-sections.js
+++ b/app/javascript/app/routes/app-routes/emission-pathways-model-sections/emission-pathways-model-sections.js
@@ -14,10 +14,14 @@ export default [
       })
   },
   {
-    hash: 'scenarios-indicators',
-    label: 'Scenarios & Indicators',
+    hash: 'scenarios',
+    label: 'Scenarios',
     anchor: true,
     nav: true,
-    component: EmissionPathwaysTableMenu
+    component: props =>
+      createElement(EmissionPathwaysTableMenu, {
+        routeLinks: props.routeLinks,
+        uploadButton: true
+      })
   }
 ];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/36024107-f79892f2-0d8e-11e8-934b-6546e4e090ff.png)
- Remove indicators from menu
- Add get in touch button
- Remove all the indicators logic and change url to models/7 instead of models/7/scenarios
- Add custom message when the selected model or indicator is not available:
![image](https://user-images.githubusercontent.com/9701591/36028744-6dcfba16-0da0-11e8-8c0c-02ed7b670fe6.png)
