### PR TITLE
Feature/pinned story

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -5,11 +5,11 @@ class Story < ApplicationRecord
 
     pinned_stories = pinned_stories(1)
     tagged_stories = tagged_stories(tags_array, limit)
-    main_stories = pinned_stories + tagged_stories
+    main_stories = (pinned_stories + tagged_stories).uniq
     return main_stories if main_stories.length >= limit
 
     more_stories = not_tagged_by(tags_array, limit)
-    return (main_stories + more_stories).first(limit) if main_stories
+    return (main_stories + more_stories).uniq.first(limit) if main_stories
     more_stories
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -3,12 +3,20 @@ class Story < ApplicationRecord
     tags_array = tags.try(:split, ',')
     limit = limit.try(:to_i) || 5
 
+    pinned_stories = pinned_stories(1)
     tagged_stories = tagged_stories(tags_array, limit)
-    return tagged_stories if tagged_stories.length >= limit
+    main_stories = pinned_stories + tagged_stories
+    return main_stories if main_stories.length >= limit
 
     more_stories = not_tagged_by(tags_array, limit)
-    return (tagged_stories + more_stories).first(limit) if tagged_stories
+    return (main_stories + more_stories).first(limit) if main_stories
     more_stories
+  end
+
+  def self.pinned_stories(limit)
+    Story.where('tags && Array[?]::varchar[]', ['climatewatch-pinned']).
+      order(published_at: :desc).
+      limit(limit)
   end
 
   def self.tagged_stories(tags, limit)

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -6,8 +6,23 @@ RSpec.describe Story, type: :model do
     FactoryGirl.create(:story, tags: %w[NDC esp])
     FactoryGirl.create(:story, tags: %w[OP23])
     FactoryGirl.create(:story, tags: %w[OP])
+    FactoryGirl.create(:story, tags: %w[climatewatch-pinned])
+    FactoryGirl.create(:story, tags: %w[climatewatch-pinned esp])
     FactoryGirl.create(:story, tags: nil)
   end
+
+  describe '#pinned_stories' do
+    it 'should return one story' do
+      expect(Story.pinned_stories(1)).to have(1).items
+    end
+  end
+
+  describe '#pinned_stories' do
+    it 'should return one story' do
+      expect(Story.pinned_stories(2)).to have(2).items
+    end
+  end
+
   describe '#tagged_stories' do
     it 'should return two stories' do
       expect(Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)).to have(2).items
@@ -15,13 +30,13 @@ RSpec.describe Story, type: :model do
   end
 
   describe '#untagged_stories' do
-    it 'should return 2 stories' do
+    it 'should return three stories' do
       expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(3).items
     end
   end
 
   describe '#stories_filter' do
-    it 'should return 5 stories' do
+    it 'should return five stories' do
       expect(Story.stories_filter('NDC, esp, climate watch', 5)).to have(5).items
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Story, type: :model do
   before(:each) do
     FactoryGirl.create(:story, tags: %w[NDC])
-    FactoryGirl.create(:story, tags: %w[NDC esp])
+    FactoryGirl.create(:story, tags: %w[NDC esp mapping])
     FactoryGirl.create(:story, tags: %w[OP23])
-    FactoryGirl.create(:story, tags: %w[OP])
     FactoryGirl.create(:story, tags: %w[climatewatch-pinned])
     FactoryGirl.create(:story, tags: %w[climatewatch-pinned esp])
+    FactoryGirl.create(:story, tags: %w[OP])
     FactoryGirl.create(:story, tags: nil)
   end
 
@@ -18,20 +18,28 @@ RSpec.describe Story, type: :model do
   end
 
   describe '#pinned_stories' do
-    it 'should return one story' do
+    it 'should return two story' do
       expect(Story.pinned_stories(2)).to have(2).items
     end
   end
 
   describe '#tagged_stories' do
-    it 'should return two stories' do
-      expect(Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)).to have(2).items
+    it 'should return three stories' do
+      expect(Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)).to have(3).items
     end
   end
 
   describe '#untagged_stories' do
-    it 'should return three stories' do
-      expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(3).items
+    it 'should return four stories' do
+      expect(Story.not_tagged_by(['NDC', 'esp', 'climate watch'], 5)).to have(4).items
+    end
+  end
+
+  describe '#pinned_stories plus tagged_stories' do
+    it 'should return four stories' do
+      pinned = Story.pinned_stories(1)
+      tagged = Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)
+      expect((pinned + tagged).uniq).to have(4).items
     end
   end
 


### PR DESCRIPTION
This PR adds `pinned` filter to the Stories model. That way we will pin the last Story with the `climatewatch-pinned` tag as the main story in the home page.  
Basecamp thread could be checked [here](https://basecamp.com/1756858/projects/13795275/todos/333348992#comment_598780477)  