### PR TITLE
Feature/show country ghg disclaimer

### DIFF
--- a/app/javascript/app/components/button/button-component.jsx
+++ b/app/javascript/app/components/button/button-component.jsx
@@ -15,6 +15,7 @@ const Button = props => {
     color,
     disabled,
     onClick,
+    noBox,
     noSpace
   } = props;
   const classNames = cx(className, styles.button, {
@@ -23,6 +24,7 @@ const Button = props => {
     [styles.yellow]: color === 'yellow',
     [styles.white]: color === 'white',
     [styles.plain]: color === 'plain',
+    [styles.noBox]: noBox,
     [styles.disabled]: !onClick && !link && !href,
     [styles.noSpace]: noSpace
   });
@@ -59,6 +61,7 @@ Button.propTypes = {
   square: PropTypes.bool,
   color: PropTypes.string,
   noSpace: PropTypes.bool,
+  noBox: PropTypes.bool,
   disabled: PropTypes.bool,
   onClick: PropTypes.func
 };

--- a/app/javascript/app/components/button/button-styles.scss
+++ b/app/javascript/app/components/button/button-styles.scss
@@ -37,6 +37,16 @@
   }
 }
 
+.noBox {
+  width: 45px;
+  background-color: transparent;
+  box-shadow: none;
+
+  &:hover {
+    box-shadow: none;
+  }
+}
+
 .square {
   width: 45px;
   padding: 0;

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router-dom';
 import { getLocationParamUpdated } from 'utils/navigation';
 import qs from 'query-string';
 import ReactGA from 'react-ga';
-import { COUNTRY_GHG_TITLE } from 'data/constants';
 
 import { actions as modalActions } from 'components/modal-metadata';
 import ownActions from './country-ghg-emissions-actions';
@@ -106,7 +105,8 @@ class CountryGhgEmissionsContainer extends PureComponent {
       this.props.setModalMetadata({
         category: 'Country',
         slugs: [source, 'ndc_quantification_UNDP', 'ndc_quantification_WRI'],
-        customTitle: COUNTRY_GHG_TITLE,
+        customTitle: 'Greenhouse Gas Emissions and Emissions Targets',
+        showDisclaimer: true,
         open: true
       });
     }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { getLocationParamUpdated } from 'utils/navigation';
 import qs from 'query-string';
 import ReactGA from 'react-ga';
+import { COUNTRY_GHG_TITLE } from 'data/constants';
 
 import { actions as modalActions } from 'components/modal-metadata';
 import ownActions from './country-ghg-emissions-actions';
@@ -101,14 +102,11 @@ class CountryGhgEmissionsContainer extends PureComponent {
 
   handleInfoClick = () => {
     const { source } = this.props.sourceSelected;
-
-    // hide quantification sources from prod
-    // slugs: [source, 'ndc_quantification_UNDP', 'ndc_quantification_WRI'],
     if (source) {
       this.props.setModalMetadata({
         category: 'Country',
         slugs: [source, 'ndc_quantification_UNDP', 'ndc_quantification_WRI'],
-        customTitle: 'Greenhouse Gas Emissions and Emissions Targets',
+        customTitle: COUNTRY_GHG_TITLE,
         open: true
       });
     }

--- a/app/javascript/app/components/country/country-ghg/country-ghg-component.jsx
+++ b/app/javascript/app/components/country/country-ghg/country-ghg-component.jsx
@@ -3,11 +3,11 @@ import CountryGHGEmissions from 'components/country/country-ghg-emissions';
 import CountryGHGMap from 'components/country/country-ghg-map';
 import EmissionsMetaProvider from 'providers/ghg-emissions-meta-provider';
 import WbCountryDataProvider from 'providers/wb-country-data-provider';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
 import throttle from 'lodash/throttle';
 import { CALCULATION_OPTIONS } from 'app/data/constants';
 import { TabletLandscape } from 'components/responsive';
+import Disclaimer from 'components/disclaimer';
 
 import layout from 'styles/layout.scss';
 import styles from './country-ghg-styles.scss';
@@ -33,19 +33,22 @@ class CountryGhg extends PureComponent {
       search.calculation &&
       search.calculation !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value;
     return (
-      <div className={cx(layout.content, styles.grid)}>
-        <EmissionsMetaProvider />
-        {needsWBData && <WbCountryDataProvider />}
-        <CountryGHGEmissions handleYearHover={this.handleYearHover} />
-        <TabletLandscape>
-          <div className={styles.map}>
-            <CountryGHGMap
-              search={search}
-              className={styles.map}
-              year={this.state.year}
-            />
-          </div>
-        </TabletLandscape>
+      <div className={layout.content}>
+        <div className={styles.grid}>
+          <EmissionsMetaProvider />
+          {needsWBData && <WbCountryDataProvider />}
+          <CountryGHGEmissions handleYearHover={this.handleYearHover} />
+          <TabletLandscape>
+            <div className={styles.map}>
+              <CountryGHGMap
+                search={search}
+                className={styles.map}
+                year={this.state.year}
+              />
+            </div>
+          </TabletLandscape>
+        </div>
+        <Disclaimer className={styles.disclaimer} />
       </div>
     );
   }

--- a/app/javascript/app/components/country/country-ghg/country-ghg-styles.scss
+++ b/app/javascript/app/components/country/country-ghg/country-ghg-styles.scss
@@ -16,3 +16,11 @@
   margin-left: $gutter-padding / 2;
   padding: 30px 0;
 }
+
+.disclaimer {
+  margin: -180px -15px 0 -15px;
+
+  @media #{$tablet-landscape} {
+    margin: -140px 0 0 0;
+  }
+}

--- a/app/javascript/app/components/disclaimer/disclaimer-component.jsx
+++ b/app/javascript/app/components/disclaimer/disclaimer-component.jsx
@@ -1,0 +1,61 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Button from 'components/button';
+import Icon from 'components/icon';
+import closeIcon from 'assets/icons/sidebar-close.svg';
+import cx from 'classnames';
+import styles from './disclaimer-styles.scss';
+
+class Disclaimer extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const {
+      handleOnRequestClose,
+      hasBeenShown,
+      className,
+      onlyText
+    } = this.props;
+    return onlyText || !hasBeenShown ? (
+      <div className={cx(styles.disclaimerBox, className)}>
+        <div className={styles.firstText}>
+          Please note that the level of emissions in future years are estimated
+          based on greenhouse gas reduction targets communicated by countries,
+          which might differ from historical emissions presented in terms of
+          source, sector and gas coverage, GWP values and inventory
+          methodologies used. The data are presented on the same chart for
+          illustration only and should be treated with caution.
+        </div>
+        <div className={styles.secondText}>
+          For detailed methodology and data sources used, please refer to WRI’s
+          publication{' '}
+          <a
+            className={styles.link}
+            href="https://www.wri.org/sites/default/files/Translating_Targets_into_Numbers.pdf"
+          >
+            Translating Targets into Numbers: Quantifying the Greenhouse Gas
+            Targets of the G20 Countries for G20 countries, and UNEP’s Pledge
+            Pipeline for other countries.
+          </a>
+        </div>
+        {!onlyText && (
+          <Button
+            className={styles.closeButton}
+            onClick={handleOnRequestClose}
+            noBox
+          >
+            <Icon icon={closeIcon} className={styles.close} />
+          </Button>
+        )}
+      </div>
+    ) : null;
+  }
+}
+
+Disclaimer.propTypes = {
+  hasBeenShown: PropTypes.bool,
+  onlyText: PropTypes.bool,
+  handleOnRequestClose: PropTypes.func.isRequired,
+  className: PropTypes.string
+};
+
+export default Disclaimer;

--- a/app/javascript/app/components/disclaimer/disclaimer-component.jsx
+++ b/app/javascript/app/components/disclaimer/disclaimer-component.jsx
@@ -16,7 +16,13 @@ class Disclaimer extends PureComponent {
       onlyText
     } = this.props;
     return onlyText || !hasBeenShown ? (
-      <div className={cx(styles.disclaimerBox, className)}>
+      <div
+        className={cx(
+          styles.disclaimerBox,
+          { [styles.onlyText]: onlyText },
+          className
+        )}
+      >
         <div className={styles.firstText}>
           Please note that the level of emissions in future years are estimated
           based on greenhouse gas reduction targets communicated by countries,
@@ -31,6 +37,8 @@ class Disclaimer extends PureComponent {
           <a
             className={styles.link}
             href="https://www.wri.org/sites/default/files/Translating_Targets_into_Numbers.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Translating Targets into Numbers: Quantifying the Greenhouse Gas
             Targets of the G20 Countries for G20 countries, and UNEP’s Pledge

--- a/app/javascript/app/components/disclaimer/disclaimer-styles.scss
+++ b/app/javascript/app/components/disclaimer/disclaimer-styles.scss
@@ -3,7 +3,7 @@
 .disclaimerBox {
   box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.1);
   display: flex;
-  padding: 30px;
+  padding: $gutter-padding;
   position: relative;
   line-height: $line-height-medium;
   font-size: $font-size-xs;

--- a/app/javascript/app/components/disclaimer/disclaimer-styles.scss
+++ b/app/javascript/app/components/disclaimer/disclaimer-styles.scss
@@ -1,0 +1,45 @@
+@import '~styles/layout.scss';
+
+.disclaimerBox {
+  box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.1);
+  display: flex;
+  padding: 30px;
+  position: relative;
+  line-height: $line-height-medium;
+  font-size: $font-size-xs;
+  background-color: $white;
+  flex-direction: column;
+
+  @media #{$tablet-landscape} {
+    padding: 20px;
+    flex-direction: row;
+  }
+}
+
+.firstText {
+  color: $theme-color;
+  flex: 1;
+}
+
+.secondText {
+  color: $dark-gray;
+  flex: 1;
+  margin: 10px 0 0;
+
+  @media #{$tablet-landscape} {
+    margin: 0 20px;
+  }
+}
+
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.link {
+  line-height: $line-height-medium;
+  color: $dark-gray;
+  height: 1.62;
+  border-bottom: 1px solid $theme-secondary;
+}

--- a/app/javascript/app/components/disclaimer/disclaimer-styles.scss
+++ b/app/javascript/app/components/disclaimer/disclaimer-styles.scss
@@ -10,6 +10,13 @@
   background-color: $white;
   flex-direction: column;
 
+  &.onlyText {
+    box-shadow: none;
+    padding: 0;
+    background-color: transparent;
+    margin-top: 20px;
+  }
+
   @media #{$tablet-landscape} {
     padding: 20px;
     flex-direction: row;

--- a/app/javascript/app/components/disclaimer/disclaimer.js
+++ b/app/javascript/app/components/disclaimer/disclaimer.js
@@ -1,0 +1,26 @@
+import { createElement, PureComponent } from 'react';
+import Component from './disclaimer-component';
+
+class DisclaimerContainer extends PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      hasBeenShown: JSON.parse(localStorage.getItem('disclaimerShown'))
+    };
+  }
+
+  handleOnRequestClose() {
+    this.setState({ hasBeenShown: true });
+    localStorage.setItem('disclaimerShown', 'true');
+  }
+
+  render() {
+    return createElement(Component, {
+      hasBeenShown: this.state.hasBeenShown,
+      handleOnRequestClose: this.handleOnRequestClose.bind(this),
+      ...this.props
+    });
+  }
+}
+
+export default DisclaimerContainer;

--- a/app/javascript/app/components/disclaimer/disclaimer.js
+++ b/app/javascript/app/components/disclaimer/disclaimer.js
@@ -1,17 +1,18 @@
 import { createElement, PureComponent } from 'react';
+import { DISCLAIMER_SHOWN } from 'data/constants';
 import Component from './disclaimer-component';
 
 class DisclaimerContainer extends PureComponent {
   constructor() {
     super();
     this.state = {
-      hasBeenShown: JSON.parse(localStorage.getItem('disclaimerShown'))
+      hasBeenShown: JSON.parse(localStorage.getItem(DISCLAIMER_SHOWN))
     };
   }
 
   handleOnRequestClose() {
     this.setState({ hasBeenShown: true });
-    localStorage.setItem('disclaimerShown', 'true');
+    localStorage.setItem(DISCLAIMER_SHOWN, 'true');
   }
 
   render() {

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -109,7 +109,7 @@ class ModalMetadata extends PureComponent {
   }
 
   render() {
-    const { isOpen, title, tabTitles } = this.props;
+    const { isOpen, title, tabTitles, extraContent } = this.props;
     return (
       <CustomModal
         onRequestClose={this.handleOnRequestClose}
@@ -124,6 +124,9 @@ class ModalMetadata extends PureComponent {
         }
       >
         {this.getContent()}
+        {extraContent &&
+          Object.keys(extraContent).indexOf(title) > -1 &&
+          extraContent[title]}
       </CustomModal>
     );
   }
@@ -133,6 +136,7 @@ ModalMetadata.propTypes = {
   title: PropTypes.string,
   tabTitles: PropTypes.array,
   data: PropTypes.array,
+  extraContent: PropTypes.node,
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -29,8 +29,7 @@ class ModalMetadata extends PureComponent {
   }
 
   getContent() {
-    const { data, loading } = this.props;
-
+    const { data, loading, showDisclaimer, disclaimer } = this.props;
     if (loading) {
       return <Loading className={styles.loadingContainer} />;
     }
@@ -99,6 +98,7 @@ class ModalMetadata extends PureComponent {
             </a>
           </MetadataProp>
         )}
+        {showDisclaimer && disclaimer}
       </div>
     );
   }
@@ -109,7 +109,7 @@ class ModalMetadata extends PureComponent {
   }
 
   render() {
-    const { isOpen, title, tabTitles, extraContent } = this.props;
+    const { isOpen, title, tabTitles } = this.props;
     return (
       <CustomModal
         onRequestClose={this.handleOnRequestClose}
@@ -124,9 +124,6 @@ class ModalMetadata extends PureComponent {
         }
       >
         {this.getContent()}
-        {extraContent &&
-          Object.keys(extraContent).indexOf(title) > -1 &&
-          extraContent[title]}
       </CustomModal>
     );
   }
@@ -136,10 +133,15 @@ ModalMetadata.propTypes = {
   title: PropTypes.string,
   tabTitles: PropTypes.array,
   data: PropTypes.array,
-  extraContent: PropTypes.object,
+  disclaimer: PropTypes.node,
+  showDisclaimer: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
+};
+
+ModalMetadata.defaultProps = {
+  showDisclaimer: false
 };
 
 export default ModalMetadata;

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -136,7 +136,7 @@ ModalMetadata.propTypes = {
   title: PropTypes.string,
   tabTitles: PropTypes.array,
   data: PropTypes.array,
-  extraContent: PropTypes.node,
+  extraContent: PropTypes.object,
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired

--- a/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
@@ -3,6 +3,7 @@ export const initialState = {
   loading: false,
   isOpen: false,
   customTitle: '',
+  showDisclaimer: false,
   active: [],
   data: {}
 };
@@ -11,6 +12,7 @@ const setModalMetadataParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
   active: typeof payload.slugs === 'string' ? [payload.slugs] : payload.slugs,
+  showDisclaimer: payload.showDisclaimer || false,
   customTitle: payload.customTitle || state.title
 });
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata.js
@@ -16,7 +16,8 @@ const mapStateToProps = ({ modalMetadata }) => ({
   loading: modalMetadata.loading,
   title: getModalTitle(modalMetadata),
   tabTitles: getTabTitles(modalMetadata),
-  data: getModalData(modalMetadata)
+  data: getModalData(modalMetadata),
+  showDisclaimer: modalMetadata.showDisclaimer
 });
 
 const includeActions = withHandlers({

--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -5,7 +5,6 @@ import { themr } from 'react-css-themr';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import closeIcon from 'assets/icons/sidebar-close.svg';
-import ClickOutside from 'react-click-outside';
 import styles from './modal-styles.scss';
 
 class CustomModal extends PureComponent {
@@ -35,21 +34,20 @@ class CustomModal extends PureComponent {
     const modalStyles = { ...defaultStyles, ...customStyles };
 
     return (
-      <ClickOutside onClickOutside={onRequestClose}>
-        <Modal
-          className={{ base: styles.modal }}
-          style={modalStyles}
-          isOpen={isOpen}
-          contentLabel={contentLabel}
-          shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
-        >
-          {header}
-          <Button onClick={onRequestClose} className={theme.closeBtn} square>
-            <Icon icon={closeIcon} className={theme.close} />
-          </Button>
-          <div className={theme.content}>{children}</div>
-        </Modal>
-      </ClickOutside>
+      <Modal
+        className={{ base: styles.modal }}
+        style={modalStyles}
+        isOpen={isOpen}
+        contentLabel={contentLabel}
+        onRequestClose={onRequestClose}
+        shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+      >
+        {header}
+        <Button onClick={onRequestClose} className={theme.closeBtn} square>
+          <Icon icon={closeIcon} className={theme.close} />
+        </Button>
+        <div className={theme.content}>{children}</div>
+      </Modal>
     );
   }
 }

--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -5,6 +5,7 @@ import { themr } from 'react-css-themr';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import closeIcon from 'assets/icons/sidebar-close.svg';
+import ClickOutside from 'react-click-outside';
 import styles from './modal-styles.scss';
 
 class CustomModal extends PureComponent {
@@ -34,19 +35,21 @@ class CustomModal extends PureComponent {
     const modalStyles = { ...defaultStyles, ...customStyles };
 
     return (
-      <Modal
-        className={{ base: styles.modal }}
-        style={modalStyles}
-        isOpen={isOpen}
-        contentLabel={contentLabel}
-        shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
-      >
-        {header}
-        <Button onClick={onRequestClose} className={theme.closeBtn} square>
-          <Icon icon={closeIcon} className={theme.close} />
-        </Button>
-        <div className={theme.content}>{children}</div>
-      </Modal>
+      <ClickOutside onClickOutside={onRequestClose}>
+        <Modal
+          className={{ base: styles.modal }}
+          style={modalStyles}
+          isOpen={isOpen}
+          contentLabel={contentLabel}
+          shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+        >
+          {header}
+          <Button onClick={onRequestClose} className={theme.closeBtn} square>
+            <Icon icon={closeIcon} className={theme.close} />
+          </Button>
+          <div className={theme.content}>{children}</div>
+        </Modal>
+      </ClickOutside>
     );
   }
 }

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -178,8 +178,6 @@ export const CLIMATE_VULNERABILITY_DEFINITIONS = {
 };
 
 export const DISCLAIMER_SHOWN = 'disclaimerShown';
-export const COUNTRY_GHG_TITLE =
-  'Greenhouse Gas Emissions and Emissions Targets';
 
 export default {
   CALCULATION_OPTIONS,
@@ -194,6 +192,5 @@ export default {
   MIN_ZOOM_SHOW_ISLANDS,
   PATH_LAYERS,
   CLIMATE_VULNERABILITY_DEFINITIONS,
-  DISCLAIMER_SHOWN,
-  COUNTRY_GHG_TITLE
+  DISCLAIMER_SHOWN
 };

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -177,6 +177,8 @@ export const CLIMATE_VULNERABILITY_DEFINITIONS = {
     Source: IPCC, " Annex II: Glossary," 2014. [Online]. Available: http://www.ipcc.ch/pdf/assessment-report/ar5/wg3/ipcc_wg3_ar5_annex-ii.pdf`
 };
 
+export const DISCLAIMER_SHOWN = 'disclaimerShown';
+
 export default {
   CALCULATION_OPTIONS,
   TOP_EMITTERS,
@@ -189,5 +191,6 @@ export default {
   FILTERS_BY_CATEGORY,
   MIN_ZOOM_SHOW_ISLANDS,
   PATH_LAYERS,
-  CLIMATE_VULNERABILITY_DEFINITIONS
+  CLIMATE_VULNERABILITY_DEFINITIONS,
+  DISCLAIMER_SHOWN
 };

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -178,6 +178,8 @@ export const CLIMATE_VULNERABILITY_DEFINITIONS = {
 };
 
 export const DISCLAIMER_SHOWN = 'disclaimerShown';
+export const COUNTRY_GHG_TITLE =
+  'Greenhouse Gas Emissions and Emissions Targets';
 
 export default {
   CALCULATION_OPTIONS,
@@ -192,5 +194,6 @@ export default {
   MIN_ZOOM_SHOW_ISLANDS,
   PATH_LAYERS,
   CLIMATE_VULNERABILITY_DEFINITIONS,
-  DISCLAIMER_SHOWN
+  DISCLAIMER_SHOWN,
+  COUNTRY_GHG_TITLE
 };

--- a/app/javascript/app/pages/country/country-component.jsx
+++ b/app/javascript/app/pages/country/country-component.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import Sticky from 'react-stickynode';
 import { COUNTRY_PROFILES } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
-
+import { COUNTRY_GHG_TITLE } from 'data/constants';
 import Header from 'components/header';
 import CountryTimeline from 'components/country/country-timeline';
 import Intro from 'components/intro';
@@ -65,9 +65,7 @@ class Country extends PureComponent {
           ))}
         <ModalMetadata
           extraContent={{
-            'Greenhouse Gas Emissions and Emissions Targets': (
-              <Disclaimer onlyText />
-            )
+            [COUNTRY_GHG_TITLE]: <Disclaimer onlyText />
           }}
         />
       </div>

--- a/app/javascript/app/pages/country/country-component.jsx
+++ b/app/javascript/app/pages/country/country-component.jsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import Sticky from 'react-stickynode';
 import { COUNTRY_PROFILES } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
-import { COUNTRY_GHG_TITLE } from 'data/constants';
 import Header from 'components/header';
 import CountryTimeline from 'components/country/country-timeline';
 import Intro from 'components/intro';
@@ -63,11 +62,7 @@ class Country extends PureComponent {
               <section.component />
             </div>
           ))}
-        <ModalMetadata
-          extraContent={{
-            [COUNTRY_GHG_TITLE]: <Disclaimer onlyText />
-          }}
-        />
+        <ModalMetadata disclaimer={<Disclaimer onlyText />} />
       </div>
     );
   }

--- a/app/javascript/app/pages/country/country-component.jsx
+++ b/app/javascript/app/pages/country/country-component.jsx
@@ -11,6 +11,7 @@ import Intro from 'components/intro';
 import Button from 'components/button';
 import AnchorNav from 'components/anchor-nav';
 import ModalMetadata from 'components/modal-metadata';
+import Disclaimer from 'components/disclaimer';
 import SocioeconomicsProvider from 'providers/socioeconomics-provider';
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 
@@ -62,7 +63,13 @@ class Country extends PureComponent {
               <section.component />
             </div>
           ))}
-        <ModalMetadata />
+        <ModalMetadata
+          extraContent={{
+            'Greenhouse Gas Emissions and Emissions Targets': (
+              <Disclaimer onlyText />
+            )
+          }}
+        />
       </div>
     );
   }

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -2,6 +2,7 @@
 $font-family-1: 'Lato', sans-serif;
 
 // Font sizes
+$font-size-xs: 0.75rem; // 12px / 16px
 $font-size-s: 0.8125rem; // 13px / 16px
 $font-size-sm: 0.875rem; // 14px / 16px
 $font-size: 1rem; // 16px / 16px


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155740305
https://zpl.io/anrRogx

This PR adds a disclaimer to be shown in the country Greenhouse Gas Emissions and Emissions Targets Section only once per browser. So once the disclaimer is shown a variable is added in localStorage to prevent it from showing again.

The disclaimer is also shown at the end of the info modal of this section. As the country page share the same modal Component and it is not possible to select the right modal component rendered in one of the sections, the modal has an extraContent prop with the title of the modal as the key for the extra content. 

To test several times add
```localStorage.setItem('disclaimerShown', 'false');```
to line 7 in disclaimer.js just before the state declaration

---
Extra:

Add ClickOutside to Modal component so it will close if we click outside the modal.

![image](https://user-images.githubusercontent.com/9701591/37093349-55be6070-220f-11e8-870e-846d812316ba.png)

![image](https://user-images.githubusercontent.com/9701591/37093088-60e7d8ce-220e-11e8-814c-c1bc8bb367be.png)
