### PR TITLE
Removes method and fetchs more pinned...

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -3,20 +3,16 @@ class Story < ApplicationRecord
     tags_array = tags.try(:split, ',')
     limit = limit.try(:to_i) || 5
 
-    pinned_stories = pinned_stories(1)
+    pinned_stories = tagged_stories(['climatewatch-pinned'], limit)
+    return pinned_stories if pinned_stories.length >= limit
+
     tagged_stories = tagged_stories(tags_array, limit)
-    main_stories = (pinned_stories + tagged_stories).uniq
+    main_stories = (pinned_stories + tagged_stories).uniq.first(limit)
     return main_stories if main_stories.length >= limit
 
     more_stories = not_tagged_by(tags_array, limit)
     return (main_stories + more_stories).uniq.first(limit) if main_stories
     more_stories
-  end
-
-  def self.pinned_stories(limit)
-    Story.where('tags && Array[?]::varchar[]', ['climatewatch-pinned']).
-      order(published_at: :desc).
-      limit(limit)
   end
 
   def self.tagged_stories(tags, limit)

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -11,18 +11,6 @@ RSpec.describe Story, type: :model do
     FactoryBot.create(:story, tags: nil)
   end
 
-  describe '#pinned_stories' do
-    it 'should return one story' do
-      expect(Story.pinned_stories(1)).to have(1).items
-    end
-  end
-
-  describe '#pinned_stories' do
-    it 'should return two story' do
-      expect(Story.pinned_stories(2)).to have(2).items
-    end
-  end
-
   describe '#tagged_stories' do
     it 'should return three stories' do
       expect(Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)).to have(3).items
@@ -37,7 +25,7 @@ RSpec.describe Story, type: :model do
 
   describe '#pinned_stories plus tagged_stories' do
     it 'should return four stories' do
-      pinned = Story.pinned_stories(1)
+      pinned = Story.tagged_stories(['climatewatch-pinned'], 1)
       tagged = Story.tagged_stories(['NDC', 'esp', 'climate watch'], 5)
       expect((pinned + tagged).uniq).to have(4).items
     end


### PR DESCRIPTION
Looking at their current data it seems that they have more than one
pinned story, so let's try to fetch all pinned first and then move
to the tagged stories.

Looking closely at the code it seems we can get rid of the
pinned_stories method as we can use the tagged_stories method for the
same purpose by passing the correct tag.