### PR TITLE
Staging - Use named params to keep category

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -13,7 +13,8 @@ const fetchNdcsCountryAccordionFailed = createAction(
 
 const fetchNdcsCountryAccordion = createThunkAction(
   'fetchNdcsCountryAccordion',
-  (locations, category, compare) => dispatch => {
+  params => dispatch => {
+    const { locations, category, compare } = params;
     if (locations) {
       dispatch(fetchNdcsCountryAccordionInit());
       fetch(

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -44,7 +44,7 @@ class NdcsCountryAccordionContainer extends PureComponent {
       compare
     } = this.props;
     const locations = iso || search.locations;
-    fetchNdcsCountryAccordion(locations, category, compare);
+    fetchNdcsCountryAccordion({ locations, category, compare });
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
The category prop was not loading in staging. It's a strange issue. I cant find out why only in staging, with the same code, the createThunkAction was only accepting the first parameter. It's working now. Let me know if you have a better solution