### PR TITLE
Feature/esp scenario page changes

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
@@ -27,7 +27,6 @@ class EmissionPathwaysScenarioTableComponent extends PureComponent {
       <Table
         data={data}
         rowHeight={60}
-        sortBy={'name'}
         hasColumnSelect
         defaultColumns={defaultColumns}
         trendLine={'trend'}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
@@ -14,7 +14,13 @@ import styles from './emission-pathways-scenario-table-styles.scss';
 
 class EmissionPathwaysScenarioTableComponent extends PureComponent {
   renderTable() {
-    const { data, noContentMsg, defaultColumns, error } = this.props;
+    const {
+      data,
+      noContentMsg,
+      defaultColumns,
+      titleLinks,
+      error
+    } = this.props;
     if (error) {
       return (
         <NoContent
@@ -30,6 +36,7 @@ class EmissionPathwaysScenarioTableComponent extends PureComponent {
         hasColumnSelect
         defaultColumns={defaultColumns}
         trendLine={'trend'}
+        titleLinks={titleLinks}
       />
     ) : (
       <NoContent message={noContentMsg} className={styles.noContent} />
@@ -107,6 +114,7 @@ EmissionPathwaysScenarioTableComponent.propTypes = {
   handleSearchChange: PropTypes.func,
   categories: PropTypes.array,
   locations: PropTypes.array,
+  titleLinks: PropTypes.array,
   selectedCategory: PropTypes.object,
   selectedLocation: PropTypes.object,
   handleCategoryChange: PropTypes.func,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
@@ -138,11 +138,11 @@ const filteredDataByCategory = createSelector(
   }
 );
 
-const dataWithTrendLine = createSelector(
+const dataWithExtraColumns = createSelector(
   [filteredDataByCategory, getScenarioTrendData],
   (data, trendData) => {
     if (!data) return null;
-    const dataWithTrendLines = [];
+    const dataWithExtra = [];
     data.forEach(d => {
       const rowData = d;
       const indicatorId = d.id;
@@ -154,14 +154,20 @@ const dataWithTrendLine = createSelector(
           : sortBy(indicatorTrendData.values, ['year']).map(v =>
             parseFloat(v.value)
           );
-        dataWithTrendLines.push(rowData);
+        const round2D = n => Math.round(n * 100) / 100;
+        const firstData = indicatorTrendData.values[0];
+        const lastData =
+          indicatorTrendData.values[indicatorTrendData.values.length - 1];
+        rowData.first = `${firstData.year} | ${round2D(firstData.value)}`;
+        rowData.last = `${lastData.year} | ${round2D(lastData.value)}`;
+        dataWithExtra.push(rowData);
       }
     });
-    return dataWithTrendLines;
+    return dataWithExtra;
   }
 );
 
-const sortDataByCategory = createSelector([dataWithTrendLine], data => {
+const sortDataByCategory = createSelector([dataWithExtraColumns], data => {
   if (!data || isEmpty(data)) return null;
   return sortBy(data, d => d.category.name);
 });
@@ -208,6 +214,8 @@ export const defaultColumns = () => [
   'subcategory',
   'name',
   'unit',
+  'first',
+  'last',
   'trend'
 ];
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-selectors.js
@@ -173,15 +173,24 @@ export const filterDataByBlackList = createSelector(
   }
 );
 
+export const sortDataByCategory = createSelector(
+  [filterDataByBlackList],
+  data => {
+    if (!data || isEmpty(data)) return null;
+    return sortBy(data, d => d.category.name);
+  }
+);
+
 export const defaultColumns = () => [
-  'name',
   'category',
   'subcategory',
+  'name',
+  'unit',
   'trend'
 ];
 export default {
   getLocationOptions,
-  filterDataByBlackList,
+  sortDataByCategory,
   defaultColumns,
   getCategories,
   getSelectedCategoryOption,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table.js
@@ -5,12 +5,13 @@ import PropTypes from 'prop-types';
 import { getLocationParamUpdated } from 'utils/navigation';
 import qs from 'query-string';
 import {
-  sortDataByCategory,
+  filterDataByBlackList,
   defaultColumns,
   getCategories,
   getLocationOptions,
   getSelectedCategoryOption,
-  getSelectedLocationOption
+  getSelectedLocationOption,
+  titleLinks
 } from './emission-pathways-scenario-table-selectors';
 import Component from './emission-pathways-scenario-table-component';
 
@@ -47,13 +48,14 @@ const mapStateToProps = (state, { category, match, location }) => {
   };
 
   return {
-    data: sortDataByCategory(EspData),
+    data: filterDataByBlackList(EspData),
     defaultColumns: defaultColumns(EspData),
     categories: getCategories(EspData),
     locations: getLocationOptions(EspData),
     selectedCategory: getSelectedCategoryOption(EspData),
     selectedLocation: getSelectedLocationOption(EspData),
     query: search.search,
+    titleLinks: titleLinks(EspData),
     loading:
       state.espScenarios.loading ||
       state.espIndicators.loading ||

--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { getLocationParamUpdated } from 'utils/navigation';
 import qs from 'query-string';
 import {
-  filterDataByBlackList,
+  sortDataByCategory,
   defaultColumns,
   getCategories,
   getLocationOptions,
@@ -47,7 +47,7 @@ const mapStateToProps = (state, { category, match, location }) => {
   };
 
   return {
-    data: filterDataByBlackList(EspData),
+    data: sortDataByCategory(EspData),
     defaultColumns: defaultColumns(EspData),
     categories: getCategories(EspData),
     locations: getLocationOptions(EspData),

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -4,6 +4,7 @@ import { deburrUpper } from 'app/utils';
 import remove from 'lodash/remove';
 import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
+import sortBy from 'lodash/sortBy';
 import { ESP_BLACKLIST, FILTERS_BY_CATEGORY } from 'data/constants';
 
 const getCategory = state =>
@@ -208,8 +209,17 @@ export const renameDataColumns = createSelector(
   }
 );
 
+export const sortDataByCategoryAttribute = createSelector(
+  [renameDataColumns, getCategory],
+  (data, category) => {
+    if (!data || isEmpty(data) || !category) return null;
+    if (category !== 'indicators') return data;
+    return sortBy(data, d => d.category.name);
+  }
+);
+
 export default {
-  renameDataColumns,
+  sortDataByCategoryAttribute,
   titleLinks,
   filteredDataByFilters,
   getFilterOptionsByCategory,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table.js
@@ -5,7 +5,7 @@ import { getLocationParamUpdated } from 'utils/navigation';
 import qs from 'query-string';
 import PropTypes from 'prop-types';
 import {
-  renameDataColumns,
+  sortDataByCategoryAttribute,
   titleLinks,
   getDefaultColumns,
   getFullTextColumns,
@@ -25,7 +25,7 @@ const mapStateToProps = (state, { category, location }) => {
   };
   return {
     titleLinks: titleLinks(espData),
-    data: renameDataColumns(espData),
+    data: sortDataByCategoryAttribute(espData),
     defaultColumns: getDefaultColumns(espData),
     fullTextColumns: getFullTextColumns(espData),
     categoryName: category,

--- a/app/javascript/app/components/table/cell-renderer-component.jsx
+++ b/app/javascript/app/components/table/cell-renderer-component.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { LineChart, Line } from 'recharts';
 import { sanitize } from 'app/utils';
 import 'react-virtualized/styles.css'; // only needs to be imported once
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import styles from './table-styles.scss';
 
 const renderTrendLine = (chartData, titleLink) => {
@@ -15,9 +15,9 @@ const renderTrendLine = (chartData, titleLink) => {
     </LineChart>
   );
   return titleLink ? (
-    <a href={titleLink.url} className={styles.trendLink}>
+    <Link className={styles.trendLink} to={titleLink.url}>
       {chart}
-    </a>
+    </Link>
   ) : (
     chart
   );

--- a/app/javascript/app/components/table/cell-renderer-component.jsx
+++ b/app/javascript/app/components/table/cell-renderer-component.jsx
@@ -4,14 +4,22 @@ import { LineChart, Line } from 'recharts';
 import { sanitize } from 'app/utils';
 import 'react-virtualized/styles.css'; // only needs to be imported once
 import { NavLink } from 'react-router-dom';
+import styles from './table-styles.scss';
 
-const renderTrendLine = chartData => {
+const renderTrendLine = (chartData, titleLink) => {
   const dataValues =
     chartData && chartData.split(',').map(v => ({ value: parseFloat(v) }));
-  return (
+  const chart = (
     <LineChart width={70} height={35} data={dataValues}>
       <Line dot={false} dataKey="value" stroke="#113750" strokeWidth={2} />
     </LineChart>
+  );
+  return titleLink ? (
+    <a href={titleLink.url} className={styles.trendLink}>
+      {chart}
+    </a>
+  ) : (
+    chart
   );
 };
 
@@ -22,15 +30,16 @@ const cellRenderer = ({
   let { cellData } = cell;
   const { rowIndex, dataKey } = cell;
   cellData = sanitize(cellData);
-  // check for Trendline
-  if (trendLine && dataKey === trendLine) {
-    return renderTrendLine(cellData);
-  }
   // check for TitleLink
   const titleLink =
     titleLinks &&
     titleLinks[rowIndex] &&
     titleLinks[rowIndex].find(t => t.columnName === dataKey);
+
+  // check for Trendline
+  if (trendLine && dataKey === trendLine) {
+    return renderTrendLine(cellData, titleLink);
+  }
   if (titleLink) {
     return titleLink.url === 'self' ? (
       <a target="_blank" href={cellData}>

--- a/app/javascript/app/components/table/table-styles.scss
+++ b/app/javascript/app/components/table/table-styles.scss
@@ -110,3 +110,7 @@
   right: 10px;
   top: 15px;
 }
+
+.trendLink {
+  cursor: pointer;
+}

--- a/app/javascript/app/components/table/table-styles.scss
+++ b/app/javascript/app/components/table/table-styles.scss
@@ -112,5 +112,7 @@
 }
 
 .trendLink {
-  cursor: pointer;
+  > div {
+    cursor: pointer !important;
+  }
 }

--- a/app/javascript/app/components/table/table.js
+++ b/app/javascript/app/components/table/table.js
@@ -11,12 +11,12 @@ import Component from './table-component';
 class TableContainer extends PureComponent {
   constructor(props) {
     super(props);
-    const { data, defaultColumns } = props;
+    const { data, defaultColumns, sortBy } = props;
     const columns = defaultColumns || Object.keys(data[0]);
     this.state = {
       data,
       optionsOpen: false,
-      sortBy: Object.keys(data[0])[0],
+      sortBy: sortBy || Object.keys(data[0])[0],
       sortDirection: SortDirection.ASC,
       activeColumns: columns.map(d => ({
         label: upperFirst(lowerCase(d)),
@@ -92,7 +92,8 @@ class TableContainer extends PureComponent {
 
 TableContainer.propTypes = {
   data: PropTypes.array.isRequired,
-  defaultColumns: PropTypes.array
+  defaultColumns: PropTypes.array,
+  sortBy: PropTypes.string.isRequired
 };
 
 TableContainer.defaultProps = {

--- a/app/javascript/app/pages/emission-pathways-model/emission-pathways-model-component.jsx
+++ b/app/javascript/app/pages/emission-pathways-model/emission-pathways-model-component.jsx
@@ -28,7 +28,7 @@ class EmissionPathwaysModel extends PureComponent {
                 textColumns
               />
             </div>
-            <Sticky activeClass="sticky -emission" top="#navBarMobile">
+            <Sticky activeClass="sticky -emissions" top="#navBarMobile">
               <AnchorNav
                 links={anchorLinks}
                 className={layout.content}

--- a/app/javascript/app/pages/emission-pathways-scenario/emission-pathways-scenario-component.jsx
+++ b/app/javascript/app/pages/emission-pathways-scenario/emission-pathways-scenario-component.jsx
@@ -37,7 +37,7 @@ class EmissionPathwaysScenario extends PureComponent {
                 textColumns
               />
             </div>
-            <Sticky activeClass="sticky -emission" top="#navBarMobile">
+            <Sticky activeClass="sticky -emissions" top="#navBarMobile">
               <AnchorNav
                 links={anchorLinks}
                 className={layout.content}


### PR DESCRIPTION
- Add Unit for indicators
- Order alphabetically by category (It was needed to create a selector as the category is an object and the default sorting of the table wasn't working with it)
- Link to the pathways graph from the name with filters (scenario, model, country/region, category, subcategory and indicator)
- Change the ordering of columns to "Category", "Sub-Category", "Name",  'Unit', 'trend'
- Add first and last columns with respective year and data for the trendlines.

![image](https://user-images.githubusercontent.com/9701591/36441385-c59326cc-1672-11e8-9ad6-e1265423cd8f.png)
---
Extra:
- Order the ESP table alphabetically by category in indicators section
- Fix anchor navbar