### PR TITLE
Show No data as tooltip text when the country has no data

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
@@ -67,7 +67,7 @@ class NDCMapContainer extends PureComponent {
     const id = isEuropeanCountry ? europeSlug : geometryIdHover;
     return selectedIndicator.locations && selectedIndicator.locations[id]
       ? selectedIndicator.locations[id].value
-      : '';
+      : 'No data';
   }
 
   handleCountryClick = geography => {
@@ -84,11 +84,8 @@ class NDCMapContainer extends PureComponent {
   };
 
   handleCountryEnter = geography => {
-    const { isoCountries } = this.props;
     const iso = geography.properties && geography.properties.id;
-    if (iso && isCountryIncluded(isoCountries, iso)) {
-      this.setState({ geometryIdHover: iso });
-    }
+    if (iso) this.setState({ geometryIdHover: iso });
     this.setState({ country: geography.properties.name });
   };
 


### PR DESCRIPTION
This PR fixes a little bug in the Ndcs map. The tooltip was showing the wrong info when you hovered over countries with no data. 

![image](https://user-images.githubusercontent.com/9701591/36419134-579e4aac-1631-11e8-8990-8cd3cd9309b7.png)
