### PR TITLE
Feature/grid navigation and home

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   overflow: scroll;
 
-  @include overflowFix('large');
+  @include overflowFix(250px);
 
   padding-top: 260px;
 

--- a/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-styles.scss
@@ -16,7 +16,7 @@
 .timelineContainer {
   overflow-x: auto;
 
-  @include overflowFix('small');
+  @include overflowFix(80px);
 }
 
 .timeline { // overwriting timeline styles

--- a/app/javascript/app/components/footer/bottom-bar/bottom-bar-component.jsx
+++ b/app/javascript/app/components/footer/bottom-bar/bottom-bar-component.jsx
@@ -11,7 +11,7 @@ const BottomBar = ({ className }) => (
       <Link className={styles.text} to="/about/permissions">
         Permissions & Licensing
       </Link>
-      <span className={cx(styles.text, styles.right)}>
+      <span className={cx(styles.text, styles.align)}>
         Climate Watch © {new Date().getFullYear()} Powered by Resource Watch
       </span>
     </div>

--- a/app/javascript/app/components/footer/bottom-bar/bottom-bar-styles.scss
+++ b/app/javascript/app/components/footer/bottom-bar/bottom-bar-styles.scss
@@ -1,7 +1,11 @@
 @import '~styles/layout.scss';
 
 .row {
-  @include row(6);
+  @include row((4, 8));
+
+  @media #{$mobile-only} {
+    @include row(12);
+  }
 }
 
 .container {
@@ -31,6 +35,10 @@
   }
 }
 
-.right {
+.align {
   text-align: right;
+
+  @media #{$mobile-only} {
+    text-align: left;
+  }
 }

--- a/app/javascript/app/components/navbar-mobile/navbar-mobile-component.jsx
+++ b/app/javascript/app/components/navbar-mobile/navbar-mobile-component.jsx
@@ -21,7 +21,7 @@ const NavBarMobile = ({ closeMenu, hamburgerIsOpen, routes }) => (
       <Hamburger text={'MENU'} />
     </div>
     {hamburgerIsOpen && (
-      <div className={styles.fullMenu}>
+      <div className={styles.navigation}>
         <div className="grid-layout-element">
           <Nav
             routes={routes}

--- a/app/javascript/app/components/navbar-mobile/navbar-mobile-styles.scss
+++ b/app/javascript/app/components/navbar-mobile/navbar-mobile-styles.scss
@@ -29,7 +29,7 @@
   }
 }
 
-.fullMenu {
+.navigation {
   @include row((11, 1), $gridDirection: 'vertical');
 
   height: calc(100vh - #{$gutter-padding * 2});
@@ -38,6 +38,11 @@
 
 .navMenu {
   @include columns(2, $gridDirection: 'vertical');
+
+  > * {
+    position: relative;
+    width: fit-content;
+  }
 }
 
 .toolsContainer {

--- a/app/javascript/app/components/navbar/navbar-styles.scss
+++ b/app/javascript/app/components/navbar/navbar-styles.scss
@@ -17,4 +17,8 @@
 
   height: 100%;
   align-items: center;
+
+  > * {
+    flex-basis: auto;
+  }
 }

--- a/app/javascript/app/components/navbar/navbar-styles.scss
+++ b/app/javascript/app/components/navbar/navbar-styles.scss
@@ -2,15 +2,18 @@
 
 .row {
   @include row((10, 2));
+  height: $navbar-height;
 }
 
 .navigationWrapper {
   display: flex;
   align-items: center;
+  height: 100%;
 }
 
 .navigation {
   @include columns('auto');
 
+  height: 100%;
   align-items: center;
 }

--- a/app/javascript/app/components/navbar/navbar-styles.scss
+++ b/app/javascript/app/components/navbar/navbar-styles.scss
@@ -2,6 +2,7 @@
 
 .row {
   @include row((10, 2));
+
   height: $navbar-height;
 }
 

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -90,11 +90,15 @@ class Home extends PureComponent {
                   layout.screenshotMobileLayout
                 )}
               >
-                <img
-                  className={matches ? '' : styles.imageTall}
-                  src={matches ? countrySmScreenshot : countryBgScreenshot}
-                  alt="Country section screenshot"
-                />
+                <div className={matches ? styles.imgLayout : ''}>
+                  <div className={styles.imgContainer}>
+                    <img
+                      className={matches ? '' : styles.imageTall}
+                      src={matches ? countrySmScreenshot : countryBgScreenshot}
+                      alt="Country section screenshot"
+                    />
+                  </div>
+                </div>
               </div>
             )}
           </MobileOnly>
@@ -151,11 +155,13 @@ class Home extends PureComponent {
           <MobileOnly>
             {matches => (
               <div className={matches ? styles.ndcImageMobile : styles.column}>
-                <img
-                  className={matches ? '' : styles.imageRight}
-                  src={matches ? ndcSmScreenshot : ndcBgScreenshot}
-                  alt="Ndcs section screenshot"
-                />
+                <div className={styles.imgContainer}>
+                  <img
+                    className={matches ? '' : styles.imageRight}
+                    src={matches ? ndcSmScreenshot : ndcBgScreenshot}
+                    alt="Ndcs section screenshot"
+                  />
+                </div>
               </div>
             )}
           </MobileOnly>
@@ -176,11 +182,15 @@ class Home extends PureComponent {
                   layout.screenshotMobileLayout
                 )}
               >
-                <img
-                  className={matches ? '' : styles.imageRight}
-                  src={matches ? ndcSdgSmScreenshot : ndcSdgBgScreenshot}
-                  alt="NDC SDGs screenshot"
-                />
+                <div className={matches ? styles.imgLayout : ''}>
+                  <div className={styles.imgContainer}>
+                    <img
+                      className={matches ? '' : styles.imageRight}
+                      src={matches ? ndcSdgSmScreenshot : ndcSdgBgScreenshot}
+                      alt="NDC SDGs screenshot"
+                    />
+                  </div>
+                </div>
               </div>
             )}
           </MobileOnly>

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -38,7 +38,10 @@ class Home extends PureComponent {
     const { geolocation, countriesOptions, handleDropDownChange } = this.props;
     return (
       <div className={styles.homeBg}>
-        <Section className={styles.section} backgroundImage={background}>
+        <Section
+          className={cx(styles.section, styles.extraPadding)}
+          backgroundImage={background}
+        >
           <div className={cx(styles.column, styles.homeIntro)}>
             <Icon icon={cwLogo} className={styles.cwLogo} />
             <Intro description="Climate Watch offers open data, visualizations and analysis to help policymakers, researchers and other stakeholders gather insights on countries' climate progress." />

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -26,6 +26,7 @@ import theme from 'styles/themes/dropdown/dropdown-links.scss';
 import screenfull from 'screenfull';
 
 import introDark from 'styles/themes/intro/intro-dark.scss';
+import layout from 'styles/layout.scss';
 import styles from './home-styles.scss';
 
 class Home extends PureComponent {
@@ -76,22 +77,24 @@ class Home extends PureComponent {
             />
           </div>
         </Section>
-        <div className={cx(styles.storiesLayout, styles.section)}>
+        <div className={cx(layout.content, styles.section)}>
           <Stories />
         </div>
         <Section className={cx(styles.section, styles.countries)}>
           <MobileOnly>
-            {isMobile => (
-              <div className={cx(styles.column, styles.invertOrder)}>
-                <div className={styles.imgLayout}>
-                  <div className="grid-column">
-                    <img
-                      className={isMobile ? '' : styles.imageTall}
-                      src={isMobile ? countrySmScreenshot : countryBgScreenshot}
-                      alt="Country section screenshot"
-                    />
-                  </div>
-                </div>
+            {matches => (
+              <div
+                className={cx(
+                  styles.column,
+                  styles.invertOrder,
+                  layout.screenshotMobileLayout
+                )}
+              >
+                <img
+                  className={matches ? '' : styles.imageTall}
+                  src={matches ? countrySmScreenshot : countryBgScreenshot}
+                  alt="Country section screenshot"
+                />
               </div>
             )}
           </MobileOnly>
@@ -166,7 +169,13 @@ class Home extends PureComponent {
         >
           <MobileOnly>
             {matches => (
-              <div className={cx(styles.column, styles.invertOrder)}>
+              <div
+                className={cx(
+                  styles.column,
+                  styles.invertOrder,
+                  layout.screenshotMobileLayout
+                )}
+              >
                 <img
                   className={matches ? '' : styles.imageRight}
                   src={matches ? ndcSdgSmScreenshot : ndcSdgBgScreenshot}

--- a/app/javascript/app/pages/home/home-styles.scss
+++ b/app/javascript/app/pages/home/home-styles.scss
@@ -2,7 +2,11 @@
 @import '~styles/layout.scss';
 
 .doubleFold {
-  @include columns(6);
+  @include columns(12);
+
+  @media #{$tablet-portrait} {
+    @include columns(6);
+  }
 }
 
 .storiesLayout {
@@ -10,17 +14,17 @@
 }
 
 .imgLayout {
-  @include columns(8);
+  @include columns(12);
 
   > *:first-child {
-    @include column-offset(2);
+    @include column-offset(0);
   }
 
-  @media #{$tablet-portrait} {
-    @include columns(12);
+  @media #{$mobile-only} {
+    @include columns(8);
 
     > *:first-child {
-      @include column-offset(0);
+      @include column-offset(2);
     }
   }
 }
@@ -124,6 +128,7 @@
 
 .countries {
   display: flex;
+  padding-bottom: 0;
 }
 
 .sdgLinkages {
@@ -143,10 +148,21 @@
 
 .invertOrder {
   order: 2;
-  margin: 0 auto;
+  margin-bottom: 0;
 
   @media #{$tablet-landscape} {
     order: initial;
+  }
+}
+
+.imgContainer {
+  @media #{$tablet-portrait} {
+    display: flex;
+    justify-content: center;
+  }
+
+  @media #{$tablet-landscape} {
+    display: block;
   }
 }
 

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -25,7 +25,7 @@ $grid-padding-gutters: $gutter-padding;
 }
 
 @mixin columns($columns: full, $wrap: true, $gutters: true, $gridDirection: 'horizontal') {
-  @include xy-grid($wrap: $wrap);
+  @include xy-grid($wrap: $wrap, $direction: $gridDirection);
   $negative: true;
   $gutters-value: $grid-margin-gutters;
 
@@ -66,10 +66,10 @@ $grid-padding-gutters: $gutter-padding;
   @else {
     > * {
       @if $gridDirection == 'vertical' {
-        @include xy-cell('full');
-        @include xy-cell($columns, $vertical: true);
-        @include xy-gutters($gutter-position: ('top', 'bottom'));
-      }
+          @include xy-cell('full');
+          @include xy-cell($columns, $vertical: true);
+          @include xy-gutters($gutter-position: ('top', 'bottom'));
+        }
 
       @else {
         @include xy-cell($columns, $gutters: $gutters);

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -140,13 +140,6 @@ $grid-padding-gutters: $gutter-padding;
 }
 // the overflow-x scroll prevents the overflow-y to be visible so we need this hack to keep the dropdowns visible
 @mixin overflowFix($size) {
-  @if $size=='small' {
-    padding-top: 100px;
-    margin-top: -100px;
-  }
-
-  @if $size=='large' {
-    padding-top: 250px;
-    margin-top: -250px;
-  }
+  padding-top: $size;
+  margin-top: -#{$size};
 }

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -66,10 +66,10 @@ $grid-padding-gutters: $gutter-padding;
   @else {
     > * {
       @if $gridDirection == 'vertical' {
-          @include xy-cell('full');
-          @include xy-cell($columns, $vertical: true);
-          @include xy-gutters($gutter-position: ('top', 'bottom'));
-        }
+        @include xy-cell('full');
+        @include xy-cell($columns, $vertical: true);
+        @include xy-gutters($gutter-position: ('top', 'bottom'));
+      }
 
       @else {
         @include xy-cell($columns, $gutters: $gutters);

--- a/app/javascript/app/styles/layout.scss
+++ b/app/javascript/app/styles/layout.scss
@@ -79,7 +79,7 @@ $grid-padding-gutters: $gutter-padding;
 }
 
 .content {
-  @include row();
+  @include row(12);
 }
 
 %grid {


### PR DESCRIPTION
This PR implements newly created `xy-grid` mixins both on home page and on top navigation.  
Mixins could be found on `layout.scss` file.  
Mainly two mixins could be used when creating grid elements on the page:  
  ##### `row($columns: full, $wrap: true, $gridDirection: 'horizontal')`   
  - This mixin creates a row where by default all its columns will grow to fill the 100% of the available space.  
  - The argument `$columns` accepts a keyword (`full`, `auto`, `shrink`) a number from `1` to `12` (to set the calculated width of each column) or a `list` (to define the width of each column *e.g*: `(8, 4)`).
  - `$wrap` accepts a `boolean` that defines if the items should wrap.
  - `$gridDirection` parameter could be set to `vertical` to made the grid calculate the height of the items instead of the width. 
##### `columns($columns: full, $wrap: true, $gutters: true, $gridDirection: 'horizontal')` 
  -This mixin works as `row()` mixin except that it is used only on inner rows (rows inside columns), and the main difference is that it collapses external gutters to align the inner row to the outter row. 
