### PR TITLE
Fix Country GHG sectors - Always use AR4 if possible

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -117,7 +117,10 @@ export const getVersionSelected = createSelector(
   [getVersionOptions, getVersionSelection],
   (versions, selected) => {
     if (!versions || !versions.length) return {};
-    if (!selected) return versions[0];
+    if (!selected) {
+      const AR4Version = versions.find(version => version.label === 'AR4');
+      return AR4Version || versions[0];
+    }
     return versions.find(version => version.value === parseInt(selected, 10));
   }
 );
@@ -125,7 +128,7 @@ export const getVersionSelected = createSelector(
 export const getAllowedSectors = createSelector(
   [getSourceSelected, getVersionSelected],
   (source, version) => {
-    if (!source || !version) return null;
+    if (!source || isEmpty(source) || !version || isEmpty(version)) return null;
     if (source.label === 'UNFCCC') {
       return ALLOWED_SECTORS_BY_SOURCE[source.label][version.label];
     }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -116,7 +116,7 @@ export const getVersionOptions = createSelector(
 export const getVersionSelected = createSelector(
   [getVersionOptions, getVersionSelection],
   (versions, selected) => {
-    if (!versions || !versions.length) return {};
+    if (!versions || !versions.length) return null;
     if (!selected) {
       const AR4Version = versions.find(version => version.label === 'AR4');
       return AR4Version || versions[0];
@@ -128,7 +128,7 @@ export const getVersionSelected = createSelector(
 export const getAllowedSectors = createSelector(
   [getSourceSelected, getVersionSelected],
   (source, version) => {
-    if (!source || isEmpty(source) || !version || isEmpty(version)) return null;
+    if (!source || !version) return null;
     if (source.label === 'UNFCCC') {
       return ALLOWED_SECTORS_BY_SOURCE[source.label][version.label];
     }


### PR DESCRIPTION
https://basecamp.com/1756858/projects/13795275/todos/343578930
We were selecting AR2 instead of AR4 by default and the allowed sectors are different for each version so they weren't showing. Now we select AR4 by default.

![image](https://user-images.githubusercontent.com/9701591/37352336-506212fc-26dd-11e8-8a09-a56592370d49.png)
