### PR TITLE
Reduce list of featured tags, limit pinned to two items

### DIFF
--- a/app/javascript/app/components/stories/stories-actions.js
+++ b/app/javascript/app/components/stories/stories-actions.js
@@ -56,7 +56,7 @@ const fetchStoriesInit = createAction('fetchStoriesInit');
 const fetchStoriesReady = createAction('fetchStoriesReady');
 const fetchStoriesFail = createAction('fetchStoriesFail');
 
-const TAGS = ['NDC', 'ndcsdg', 'esp', 'climatewatch'];
+const TAGS = ['climatewatch'];
 
 const fetchStories = createThunkAction('fetchStories', () => dispatch => {
   if (FEATURE_STORIES === 'true') {

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -3,7 +3,7 @@ class Story < ApplicationRecord
     tags_array = tags.try(:split, ',')
     limit = limit.try(:to_i) || 5
 
-    pinned_stories = tagged_stories(['climatewatch-pinned'], limit)
+    pinned_stories = tagged_stories(['climatewatch-pinned'], 2)
     return pinned_stories if pinned_stories.length >= limit
 
     tagged_stories = tagged_stories(tags_array, limit)


### PR DESCRIPTION
As requested on Basecamp this PR introduces the following changes:

- include two pinned-stories instead of all pinned stories in the first positions;
- filter by only **climatewatch** and removes the other tags.

To see this reflected properly you should re-import your stories:

`rails stories:fresh_import`