### PR TITLE
Bring Ghg emissions and Pathways to the first nav level

### DIFF
--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -100,20 +100,6 @@ export default [
     ]
   },
   {
-    label: 'GHG EMISSIONS',
-    nav: true,
-    routes: [
-      {
-        path: '/ghg-emissions',
-        label: 'GHG EMISSIONS'
-      },
-      {
-        path: '/pathways',
-        label: 'PATHWAYS'
-      }
-    ]
-  },
-  {
     path: '/ndcs',
     component: NDCS,
     label: 'NDCs',
@@ -138,6 +124,7 @@ export default [
   {
     path: '/ghg-emissions',
     component: GHGEmissions,
+    nav: true,
     exact: true,
     label: 'GHG EMISSIONS',
     headerImage: 'emissions',
@@ -163,6 +150,7 @@ export default [
   {
     path: '/pathways',
     component: EmissionPathways,
+    nav: true,
     label: 'PATHWAYS',
     headerImage: 'emission-pathways',
     sections: emissionPathwaysSections,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/36311812-c843c3ca-132c-11e8-8643-2a949986bb65.png)
Now GHG emissions and Pathways are in the first level of the nav menu