### PR TITLE
Fix simple-select input with opacity 0

### DIFF
--- a/app/javascript/app/components/multiselect/multiselect-styles.scss
+++ b/app/javascript/app/components/multiselect/multiselect-styles.scss
@@ -57,7 +57,7 @@
   }
 }
 
-:global .react-selectize-search-field-and-selected-values .resizable-input {
+:global .multi-select .react-selectize-search-field-and-selected-values .resizable-input {
   opacity: 0;
 }
 


### PR DESCRIPTION
This is a cherry-pick from a commit done in grid-update:

The global tag was changing the simple-select as well as the multi-select. So the text was not displayed