### PR TITLE
Add missing div to avoid search jump

### DIFF
--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -49,25 +49,26 @@ class NDCCountry extends PureComponent {
               <div className={styles.title}>
                 <Intro title={country.wri_standard_name} />
               </div>
-              {documentsOptions &&
-                (documentsOptions.length > 1 ? (
-                  <Dropdown
-                    className={theme.dropdownOptionWithArrow}
-                    placeholder="Select a document"
-                    options={documentsOptions}
-                    onValueChange={handleDropDownChange}
-                    white
-                    hideResetButton
-                  />
-                ) : (
-                  <Button
-                    color="yellow"
-                    link={`/ndcs/country/${match.params.iso}/full`}
-                  >
-                    {`View ${documentsOptions[0].label} Document`}
-                  </Button>
-                ))}
-              {/* </div> */}
+              <div>
+                {documentsOptions &&
+                  (documentsOptions.length > 1 ? (
+                    <Dropdown
+                      className={theme.dropdownOptionWithArrow}
+                      placeholder="Select a document"
+                      options={documentsOptions}
+                      onValueChange={handleDropDownChange}
+                      white
+                      hideResetButton
+                    />
+                  ) : (
+                    <Button
+                      color="yellow"
+                      link={`/ndcs/country/${match.params.iso}/full`}
+                    >
+                      {`View ${documentsOptions[0].label} Document`}
+                    </Button>
+                  ))}
+              </div>
               <TabletLandscape>
                 <Button
                   color="yellow"


### PR DESCRIPTION
This PR fixes a layout bug that causes a jump on `ndcs/country` page header on first load as defined in [this pivotal ticket](https://www.pivotaltracker.com/n/projects/2083759).  
![kapture 2018-03-16 at 9 55 56 1](https://user-images.githubusercontent.com/6906348/37588017-422fe898-2b61-11e8-9b20-995bd50304a5.gif)

**To review the PR join `http://localhost:3000/ndcs/country/:iso`**
 