### PR TITLE
Show bars negative and customize ticks in stacked chart

### DIFF
--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import max from 'lodash/max';
 import isArray from 'lodash/isArray';
+import { getCustomTicks } from 'utils/graphs';
+
 import {
   CustomXAxisTick,
   CustomYAxisTick
@@ -97,9 +99,10 @@ class ChartStackedArea extends PureComponent {
       maxData.y = dataParsed[dataParsed.length - 1].total;
     }
 
+    const tickValues = getCustomTicks(config.columns, data);
     const domain = {
       x: ['dataMin', 'dataMax'],
-      y: [0, 'dataMax']
+      y: [tickValues.minValue, tickValues.maxValue]
     };
 
     if (points.length > 1000000000) {
@@ -115,6 +118,7 @@ class ChartStackedArea extends PureComponent {
           onMouseMove={this.handleMouseMove}
           onMouseLeave={() => this.setLastPoint(true)}
           onMouseEnter={() => this.setLastPoint(false)}
+          stackOffset="sign"
         >
           <XAxis
             domain={domain.x}
@@ -129,9 +133,11 @@ class ChartStackedArea extends PureComponent {
           />
           <YAxis
             type="number"
-            domain={['auto', domain.y[1]]}
+            domain={domain.y}
+            interval={0}
             axisLine={false}
             padding={{ top: 0, bottom: 0 }}
+            ticks={tickValues.ticks}
             tickLine={false}
             tick={<CustomYAxisTick customstrokeWidth="0" unit="t" />}
           />

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -1,6 +1,9 @@
 import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
 import chroma from 'chroma-js';
+import minBy from 'lodash/minBy';
+import maxBy from 'lodash/maxBy';
+import { getNiceTickValues } from 'recharts-scale';
 
 export const parseRegions = regions =>
   regions.map(region => ({
@@ -55,3 +58,35 @@ export const getTooltipConfig = columns => {
 
 export const getColorPalette = (colorRange, quantity) =>
   chroma.scale(colorRange).colors(quantity);
+
+export function getCustomTicks(
+  columns,
+  data,
+  tickNumber = 8,
+  decimals = false
+) {
+  const totalValues = [];
+  const yValues = columns.y.map(c => data.map(d => d[[c.value]]));
+  for (let index = 0; index < yValues[0].length; index++) {
+    const total = {
+      positive: 0,
+      negative: 0
+    };
+    for (let e = 0; e < yValues.length; e++) {
+      if (yValues[e][index] > 0) {
+        total.positive += yValues[e][index] || 0;
+      } else {
+        total.negative += yValues[e][index] || 0;
+      }
+    }
+    totalValues.push(total);
+  }
+
+  const minValue = minBy(totalValues, 'negative').negative;
+  const maxValue = maxBy(totalValues, 'positive').positive;
+  return {
+    min: minValue,
+    max: maxValue,
+    ticks: getNiceTickValues([minValue, maxValue], tickNumber, decimals)
+  };
+}


### PR DESCRIPTION
After wet and dig into rechart library we have finally a solution for the negative values!
![image](https://user-images.githubusercontent.com/10500650/36607167-1ff7b1d2-18c6-11e8-9786-cb208d23eb54.png)

Now we represent the negative values as an area below 0, and we also needed to customize the ticks to ensure that we are always showing the 0 value.
