### PR TITLE
Fix/ndc dropdown sort

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -28,6 +28,7 @@
 .tagSelector :global {
   width: 29px;
   height: 29px;
+  z-index: 0;
 
   .react-selectize-control {
     background-color: $white !important;

--- a/app/javascript/app/components/dropdown/dropdown.js
+++ b/app/javascript/app/components/dropdown/dropdown.js
@@ -20,7 +20,11 @@ const optionsSanitizer = mapProps(props => {
 
 const optionsSort = mapProps(props => {
   let updatedProps = props;
-  if (updatedProps.options && updatedProps.options.length) {
+  if (
+    !updatedProps.noAutoSort &&
+    updatedProps.options &&
+    updatedProps.options.length
+  ) {
     updatedProps = { ...props, options: sortBy(props.options, 'label') };
   }
   return updatedProps;

--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
@@ -39,6 +39,7 @@ class NdcsAutocompleteSearch extends PureComponent {
           value={optionSelected}
           hideResetButton
           white={!dark}
+          noAutoSort
         />
         <Search
           theme={dark ? darkSearch : lightSearch}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/37033975-138ee21e-2148-11e8-89fa-4e82faa935ac.png)

- Don't auto sort NDC Full document goals and targets dropdown

---
Extra: 

- FIx z-index in legend selector so it doesn't go over the sticky

![image](https://user-images.githubusercontent.com/9701591/37034096-717c8c00-2148-11e8-8105-c258793388e7.png)
