### PR TITLE
Fix bugs: font, graph, selector

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -72,7 +72,8 @@ class ChartLine extends PureComponent {
       margin,
       domain,
       forceTwoDecimals,
-      espGraph
+      espGraph,
+      noConnectNulls
     } = this.props;
     const unit =
       espGraph &&
@@ -148,6 +149,7 @@ class ChartLine extends PureComponent {
                   dataKey={column.value}
                   stroke={color}
                   strokeWidth={2}
+                  connectNulls={!noConnectNulls}
                 />
               );
             })}
@@ -179,13 +181,15 @@ ChartLine.propTypes = {
   forceTwoDecimals: PropTypes.bool,
   margin: PropTypes.object,
   domain: PropTypes.object,
-  espGraph: PropTypes.bool.isRequired
+  espGraph: PropTypes.bool.isRequired,
+  noConnectNulls: PropTypes.bool.isRequired
 };
 
 ChartLine.defaultProps = {
   height: '100%',
   onMouseMove: () => {},
-  espGraph: false
+  espGraph: false,
+  noConnectNulls: false
 };
 
 export default ChartLine;

--- a/app/javascript/app/components/compare-ghg-chart/compare-ghg-chart-component.jsx
+++ b/app/javascript/app/components/compare-ghg-chart/compare-ghg-chart-component.jsx
@@ -110,6 +110,7 @@ class CompareGhgChart extends PureComponent {
             height={500}
             loading={loading}
             hideRemoveOptions
+            noConnectNulls
           />
           <TabletPortraitOnly>
             <div className={cx(styles.buttonGroup, styles.col2)}>

--- a/app/javascript/app/components/nav/nav-styles.scss
+++ b/app/javascript/app/components/nav/nav-styles.scss
@@ -34,6 +34,7 @@
   letter-spacing: 1px;
   padding-top: 20px;
   position: relative;
+  font-family: $font-family-1;
 
   &.active::after {
     content: "";


### PR DESCRIPTION
- Use Lato always for nav menu
https://www.pivotaltracker.com/story/show/155853080
![image](https://user-images.githubusercontent.com/9701591/37298709-55b4a27c-2621-11e8-8c1d-42105b49aa9d.png)

- Dont connect null values in Compare graph
https://www.pivotaltracker.com/story/show/155852149
![image](https://user-images.githubusercontent.com/9701591/37298688-415831f4-2621-11e8-9e63-20e1568ed259.png)

- Fix compare selector styles. I can't reproduce the problem with the missing country names. Please let me know if you can
https://www.pivotaltracker.com/story/show/155852077
![image](https://user-images.githubusercontent.com/9701591/37299356-549334ec-2623-11e8-89b1-055c69f22e21.png)
