### PR TITLE
Fix/clear indicator

### DIFF
--- a/app/javascript/app/components/dropdown/dropdown.js
+++ b/app/javascript/app/components/dropdown/dropdown.js
@@ -1,4 +1,5 @@
 import { mapProps } from 'recompose';
+import sortBy from 'lodash/sortBy';
 import Component from './dropdown-component';
 
 const optionsSanitizer = mapProps(props => {
@@ -17,4 +18,12 @@ const optionsSanitizer = mapProps(props => {
   return updatedProps;
 });
 
-export default optionsSanitizer(Component);
+const optionsSort = mapProps(props => {
+  let updatedProps = props;
+  if (updatedProps.options && updatedProps.options.length) {
+    updatedProps = { ...props, options: sortBy(props.options, 'label') };
+  }
+  return updatedProps;
+});
+
+export default optionsSort(optionsSanitizer(Component));

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -111,7 +111,7 @@ class EmissionPathwayGraphContainer extends PureComponent {
     if (param === 'category') {
       params.push({ name: 'subcategory', value: '' });
     }
-    if (param === 'subcategory') {
+    if (param === 'category' || param === 'subcategory') {
       params.push({ name: 'indicator', value: '' });
     }
     this.updateUrlParam(params, clear);


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2083759/stories/155391290
- The indicator was not being cleared when the category changed so sometimes was trying to load some indicators that didn't exist.
---
Extra:
- Sort all dropdowns alphabetically by default