### PR TITLE
Fix linkages scroll and style title

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -64,16 +64,16 @@ class CountryNdcOverview extends PureComponent {
                     <span className={styles.metaTitle}>Target type</span>
                     <p
                       className={styles.targetText}
+                      // eslint-disable-next-line react/no-danger
                       dangerouslySetInnerHTML={{
-                        // eslint-disable-line
                         __html: values.ghg_target_type[0].value
                       }}
                     />
                     <span className={styles.metaTitle}>Target year</span>
                     <p
                       className={styles.targetText}
+                      // eslint-disable-next-line react/no-danger
                       dangerouslySetInnerHTML={{
-                        // eslint-disable-line react/no-danger
                         __html: values.time_target_year[0].value
                       }}
                     />
@@ -88,8 +88,8 @@ class CountryNdcOverview extends PureComponent {
                 {values && values.non_ghg_target ? (
                   <p
                     className={styles.targetText}
+                    // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{
-                      // eslint-disable-line react/no-danger
                       __html: values.non_ghg_target[0].value
                     }}
                   />
@@ -103,8 +103,8 @@ class CountryNdcOverview extends PureComponent {
                 {values && values.coverage_sectors_short ? (
                   <p
                     className={styles.targetText}
+                    // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{
-                      // eslint-disable-line react/no-danger
                       __html: values.coverage_sectors_short[0].value
                     }}
                   />
@@ -154,8 +154,8 @@ class CountryNdcOverview extends PureComponent {
     const description = hasSectors && (
       <p
         className={styles.descriptionContainer}
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
-          // eslint-disable-line react/no-danger
           __html: values.indc_summary[0] && values.indc_summary[0].value
         }}
       />

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -89,6 +89,7 @@
 
   @media #{$tablet-landscape} {
     margin-bottom: 0;
+    overflow: hidden;
   }
 }
 

--- a/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
@@ -19,7 +19,6 @@
   @include overflowFix();
 
   @media #{$tablet-landscape} {
-    overflow: auto;
     padding-top: 0;
     margin-top: 0;
   }

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-content/ndc-sdg-linkages-content-styles.scss
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-content/ndc-sdg-linkages-content-styles.scss
@@ -8,11 +8,6 @@
 
   grid-template-columns: 1fr;
 
-  &.isOpen {
-    height: 60vh;
-    overflow: hidden;
-  }
-
   @media #{$tablet-landscape} {
     @include msGridColumns(1fr, 2fr);
 

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-styles.scss
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-styles.scss
@@ -53,7 +53,9 @@
   top: $gutter-padding;
   opacity: 1;
   width: 100%;
-  padding: 0 15px;
+  font-weight: $font-weight;
+  font-size: $font-size-large;
+  color: $theme-color;
 
   @media #{$tablet-landscape} {
     display: block;

--- a/app/javascript/app/pages/ndc-sdg/ndc-sdg-styles.scss
+++ b/app/javascript/app/pages/ndc-sdg/ndc-sdg-styles.scss
@@ -6,7 +6,8 @@
 }
 
 .bgOpen {
-  height: calc(100vh - #{$navbar-height});
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
@@ -18,6 +19,10 @@
 
 .headerOpen {
   height: $header-height;
+
+  @media #{$tablet-landscape} {
+    height: auto;
+  }
 }
 
 @media #{$tablet-landscape} {
@@ -30,12 +35,5 @@
 }
 
 .wrapperOpen {
-  height: 60vh;
-  overflow: hidden;
-
-  @media #{$tablet-landscape} {
-    height: auto;
-    overflow: auto;
-  }
+  overflow: auto;
 }
-


### PR DESCRIPTION
Linkages page was not scrolling to the end of the goal list and hiding part of the legend. Flexbox to the rescue!
- Be able to scroll to the bottom of the info
- Remove extra margin in the header

![image](https://user-images.githubusercontent.com/9701591/36592687-22dd5e12-1897-11e8-8b26-8d05e06a3e2a.png)
---
Extra:
- Style the title
- Remove scroll in landscape view in Country - Timeline and Overview : https://basecamp.com/1756858/projects/13795275/todos/343197508

