### PR TITLE
Show only indicators with trendLines

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
@@ -148,7 +148,8 @@ export const dataWithTrendLine = createSelector(
   [filteredDataByCategory, getScenarioTrendData],
   (data, trendData) => {
     if (!data) return null;
-    return data.map(d => {
+    const dataWithTrendLines = [];
+    data.forEach(d => {
       const rowData = d;
       const indicatorId = d.id;
       const indicatorTrendData =
@@ -159,11 +160,10 @@ export const dataWithTrendLine = createSelector(
           : sortBy(indicatorTrendData.values, ['year']).map(v =>
             parseFloat(v.value)
           );
-      } else {
-        rowData.trend = null;
+        dataWithTrendLines.push(rowData);
       }
-      return rowData;
     });
+    return dataWithTrendLines;
   }
 );
 


### PR DESCRIPTION
- Show only indicators for a location that have some trendline data.

We may have to review this as only the World indicators seem to have data. Is this true and what we want? Maybe we should remove the location dropdown then