### PR TITLE
Feature/socioeconomic adjustment

### DIFF
--- a/app/controllers/api/v1/socioeconomics_controller.rb
+++ b/app/controllers/api/v1/socioeconomics_controller.rb
@@ -10,6 +10,10 @@ module Api
                each_serializer: Api::V1::Socioeconomic::IndicatorSerializer
       end
 
+      def latest
+        render json: @location.latest_socioeconomics
+      end
+
       private
 
       def set_location

--- a/app/controllers/api/v1/socioeconomics_controller.rb
+++ b/app/controllers/api/v1/socioeconomics_controller.rb
@@ -4,7 +4,7 @@ module Api
       def index
         indicators = ::Socioeconomic::Indicator.
           includes(:location).
-          where(locations: {iso_code3: params[:location]}).
+          where(locations: {iso_code3: params[:code]}).
           order(:year)
 
         render json: indicators,

--- a/app/controllers/api/v1/socioeconomics_controller.rb
+++ b/app/controllers/api/v1/socioeconomics_controller.rb
@@ -1,14 +1,19 @@
 module Api
   module V1
     class SocioeconomicsController < ApiController
+      before_action :set_location
+
       def index
-        indicators = ::Socioeconomic::Indicator.
-          includes(:location).
-          where(locations: {iso_code3: params[:code]}).
-          order(:year)
+        indicators = @location.socioeconomic_indicators.order(:year)
 
         render json: indicators,
                each_serializer: Api::V1::Socioeconomic::IndicatorSerializer
+      end
+
+      private
+
+      def set_location
+        @location = Location.find_by(iso_code3: params[:location_code])
       end
     end
   end

--- a/app/controllers/api/v1/wb_extra_country_data_controller.rb
+++ b/app/controllers/api/v1/wb_extra_country_data_controller.rb
@@ -14,7 +14,7 @@ module Api
 
       def show
         country = Location.find_by(location_type: 'COUNTRY',
-                                   iso_code3: params[:iso])
+                                   iso_code3: params[:code])
         unless country
           render json: {
             error: 'Country not found',

--- a/app/javascript/app/pages/country/country-selectors.js
+++ b/app/javascript/app/pages/country/country-selectors.js
@@ -33,35 +33,28 @@ export const getAnchorLinks = createSelector(
     }))
 );
 
-export const getCountryDescription = createSelector(
+export const getDescriptionText = createSelector(
   [getSocioeconomicsData],
   socioeconomicsData => {
     if (!socioeconomicsData) return null;
-    return socioeconomicsData[socioeconomicsData.length - 1];
-  }
-);
-
-export const getDescriptionText = createSelector(
-  [getCountryDescription],
-  description => {
-    if (!description) return null;
     const gdpPerCapitaLocale =
-      description.gdp_per_capita &&
-      truncateDecimals(description.gdp_per_capita, 0).toLocaleString();
+      socioeconomicsData.gdp_per_capita &&
+      truncateDecimals(socioeconomicsData.gdp_per_capita, 0).toLocaleString();
     const populationLocale =
-      description.population && description.population.toLocaleString();
+      socioeconomicsData.population &&
+      socioeconomicsData.population.toLocaleString();
     const populationGrowthLocale = (Math.round(
-      description.population_growth * 100
+      socioeconomicsData.population_growth * 100
     ) / 100).toLocaleString();
 
     let text = '';
-    if (gdpPerCapitaLocale && description.gdp_per_capita_rank) {
-      text += `GDP per capita (${description.year}) - USD
-      ${gdpPerCapitaLocale} (ranked ${description.gdp_per_capita_rank} globally)
+    if (gdpPerCapitaLocale && socioeconomicsData.gdp_per_capita_rank) {
+      text += `GDP per capita (${socioeconomicsData.gdp_per_capita_year}) - USD
+      ${gdpPerCapitaLocale} (ranked ${socioeconomicsData.gdp_per_capita_rank} globally)
       <br/>`;
     }
     if (populationLocale && populationGrowthLocale) {
-      text += `Population (${description.year}) - ${populationLocale}
+      text += `Population (${socioeconomicsData.population_year}) - ${populationLocale}
       (${populationGrowthLocale}% annual growth)`;
     }
     return text;
@@ -70,6 +63,5 @@ export const getDescriptionText = createSelector(
 
 export default {
   getCountryName,
-  getCountryDescription,
   getAnchorLinks
 };

--- a/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider-actions.js
+++ b/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider-actions.js
@@ -16,7 +16,7 @@ const fetchSocioeconomics = createThunkAction(
       !socioeconomics.loading
     ) {
       dispatch(fetchSocioeconomicsInit());
-      fetch(`/api/v1/socioeconomics/${iso}`)
+      fetch(`/api/v1/locations/${iso}/socioeconomics`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider-actions.js
+++ b/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider-actions.js
@@ -16,7 +16,7 @@ const fetchSocioeconomics = createThunkAction(
       !socioeconomics.loading
     ) {
       dispatch(fetchSocioeconomicsInit());
-      fetch(`/api/v1/locations/${iso}/socioeconomics`)
+      fetch(`/api/v1/locations/${iso}/socioeconomics/latest`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -38,43 +38,8 @@ class Location < ApplicationRecord
   end
 
   def latest_socioeconomics
-    sql = <<-SQL
-      SELECT
-        soci_pop.year AS population_year, soci_pop.population AS population,
-        soci_pop.population_rank AS population_rank,
-
-        soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
-        soci_gdp.gdp_rank AS gdp_rank,
-
-        soci_pop_growth.year AS population_growth_year,
-        soci_pop_growth.population_growth AS population_growth,
-        soci_pop_growth.population_growth_rank AS population_growth_rank,
-
-        soci_gdp_per_capita.year AS gdp_per_capita_year,
-        soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
-        soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
-
-      FROM socioeconomic_indicators soci_pop,
-           socioeconomic_indicators soci_gdp,
-           socioeconomic_indicators soci_pop_growth,
-           socioeconomic_indicators soci_gdp_per_capita
-
-      WHERE soci_pop.location_id = soci_gdp.location_id
-        AND soci_gdp.location_id = soci_pop_growth.location_id
-        AND soci_pop_growth.location_id = soci_gdp_per_capita.location_id
-        AND soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
-        AND soci_gdp.gdp <> 0 AND soci_gdp.gdp IS NOT NULL
-        AND soci_pop_growth.population_growth <> 0
-        AND soci_pop_growth.population_growth IS NOT NULL
-        AND soci_gdp_per_capita.gdp_per_capita <> 0
-        AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
-        AND soci_pop.location_id = #{self.id}
-      ORDER BY soci_pop.year DESC, soci_gdp.year DESC,
-      soci_pop_growth.year DESC, soci_gdp_per_capita.year DESC
-      LIMIT 1
-    SQL
-
-    result = ActiveRecord::Base.connection.execute(sql).first
+    result = ActiveRecord::Base.connection.
+      execute(Socioeconomic::Indicator.latest_available_data_query(id)).first
 
     if !result
       return {}

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -82,18 +82,18 @@ class Location < ApplicationRecord
 
     {
       location: iso_code3,
-      gdp_year: result["gdp_year"],
-      gdp: result["gdp"],
-      gdp_rank: result["gdp_rank"].try(:ordinalize),
-      gdp_per_capita_year: result["gdp_per_capita_year"],
-      gdp_per_capita: result["gdp_per_capita"],
-      gdp_per_capita_rank: result["gdp_per_capita_rank"].try(:ordinalize),
-      population_year: result["population_year"],
-      population: result["population"],
-      population_rank: result["population_rank"].try(:ordinalize),
-      population_growth_year: result["population_growth_year"],
-      population_growth: result["population_growth"],
-      population_growth_rank: result["population_growth_rank"].try(:ordinalize)
+      gdp_year: result['gdp_year'],
+      gdp: result['gdp'],
+      gdp_rank: result['gdp_rank'].try(:ordinalize),
+      gdp_per_capita_year: result['gdp_per_capita_year'],
+      gdp_per_capita: result['gdp_per_capita'],
+      gdp_per_capita_rank: result['gdp_per_capita_rank'].try(:ordinalize),
+      population_year: result['population_year'],
+      population: result['population'],
+      population_rank: result['population_rank'].try(:ordinalize),
+      population_growth_year: result['population_growth_year'],
+      population_growth: result['population_growth'],
+      population_growth_rank: result['population_growth_rank'].try(:ordinalize)
     }
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -10,6 +10,8 @@ class Location < ApplicationRecord
            class_name: 'Indc::Indicator',
            through: :values
 
+  has_many :socioeconomic_indicators, class_name: 'Socioeconomic::Indicator'
+
   validates :iso_code3, presence: true, uniqueness: true
   validates :iso_code2, presence: true, uniqueness: true, if: proc { |l|
     l.show_in_cw? && l.country?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -38,7 +38,7 @@ class Location < ApplicationRecord
   end
 
   def latest_socioeconomics
-    result = socioeconomic_indicators.latest_available_data_query(id).first
+    result = socioeconomic_indicators.latest_available_data_query
 
     if !result
       return {}

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -36,4 +36,64 @@ class Location < ApplicationRecord
   def country?
     location_type == 'COUNTRY'
   end
+
+  def latest_socioeconomics
+    sql = <<-SQL
+      SELECT
+        soci_pop.year AS population_year, soci_pop.population AS population,
+        soci_pop.population_rank AS population_rank,
+
+        soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
+        soci_gdp.gdp_rank AS gdp_rank,
+
+        soci_pop_growth.year AS population_growth_year,
+        soci_pop_growth.population_growth AS population_growth,
+        soci_pop_growth.population_growth_rank AS population_growth_rank,
+
+        soci_gdp_per_capita.year AS gdp_per_capita_year,
+        soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
+        soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
+
+      FROM socioeconomic_indicators soci_pop,
+           socioeconomic_indicators soci_gdp,
+           socioeconomic_indicators soci_pop_growth,
+           socioeconomic_indicators soci_gdp_per_capita
+
+      WHERE soci_pop.location_id = soci_gdp.location_id
+        AND soci_gdp.location_id = soci_pop_growth.location_id
+        AND soci_pop_growth.location_id = soci_gdp_per_capita.location_id
+        AND soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
+        AND soci_gdp.gdp <> 0 AND soci_gdp.gdp IS NOT NULL
+        AND soci_pop_growth.population_growth <> 0
+        AND soci_pop_growth.population_growth IS NOT NULL
+        AND soci_gdp_per_capita.gdp_per_capita <> 0
+        AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
+        AND soci_pop.location_id = #{self.id}
+      ORDER BY soci_pop.year DESC, soci_gdp.year DESC,
+      soci_pop_growth.year DESC, soci_gdp_per_capita.year DESC
+      LIMIT 1
+    SQL
+
+    result = ActiveRecord::Base.connection.execute(sql).first
+
+    if !result
+      return {}
+    end
+
+    {
+      location: iso_code3,
+      gdp_year: result["gdp_year"],
+      gdp: result["gdp"],
+      gdp_rank: result["gdp_rank"].try(:ordinalize),
+      gdp_per_capita_year: result["gdp_per_capita_year"],
+      gdp_per_capita: result["gdp_per_capita"],
+      gdp_per_capita_rank: result["gdp_per_capita_rank"].try(:ordinalize),
+      population_year: result["population_year"],
+      population: result["population"],
+      population_rank: result["population_rank"].try(:ordinalize),
+      population_growth_year: result["population_growth_year"],
+      population_growth: result["population_growth"],
+      population_growth_rank: result["population_growth_rank"].try(:ordinalize)
+    }
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -38,8 +38,7 @@ class Location < ApplicationRecord
   end
 
   def latest_socioeconomics
-    result = ActiveRecord::Base.connection.
-      execute(Socioeconomic::Indicator.latest_available_data_query(id)).first
+    result = socioeconomic_indicators.latest_available_data_query(id).first
 
     if !result
       return {}

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -8,41 +8,36 @@ module Socioeconomic
         socioeconomic_indicators.year AS population_year,
         socioeconomic_indicators.population AS population,
         socioeconomic_indicators.population_rank AS population_rank,
-
         soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
         soci_gdp.gdp_rank AS gdp_rank,
-
         soci_pop_growth.year AS population_growth_year,
         soci_pop_growth.population_growth AS population_growth,
         soci_pop_growth.population_growth_rank AS population_growth_rank,
-
         soci_gdp_per_capita.year AS gdp_per_capita_year,
         soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
         soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
         SQL
-      ).joins(<<-SQL
+            ).joins(<<-SQL
         INNER JOIN socioeconomic_indicators soci_gdp
         ON socioeconomic_indicators.location_id = soci_gdp.location_id
         AND soci_gdp.gdp <> 0
         AND soci_gdp.gdp IS NOT NULL
-
         INNER JOIN socioeconomic_indicators soci_pop_growth
         ON socioeconomic_indicators.location_id = soci_pop_growth.location_id
         AND soci_pop_growth.population_growth <> 0
         AND soci_pop_growth.population_growth IS NOT NULL
-
         INNER JOIN socioeconomic_indicators soci_gdp_per_capita
         ON socioeconomic_indicators.location_id = soci_gdp_per_capita.location_id
         AND soci_gdp_per_capita.gdp_per_capita <> 0
         AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
       SQL
-      ).where.not(population: [0, nil]).
+                   ).where.not(population: [0, nil]).
       order(<<-SQL
         socioeconomic_indicators.year DESC,
         soci_gdp.year DESC, soci_pop_growth.year DESC,
         soci_gdp_per_capita.year DESC
       SQL
-      ).first
+           ).first
     end
   end
 end

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -3,7 +3,7 @@ module Socioeconomic
     belongs_to :location
     validates :year, presence: true, uniqueness: {scope: :location_id}
 
-    def self.latest_available_data_query(location_id)
+    def self.latest_available_data_query
       select(<<-SQL
         socioeconomic_indicators.year AS population_year,
         socioeconomic_indicators.population AS population,
@@ -22,25 +22,27 @@ module Socioeconomic
         SQL
       ).joins(<<-SQL
         INNER JOIN socioeconomic_indicators soci_gdp
-          ON socioeconomic_indicators.location_id = soci_gdp.location_id
-          AND soci_gdp.gdp <> 0
-          AND soci_gdp.gdp IS NOT NULL
+        ON socioeconomic_indicators.location_id = soci_gdp.location_id
+        AND soci_gdp.gdp <> 0
+        AND soci_gdp.gdp IS NOT NULL
+
         INNER JOIN socioeconomic_indicators soci_pop_growth
-          ON socioeconomic_indicators.location_id = soci_pop_growth.location_id
-          AND soci_pop_growth.population_growth <> 0
-          AND soci_pop_growth.population_growth IS NOT NULL
+        ON socioeconomic_indicators.location_id = soci_pop_growth.location_id
+        AND soci_pop_growth.population_growth <> 0
+        AND soci_pop_growth.population_growth IS NOT NULL
+
         INNER JOIN socioeconomic_indicators soci_gdp_per_capita
-          ON socioeconomic_indicators.location_id = soci_gdp_per_capita.location_id
-          AND soci_gdp_per_capita.gdp_per_capita <> 0
-          AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
-        SQL
-     ).where.not(population: [0, nil]).
-     order(<<-SQL
+        ON socioeconomic_indicators.location_id = soci_gdp_per_capita.location_id
+        AND soci_gdp_per_capita.gdp_per_capita <> 0
+        AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
+      SQL
+      ).where.not(population: [0, nil]).
+      order(<<-SQL
         socioeconomic_indicators.year DESC,
         soci_gdp.year DESC, soci_pop_growth.year DESC,
         soci_gdp_per_capita.year DESC
-        SQL
-      ).limit(1)
+      SQL
+      ).first
     end
   end
 end

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -4,42 +4,43 @@ module Socioeconomic
     validates :year, presence: true, uniqueness: {scope: :location_id}
 
     def self.latest_available_data_query(location_id)
-      <<-SQL
-        SELECT
-          soci_pop.year AS population_year, soci_pop.population AS population,
-          soci_pop.population_rank AS population_rank,
+      select(<<-SQL
+        socioeconomic_indicators.year AS population_year,
+        socioeconomic_indicators.population AS population,
+        socioeconomic_indicators.population_rank AS population_rank,
 
-          soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
-          soci_gdp.gdp_rank AS gdp_rank,
+        soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
+        soci_gdp.gdp_rank AS gdp_rank,
 
-          soci_pop_growth.year AS population_growth_year,
-          soci_pop_growth.population_growth AS population_growth,
-          soci_pop_growth.population_growth_rank AS population_growth_rank,
+        soci_pop_growth.year AS population_growth_year,
+        soci_pop_growth.population_growth AS population_growth,
+        soci_pop_growth.population_growth_rank AS population_growth_rank,
 
-          soci_gdp_per_capita.year AS gdp_per_capita_year,
-          soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
-          soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
-
-        FROM socioeconomic_indicators soci_pop
+        soci_gdp_per_capita.year AS gdp_per_capita_year,
+        soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
+        soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
+        SQL
+      ).joins(<<-SQL
         INNER JOIN socioeconomic_indicators soci_gdp
-          ON soci_pop.location_id = soci_gdp.location_id
+          ON socioeconomic_indicators.location_id = soci_gdp.location_id
           AND soci_gdp.gdp <> 0
           AND soci_gdp.gdp IS NOT NULL
         INNER JOIN socioeconomic_indicators soci_pop_growth
-          ON soci_pop.location_id = soci_pop_growth.location_id
+          ON socioeconomic_indicators.location_id = soci_pop_growth.location_id
           AND soci_pop_growth.population_growth <> 0
           AND soci_pop_growth.population_growth IS NOT NULL
         INNER JOIN socioeconomic_indicators soci_gdp_per_capita
-          ON soci_pop.location_id = soci_gdp_per_capita.location_id
+          ON socioeconomic_indicators.location_id = soci_gdp_per_capita.location_id
           AND soci_gdp_per_capita.gdp_per_capita <> 0
           AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
-
-        WHERE soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
-          AND soci_pop.location_id = #{location_id}
-        ORDER BY soci_pop.year DESC, soci_gdp.year DESC,
-        soci_pop_growth.year DESC, soci_gdp_per_capita.year DESC
-        LIMIT 1
-      SQL
+        SQL
+     ).where.not(population: [0, nil]).
+     order(<<-SQL
+        socioeconomic_indicators.year DESC,
+        soci_gdp.year DESC, soci_pop_growth.year DESC,
+        soci_gdp_per_capita.year DESC
+        SQL
+      ).limit(1)
     end
   end
 end

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -20,20 +20,21 @@ module Socioeconomic
           soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
           soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
 
-        FROM socioeconomic_indicators soci_pop,
-             socioeconomic_indicators soci_gdp,
-             socioeconomic_indicators soci_pop_growth,
-             socioeconomic_indicators soci_gdp_per_capita
-
-        WHERE soci_pop.location_id = soci_gdp.location_id
-          AND soci_gdp.location_id = soci_pop_growth.location_id
-          AND soci_pop_growth.location_id = soci_gdp_per_capita.location_id
-          AND soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
-          AND soci_gdp.gdp <> 0 AND soci_gdp.gdp IS NOT NULL
+        FROM socioeconomic_indicators soci_pop
+        INNER JOIN socioeconomic_indicators soci_gdp
+          ON soci_pop.location_id = soci_gdp.location_id
+          AND soci_gdp.gdp <> 0
+          AND soci_gdp.gdp IS NOT NULL
+        INNER JOIN socioeconomic_indicators soci_pop_growth
+          ON soci_pop.location_id = soci_pop_growth.location_id
           AND soci_pop_growth.population_growth <> 0
           AND soci_pop_growth.population_growth IS NOT NULL
+        INNER JOIN socioeconomic_indicators soci_gdp_per_capita
+          ON soci_pop.location_id = soci_gdp_per_capita.location_id
           AND soci_gdp_per_capita.gdp_per_capita <> 0
           AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
+
+        WHERE soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
           AND soci_pop.location_id = #{location_id}
         ORDER BY soci_pop.year DESC, soci_gdp.year DESC,
         soci_pop_growth.year DESC, soci_gdp_per_capita.year DESC

--- a/app/models/socioeconomic/indicator.rb
+++ b/app/models/socioeconomic/indicator.rb
@@ -2,5 +2,43 @@ module Socioeconomic
   class Indicator < ApplicationRecord
     belongs_to :location
     validates :year, presence: true, uniqueness: {scope: :location_id}
+
+    def self.latest_available_data_query(location_id)
+      <<-SQL
+        SELECT
+          soci_pop.year AS population_year, soci_pop.population AS population,
+          soci_pop.population_rank AS population_rank,
+
+          soci_gdp.year AS gdp_year, soci_gdp.gdp AS gdp,
+          soci_gdp.gdp_rank AS gdp_rank,
+
+          soci_pop_growth.year AS population_growth_year,
+          soci_pop_growth.population_growth AS population_growth,
+          soci_pop_growth.population_growth_rank AS population_growth_rank,
+
+          soci_gdp_per_capita.year AS gdp_per_capita_year,
+          soci_gdp_per_capita.gdp_per_capita AS gdp_per_capita,
+          soci_gdp_per_capita.gdp_per_capita_rank AS gdp_per_capita_rank
+
+        FROM socioeconomic_indicators soci_pop,
+             socioeconomic_indicators soci_gdp,
+             socioeconomic_indicators soci_pop_growth,
+             socioeconomic_indicators soci_gdp_per_capita
+
+        WHERE soci_pop.location_id = soci_gdp.location_id
+          AND soci_gdp.location_id = soci_pop_growth.location_id
+          AND soci_pop_growth.location_id = soci_gdp_per_capita.location_id
+          AND soci_pop.population <> 0 AND soci_pop.population IS NOT NULL
+          AND soci_gdp.gdp <> 0 AND soci_gdp.gdp IS NOT NULL
+          AND soci_pop_growth.population_growth <> 0
+          AND soci_pop_growth.population_growth IS NOT NULL
+          AND soci_gdp_per_capita.gdp_per_capita <> 0
+          AND soci_gdp_per_capita.gdp_per_capita IS NOT NULL
+          AND soci_pop.location_id = #{location_id}
+        ORDER BY soci_pop.year DESC, soci_gdp.year DESC,
+        soci_pop_growth.year DESC, soci_gdp_per_capita.year DESC
+        LIMIT 1
+      SQL
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       get 'auth/login', to: 'auth#login'
       get 'auth/logout', to: 'auth#logout'
 
-      resources :wb_extra, param: :iso, only: [:index, :show], controller: 'wb_extra_country_data'
+      resources :wb_extra, param: :code, only: [:index, :show], controller: 'wb_extra_country_data'
 
       resources :emissions, only: [:index], controller: :historical_emissions do
         get :meta, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       end
       resources :adaptations, only: [:index]
       resources :quantifications, only: [:index]
-      get 'socioeconomics/:location', to: 'socioeconomics#index'
+      resources :socioeconomics, param: :code, only: [:show]
       resources :metadata, param: :slug, only: [:index, :show] do
         get :acronyms, on: :collection, controller: :metadata, action: :acronyms
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
       resources :locations, param: :code, only: [] do
         resources :socioeconomics, only: [:index] do
-          get :latest, on: :member
+          get :latest, on: :collection
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,9 +34,16 @@ Rails.application.routes.draw do
         get :linkages_dataset, on: :collection, controller: :ndc_sdgs,
           action: :linkages_dataset, defaults: { format: :csv }
       end
+
       resources :adaptations, only: [:index]
       resources :quantifications, only: [:index]
-      resources :socioeconomics, param: :code, only: [:show]
+
+      resources :locations, param: :code, only: [] do
+        resources :socioeconomics, only: [:index] do
+          get :latest, on: :member
+        end
+      end
+
       resources :metadata, param: :slug, only: [:index, :show] do
         get :acronyms, on: :collection, controller: :metadata, action: :acronyms
       end

--- a/spec/controllers/api/v1/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/historical_emissions_controller_spec.rb
@@ -97,8 +97,9 @@ describe Api::V1::HistoricalEmissionsController, type: :controller do
   context do
     let!(:some_historical_emissions_records) {
       data_source = FactoryBot.create(:historical_emissions_data_source)
-      sector = FactoryBot.create(:historical_emissions_sector,
-                                  data_source: data_source)
+      sector = FactoryBot.create(
+        :historical_emissions_sector,
+        data_source: data_source)
       gas = FactoryBot.create(:historical_emissions_gas)
       gwp = FactoryBot.create(:historical_emissions_gwp)
       FactoryBot.create_list(

--- a/spec/controllers/api/v1/socioeconomics_controller_spec.rb
+++ b/spec/controllers/api/v1/socioeconomics_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::SocioeconomicsController, type: :controller do
   context do
     let(:location) {
-      location = FactoryBot.create(:location, iso_code3: 'POL')
+      FactoryBot.create(:location, iso_code3: 'POL')
     }
 
     let!(:polish_socioeconomics) {

--- a/spec/controllers/api/v1/socioeconomics_controller_spec.rb
+++ b/spec/controllers/api/v1/socioeconomics_controller_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 describe Api::V1::SocioeconomicsController, type: :controller do
   context do
-    let!(:polish_socioeconomics) {
+    let(:location) {
       location = FactoryBot.create(:location, iso_code3: 'POL')
+    }
+
+    let!(:polish_socioeconomics) {
       FactoryBot.create_list(:socioeconomic_indicator, 2, location: location)
     }
     let!(:other_socioeconomics) {
@@ -12,7 +15,7 @@ describe Api::V1::SocioeconomicsController, type: :controller do
 
     describe 'GET index' do
       it 'filters socioeconomic values by location' do
-        get :index, params: {location: 'POL'}
+        get :index, params: {location_code: location.iso_code3}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(2)
       end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -23,19 +23,34 @@ RSpec.describe Location, type: :model do
         FactoryBot.create(:location)
       }
       let!(:socio_gdp) {
-        FactoryBot.create(:socioeconomic_indicator, gdp: 1, population: 0,
-                          population_growth: 2, year: 2016,
-                          location_id: location.id)
+        FactoryBot.create(
+          :socioeconomic_indicator,
+          gdp: 1,
+          population: 0,
+          population_growth: 2,
+          year: 2016,
+          location_id: location.id
+        )
       }
       let!(:socio_ignore) {
-        FactoryBot.create(:socioeconomic_indicator, gdp: 23, population: 0,
-                          population_growth: 3, year: 2015,
-                          location_id: location.id)
+        FactoryBot.create(
+          :socioeconomic_indicator,
+          gdp: 23,
+          population: 0,
+          population_growth: 3,
+          year: 2015,
+          location_id: location.id
+        )
       }
       let!(:socio_population) {
-        FactoryBot.create(:socioeconomic_indicator, gdp: 0, population: 2,
-                          population_growth: 4, year: 2014,
-                          location_id: location.id)
+        FactoryBot.create(
+          :socioeconomic_indicator,
+          gdp: 0,
+          population: 2,
+          population_growth: 4,
+          year: 2014,
+          location_id: location.id
+        )
       }
       it 'returns gdp and population_growth of :socio_gdp, and population of :socio_population' do
         result = location.latest_socioeconomics

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -16,4 +16,39 @@ RSpec.describe Location, type: :model do
     eu28.members << pol
     expect(eu28.members).to eq([pol])
   end
+
+  context do
+    describe ':latest_socioeconomics' do
+      let(:location) {
+        FactoryBot.create(:location)
+      }
+      let!(:socio_gdp) {
+        FactoryBot.create(:socioeconomic_indicator, gdp: 1, population: 0,
+                          population_growth: 2, year: 2016,
+                          location_id: location.id)
+      }
+      let!(:socio_ignore) {
+        FactoryBot.create(:socioeconomic_indicator, gdp: 23, population: 0,
+                          population_growth: 3, year: 2015,
+                          location_id: location.id)
+      }
+      let!(:socio_population) {
+        FactoryBot.create(:socioeconomic_indicator, gdp: 0, population: 2,
+                          population_growth: 4, year: 2014,
+                          location_id: location.id)
+      }
+      it 'returns gdp and population_growth of :socio_gdp, and population of :socio_population' do
+        result = location.latest_socioeconomics
+        expect(result[:gdp]).to eq(socio_gdp.gdp)
+        expect(result[:gdp_year]).to eq(socio_gdp.year)
+        expect(result[:population_growth]).to eq(socio_gdp.population_growth)
+        expect(result[:population_growth_year]).to eq(socio_gdp.year)
+
+        expect(result[:population]).to eq(socio_population.population)
+        expect(result[:population_year]).to eq(socio_population.year)
+
+        expect(result[:location]).to eq(location.iso_code3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR solves the issue reported in this Pivotal Tracker story: https://www.pivotaltracker.com/story/show/154661142

The changes included are:

- small refactor to the params names in some of the API routes;
- changes to the way the socioeconomics endpoint was setup so that is a bit more restful and makes use of the more concise Rails syntax;
- socioeconomics endpoint is now using nested resources as we are fetching data for a location, so we might as well;
- adds a new method on the locations model to fetch the latest available data for the socioeconomic data. Because there isn't a consistent and consolidated dataset behind this sometimes there is GDP data for one year, but not Population growth data for that same year, so this aims to fix that; (big SQL query here, so some review there and advice would be very welcome!)
- adds specs to test the method and make sure it works for the key use cases;
- updates the frontend to use the new endpoint and the new data structure of the response (the latest endpoint returns a single object instead of an array of objects);


## To Test ##

- Run the specs: `rails db:test:prepare && rspec`
- Visit any country page and check that it still works OK!
- Check Brazil and compare with the pages in production;
- Check some of the cases shared by WRI: for instance Venezuela or Cuba;

Thank you for your time. =)