### PR TITLE
Feature/download dropdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV NAME climate-watch
 ENV RAKE_ENV production
 ENV RAILS_ENV production
 ENV ESP_API https://data.emissionspathways.org/api/v1
+ENV S3_BUCKET_NAME climate-watch-dev
 ENV GOOGLE_ANALYTICS_ID UA-1981881-51
 
 # Install dependencies

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,6 +5,7 @@ ENV NAME climate-watch
 ENV RAKE_ENV development
 ENV RAILS_ENV development
 ENV ESP_API https://data.emissionspathways.org/api/v1
+ENV S3_BUCKET_NAME climate-watch-dev
 ENV GOOGLE_ANALYTICS_ID UA-1981881-51
 
 # Install dependencies

--- a/app/javascript/app/components/download-menu/download-menu-component.jsx
+++ b/app/javascript/app/components/download-menu/download-menu-component.jsx
@@ -1,0 +1,28 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import SimpleMenu from 'components/simple-menu';
+import downloadIcon from 'assets/icons/download.svg';
+
+class DownloadMenu extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const { downloadMenuOptions, className, reverse } = this.props;
+    return (
+      <SimpleMenu
+        {...this.props}
+        buttonClassName={className}
+        options={downloadMenuOptions}
+        icon={downloadIcon}
+        reverse={reverse}
+      />
+    );
+  }
+}
+
+DownloadMenu.propTypes = {
+  downloadMenuOptions: PropTypes.array,
+  className: PropTypes.string,
+  reverse: PropTypes.bool
+};
+
+export default DownloadMenu;

--- a/app/javascript/app/components/download-menu/download-menu-styles.scss
+++ b/app/javascript/app/components/download-menu/download-menu-styles.scss
@@ -1,0 +1,21 @@
+@import '~styles/layout.scss';
+
+.button {
+  cursor: pointer;
+  height: 45px;
+
+  &.active::after {
+    content: "";
+    position: absolute;
+    bottom: -4px;
+    left: 0;
+    right: 0;
+    background-color: $theme-secondary;
+    width: 100%;
+    height: 3px;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/app/javascript/app/components/download-menu/download-menu.js
+++ b/app/javascript/app/components/download-menu/download-menu.js
@@ -1,0 +1,51 @@
+import { withProps } from 'recompose';
+import Component from './download-menu-component';
+
+const { S3_BUCKET_NAME } = process.env;
+
+const server = `http://${S3_BUCKET_NAME}.s3.amazonaws.com`;
+const folder = '/climate-watch-download-zip';
+const url = `${server}${folder}`;
+const downloadMenuOptions = [
+  {
+    label: 'All (12.3 MB)',
+    link: `${url}/all.zip`,
+    target: '_self'
+  },
+  {
+    label: 'NDC Content (6.4 MB)',
+    link: `${url}/ndc-content.zip`,
+    target: '_self'
+  },
+  {
+    label: 'GHG emissions (3.5 MB)',
+    link: `${url}/ghg-emissions.zip`,
+    target: '_self'
+  },
+  {
+    label: 'Adaptation (357 kB)',
+    link: `${url}/adaptation.zip`,
+    target: '_self'
+  },
+  {
+    label: 'Socioeconomic (450 kB)',
+    link: `${url}/socioeconomic-indicators.zip`,
+    target: '_self'
+  },
+  {
+    label: 'Pathways (2.1 MB)',
+    link: `${url}/pathways.zip`,
+    target: '_self'
+  },
+  {
+    label: 'NDC quantification (367 kB)',
+    link: `${url}/ndc-quantification.zip`,
+    target: '_self'
+  }
+];
+
+const withOptions = withProps(() => ({
+  downloadMenuOptions
+}));
+
+export default withOptions(Component);

--- a/app/javascript/app/components/simple-menu/simple-menu-component.jsx
+++ b/app/javascript/app/components/simple-menu/simple-menu-component.jsx
@@ -88,7 +88,7 @@ class SimpleMenu extends PureComponent {
     ) : (
       <a
         className={styles.link}
-        target="_blank"
+        target={option.target || '_blank'}
         href={option.link}
         onClick={this.handleLinkClick}
       >

--- a/app/javascript/app/components/tools-nav/tools-nav-component.jsx
+++ b/app/javascript/app/components/tools-nav/tools-nav-component.jsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import Icon from 'components/icon';
+import DownloadMenu from 'components/download-menu';
 import ShareMenu from 'components/share-menu';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
-import download from 'assets/icons/download.svg';
 import styles from './tools-nav-styles.scss';
 
 const ToolsNav = ({ className, reverse }) => (
   <div className={cx(styles.toolsNav, className)}>
     <NavLink
-      className={cx(styles.link, styles.disabled)}
+      className={cx(styles.link, styles.disabled, styles.myCwButton)}
       activeClassName={styles.linkActive}
       to=""
       disabled
@@ -19,13 +18,7 @@ const ToolsNav = ({ className, reverse }) => (
     >
       MY CW
     </NavLink>
-    <a
-      href="//climate-watch-dev.s3.amazonaws.com/climate-watch-download-zip/data-download.zip"
-      className={styles.link}
-      title="Download all Climate Watch data"
-    >
-      <Icon className={styles.download} icon={download} />
-    </a>
+    <DownloadMenu className={styles.downloadButton} reverse={reverse} />
     <ShareMenu className={styles.shareButton} reverse={reverse} />
   </div>
 );

--- a/app/javascript/app/components/tools-nav/tools-nav-styles.scss
+++ b/app/javascript/app/components/tools-nav/tools-nav-styles.scss
@@ -7,14 +7,18 @@
   border-left: solid 1px rgba($gray, 0.5);
 }
 
-.shareButton {
+.shareButton,
+.downloadButton {
   fill: $dark-gray;
-  margin-left: 20px;
-  padding: 17px 20px;
+  padding: 22px 15px 0;
 
   &.active {
     border-bottom: 3px solid $theme-secondary;
   }
+}
+
+.myCwButton {
+  margin-right: 12px;
 }
 
 .link {

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -62,6 +62,8 @@ spec:
                   key: CW_AWS_SECRET_ACCESS_KEY
           - name: ESP_API
             value: "https://data.emissionspathways.org/api/v1"
+          - name: S3_BUCKET_NAME
+            value: "climate-watch-dev"
           - name: GFW_API
             value: "https://production-api.globalforestwatch.org"
           - name: CORS_WHITELIST

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -53,6 +53,8 @@ spec:
                   key: CW_AWS_SECRET_ACCESS_KEY
           - name: ESP_API
             value: "https://www.emissionspathways.org/api/v1"
+          - name: S3_BUCKET_NAME
+            value: "climate-watch-dev"
           - name: GFW_API
             value: "https://production-api.globalforestwatch.org"
           - name: CORS_WHITELIST


### PR DESCRIPTION
This PR changes the download button to a dropdown with different files to download:
- Upload files to bucket (chore)
- Create download menu and use it in the navtools
- Set target to _self
- Add bucket name to docker and deploy files (we will have to change this if we have a different bucket for production)

![image](https://user-images.githubusercontent.com/9701591/36601403-54cfe5de-18b5-11e8-9670-8e179d98c950.png)
