### PR TITLE
Show a margin for negative values and widen y=0 line

### DIFF
--- a/app/javascript/app/components/axis-ticks/axis-ticks-component.jsx
+++ b/app/javascript/app/components/axis-ticks/axis-ticks-component.jsx
@@ -20,29 +20,18 @@ export const CustomXAxisTick = ({ x, y, payload, customStrokeWidth }) => (
   </g>
 );
 
-export const CustomYAxisTick = ({
-  index,
-  x,
-  y,
-  payload,
-  customStrokeWidth,
-  unit
-}) => (
+export const CustomYAxisTick = ({ x, y, payload, customStrokeWidth, unit }) => (
   <g transform={`translate(${x},${y})`}>
     <text
-      x="0"
-      y="0"
+      x="5"
+      y="4"
       dy="0"
       textAnchor="end"
       stroke="#b1b1c1"
       strokeWidth={customStrokeWidth || '0.5'}
       fontSize="13px"
     >
-      {index === 0 && payload.value >= 0 ? (
-        '0'
-      ) : (
-        `${format('.2s')(payload.value)}${unit}`
-      )}
+      {payload.value === 0 ? '0' : `${format('.2s')(payload.value)}${unit}`}
     </text>
   </g>
 );
@@ -57,7 +46,6 @@ CustomXAxisTick.propTypes = {
 CustomYAxisTick.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
-  index: PropTypes.number,
   payload: PropTypes.object,
   customStrokeWidth: PropTypes.string,
   unit: PropTypes.string

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
   ReferenceArea,
   ReferenceDot,
+  ReferenceLine,
   Label,
   ResponsiveContainer
 } from 'recharts';
@@ -127,13 +128,14 @@ class ChartStackedArea extends PureComponent {
           />
           <YAxis
             type="number"
-            domain={domain.y}
+            domain={['auto', domain.y[1]]}
             axisLine={false}
             padding={{ top: 0, bottom: 0 }}
             tickLine={false}
             tick={<CustomYAxisTick customstrokeWidth="0" unit="t" />}
           />
           <CartesianGrid vertical={false} />
+          <ReferenceLine y={0} strokeWidth="2" stroke="#666" fill="" />
           {tooltipVisibility && (
             <Tooltip
               viewBox={{ x: 0, y: 0, width: 100, height: 100 }}

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -125,6 +125,7 @@ class ChartStackedArea extends PureComponent {
             tickSize={8}
             allowDecimals={false}
             tickCount={data.length + points.length}
+            axisLine={false}
           />
           <YAxis
             type="number"

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -132,11 +132,11 @@ export const getFilterOptions = createSelector(
 );
 
 export const getFiltersSelected = createSelector(
-  [getFilterOptions, getFilterSelection],
-  (filters, selected) => {
+  [getFilterOptions, getFilterSelection, getCalculationSelected],
+  (filters, selected, calculation) => {
     if (!filters || !filters.length) return [];
     if (selected === '') return [];
-    if (!selected) return filters;
+    if (!selected || calculation.value !== 'ABSOLUTE_VALUE') return filters;
     let selectedFilters = [];
     const selectedValues = selected.split(',');
     const selectedValuesNum = selectedValues.map(d => parseInt(d, 10));


### PR DESCRIPTION
This PR solves the lack of visibility of negative values due to their magnitude in the country GHG graph.

Try with: http://localhost:3000/countries/IND?filter=192%2C189&source=16

Extra:

- Fix sectors that were being filtered in the per capita and per GDP options. Now you only can see the real total.

![image](https://user-images.githubusercontent.com/9701591/36392118-020bdbae-15aa-11e8-99c0-ba4bc6c2a14d.png)
