### PR TITLE
Fix/css fixes country page, legend and ESP

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -21,7 +21,7 @@ class LegendChart extends PureComponent {
     } = this.props;
     const shouldShowMultiselect =
       dataOptions && dataSelected && dataSelected.length !== dataOptions.length;
-    const mirrorX = dataSelected.length < 3;
+    const mirrorX = dataSelected.length < 2;
     return (
       <ul className={cx(styles.tags, className)}>
         {config &&

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -21,6 +21,7 @@ class LegendChart extends PureComponent {
     } = this.props;
     const shouldShowMultiselect =
       dataOptions && dataSelected && dataSelected.length !== dataOptions.length;
+    const mirrorX = dataSelected.length < 3;
     return (
       <ul className={cx(styles.tags, className)}>
         {config &&
@@ -51,6 +52,7 @@ class LegendChart extends PureComponent {
             dropdownDirection={-1}
             hideSelected
             icon={plusIcon}
+            mirrorX={mirrorX}
           />
         )}
       </ul>

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   overflow: scroll;
 
-  @include overflowFix(250px);
+  @include overflowFix('large');
 
   padding-top: 260px;
 

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   overflow: scroll;
 
-  @include overflowFix();
+  @include overflowFix(250px);
 
   padding-top: 260px;
 

--- a/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
@@ -16,7 +16,7 @@
 .timelineContainer {
   overflow-x: auto;
 
-  @include overflowFix(120px);
+  @include overflowFix('small');
 }
 
 .timeline { // overwriting timeline styles

--- a/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
@@ -16,7 +16,7 @@
 .timelineContainer {
   overflow-x: auto;
 
-  @include overflowFix();
+  @include overflowFix(120px);
 }
 
 .timeline { // overwriting timeline styles

--- a/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
@@ -93,7 +93,7 @@
 
         .links {
           display: block;
-          min-width: 120px;
+          min-width: 220px;
           position: relative;
           overflow: auto;
           max-height: 140px;

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
@@ -31,15 +31,14 @@ class EmissionPathwaysTable extends PureComponent {
       noContentMsg,
       defaultColumns,
       titleLinks,
-      fullTextColumns,
-      categoryName
+      fullTextColumns
     } = this.props;
     if (loading) return <Loading light className={styles.loader} />;
     return data && data.length > 0 ? (
       <Table
         data={data}
         titleLinks={titleLinks}
-        rowHeight={categoryName === 'Scenarios' ? 150 : 60}
+        rowHeight={60}
         hasColumnSelect
         defaultColumns={defaultColumns}
         fullTextColumns={fullTextColumns}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
@@ -31,14 +31,15 @@ class EmissionPathwaysTable extends PureComponent {
       noContentMsg,
       defaultColumns,
       titleLinks,
-      fullTextColumns
+      fullTextColumns,
+      categoryName
     } = this.props;
     if (loading) return <Loading light className={styles.loader} />;
     return data && data.length > 0 ? (
       <Table
         data={data}
         titleLinks={titleLinks}
-        rowHeight={60}
+        rowHeight={categoryName === 'Scenarios' ? 146 : 60}
         hasColumnSelect
         defaultColumns={defaultColumns}
         fullTextColumns={fullTextColumns}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -37,7 +37,7 @@ export const getFullTextColumns = createSelector([getCategory], category => {
     case 'models':
       return ['full_name'];
     case 'scenarios':
-      return [];
+      return ['description'];
     case 'indicators':
       return [];
     default:

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -35,9 +35,9 @@ export const getDefaultColumns = createSelector([getCategory], category => {
 export const getFullTextColumns = createSelector([getCategory], category => {
   switch (category) {
     case 'models':
-      return ['full_name', 'geographic_coverage'];
+      return ['full_name'];
     case 'scenarios':
-      return ['geographic_coverage_country'];
+      return [];
     case 'indicators':
       return [];
     default:

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -52,6 +52,7 @@ class Multiselect extends Component {
       label,
       parentClassName,
       children,
+      mirrorX,
       hideSelected,
       icon
     } = this.props;
@@ -63,6 +64,7 @@ class Multiselect extends Component {
             theme.dropdown,
             styles.multiSelect,
             children ? styles.hasChildren : '',
+            { [styles.mirrorX]: mirrorX },
             { [styles.searchable]: !icon }
           )}
         >
@@ -120,6 +122,7 @@ Multiselect.propTypes = {
   selectedLabel: Proptypes.string,
   children: Proptypes.node,
   hideSelected: Proptypes.bool,
+  mirrorX: Proptypes.bool,
   icon: Proptypes.object
 };
 

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -62,7 +62,8 @@ class Multiselect extends Component {
           className={cx(
             theme.dropdown,
             styles.multiSelect,
-            children ? styles.hasChildren : ''
+            children ? styles.hasChildren : '',
+            { [styles.searchable]: !icon }
           )}
         >
           <div className={cx(styles.values, 'values')}>

--- a/app/javascript/app/components/multiselect/multiselect-styles.scss
+++ b/app/javascript/app/components/multiselect/multiselect-styles.scss
@@ -34,6 +34,12 @@
   }
 }
 
+.mirrorX :global {
+  .dropdown-menu {
+    left: 0 !important;
+  }
+}
+
 .multiSelect :global {
   position: relative;
 

--- a/app/javascript/app/components/multiselect/multiselect-styles.scss
+++ b/app/javascript/app/components/multiselect/multiselect-styles.scss
@@ -51,6 +51,14 @@
   }
 }
 
+:global .react-selectize-search-field-and-selected-values .resizable-input {
+  opacity: 0;
+}
+
+.searchable :global .react-selectize-search-field-and-selected-values .resizable-input {
+  opacity: 1;
+}
+
 .selected {
   display: flex;
   justify-content: space-between;

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -10,7 +10,7 @@ import 'react-virtualized/styles.css'; // only needs to be imported once
 import cellRenderer from './cell-renderer-component';
 import styles from './table-styles.scss';
 
-const minColumnWidth = 140;
+const minColumnWidth = 180;
 const getResponsiveWidth = (columns, width) => {
   if (columns.length === 1) return width;
 
@@ -23,11 +23,12 @@ const getResponsiveWidth = (columns, width) => {
     responsiveRatio = 1.2; // Tablet
   } else if (width > pixelBreakpoints.landscape) {
     // Desktop
-    responsiveColumnRatio = 0.05;
+    responsiveColumnRatio = 0.1;
     responsiveRatio = 1;
   }
   const columnRatio = isMinColumSized ? responsiveColumnRatio : 0;
-  return width * responsiveRatio * (1 + (columnRatio * columns));
+  const columnExtraWidth = columnRatio * columns;
+  return width * responsiveRatio * (1 + columnExtraWidth);
 };
 
 class SimpleTable extends PureComponent {

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
@@ -79,10 +79,6 @@
   border-radius: 10px;
 }
 
-.listText {
-  margin-left: 10px;
-}
-
 .lineChartContainer {
   position: relative;
   height: $vulnerability-chart-height;

--- a/app/javascript/app/pages/country/country-styles.scss
+++ b/app/javascript/app/pages/country/country-styles.scss
@@ -7,11 +7,6 @@
   @include msGridColumns(10fr, 2fr);
 
   grid-template-columns: 10fr 2fr;
-
-  @media #{$tablet-landscape} {
-    // Needed because of the timeline padding hack
-    z-index: 2;
-  }
 }
 
 .section {

--- a/app/javascript/app/pages/country/country-styles.scss
+++ b/app/javascript/app/pages/country/country-styles.scss
@@ -7,8 +7,6 @@
   @include msGridColumns(10fr, 2fr);
 
   grid-template-columns: 10fr 2fr;
-  // Needed because of the timeline padding hack
-  z-index: 2;
 }
 
 .section {

--- a/app/javascript/app/pages/country/country-styles.scss
+++ b/app/javascript/app/pages/country/country-styles.scss
@@ -7,6 +7,11 @@
   @include msGridColumns(10fr, 2fr);
 
   grid-template-columns: 10fr 2fr;
+
+  @media #{$tablet-landscape} {
+    // Needed because of the timeline padding hack
+    z-index: 2;
+  }
 }
 
 .section {

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -174,7 +174,7 @@ class Home extends PureComponent {
             <Intro
               theme={introDark}
               title="Examine Links Between Sustainable Development and Climate Goals"
-              description="Identify potential alignment between the targets, actions, policies policy measures and needs in countries’ Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs)."
+              description="Identify potential alignment between the targets, actions, policy measures and needs in countries’ Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs)."
             />
             <div className={styles.doubleFold}>
               <Button color="yellow" link={'/ndcs-sdg'}>

--- a/app/javascript/app/pages/ndc-sdg/ndc-sdg-component.jsx
+++ b/app/javascript/app/pages/ndc-sdg/ndc-sdg-component.jsx
@@ -41,8 +41,8 @@ class NdcSdg extends PureComponent {
             <div className={headerTheme.headerGrid}>
               <Intro
                 title="NDC-SDG Linkages"
-                description={`Identify potential alignment between the targets, actions, policies measures and needs in countries
-                ’Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs).`}
+                description={`Identify potential alignment between the targets, actions, policy measures and needs in countries
+                Nationally Determined Contributions (NDCs) and the targets of the Sustainable Development Goals (SDGs).`}
               />
               <AutocompleteSearch />
             </div>

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -80,9 +80,8 @@
     *zoom: 1;
   }
 }
-
 // the overflow-x scroll prevents the overflow-y to be visible so we need this hack to keep the dropdowns visible
-@mixin overflowFix() {
-  padding-top: 250px;
-  margin-top: -250px;
+@mixin overflowFix($size) {
+  padding-top: $size;
+  margin-top: -$size;
 }

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -82,6 +82,13 @@
 }
 // the overflow-x scroll prevents the overflow-y to be visible so we need this hack to keep the dropdowns visible
 @mixin overflowFix($size) {
-  padding-top: $size;
-  margin-top: -$size;
+  @if $size=='small' {
+    padding-top: 100px;
+    margin-top: -100px;
+  }
+
+  @if $size=='large' {
+    padding-top: 250px;
+    margin-top: -250px;
+  }
 }


### PR DESCRIPTION
This PR fixes: 
https://www.pivotaltracker.com/story/show/155546749

- Country timeline documents: fix the styles and make it bigger
![image](https://user-images.githubusercontent.com/9701591/36913195-72e4c8b6-1e49-11e8-8b7a-69f454ab91b4.png)
- Remove tooltip on rank (only appears in the comparison) (Already done)
-Remove key hazards left margin (only appears for the comparison)

https://www.pivotaltracker.com/story/show/155652196

- Fix graph options selection (make it not searchable)
- On mobile, the second selected dropdown was being cut. Mirror the x so we can show it well
![image](https://user-images.githubusercontent.com/9701591/36913420-2ce12a0c-1e4a-11e8-91e2-363074f68075.png)

https://www.pivotaltracker.com/story/show/155649899

https://basecamp.com/1756858/projects/13795275/todos/344135369
- Typos in text

https://basecamp.com/1756858/projects/13795275/todos/344070867
- Remove full lenght in geographical coverage, smaller rows