### PR TITLE
quantification text display

### DIFF
--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -92,6 +92,7 @@ class ChartStackedArea extends PureComponent {
     if (!data.length) return null;
 
     const maxData = getMaxValue(data, config);
+    const isEdgeBrowser = navigator.userAgent.indexOf('Edge') !== -1;
 
     let dataParsed = data;
     if (includeTotalLine) {
@@ -192,7 +193,7 @@ class ChartStackedArea extends PureComponent {
                 fontSize="13px"
                 offset={25}
                 stroke="#fff"
-                strokeWidth={8}
+                strokeWidth={isEdgeBrowser ? 0 : 8}
                 style={{ paintOrder: 'stroke' }}
               />
               <Label
@@ -201,7 +202,7 @@ class ChartStackedArea extends PureComponent {
                 fill="#113750"
                 fontSize="18px"
                 stroke="#fff"
-                strokeWidth={8}
+                strokeWidth={isEdgeBrowser ? 0 : 8}
                 style={{ paintOrder: 'stroke' }}
               />
             </ReferenceDot>
@@ -222,7 +223,7 @@ class ChartStackedArea extends PureComponent {
                   position="top"
                   fill="#8f8fa1"
                   stroke="#fff"
-                  strokeWidth={8}
+                  strokeWidth={isEdgeBrowser ? 0 : 8}
                   style={{ paintOrder: 'stroke' }}
                   fontSize="13px"
                   offset={25}
@@ -240,7 +241,7 @@ class ChartStackedArea extends PureComponent {
                   value={valueLabelValue}
                   position="top"
                   stroke="#fff"
-                  strokeWidth={4}
+                  strokeWidth={isEdgeBrowser ? 0 : 4}
                   style={{ paintOrder: 'stroke' }}
                   fill="#113750"
                   fontSize="18px"
@@ -292,7 +293,7 @@ class ChartStackedArea extends PureComponent {
                         position="top"
                         fill="#8f8fa1"
                         stroke="#fff"
-                        strokeWidth={8}
+                        strokeWidth={isEdgeBrowser ? 0 : 8}
                         style={{ paintOrder: 'stroke' }}
                         fontSize="13px"
                         offset={25}
@@ -305,7 +306,7 @@ class ChartStackedArea extends PureComponent {
                         position="top"
                         fill="#8f8fa1"
                         stroke="#fff"
-                        strokeWidth={8}
+                        strokeWidth={isEdgeBrowser ? 0 : 8}
                         style={{ paintOrder: 'stroke' }}
                         fontSize="13px"
                         offset={8}


### PR DESCRIPTION
This PR addresses the issue described in [this basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/338709068). On GHG emissions chart (on Edge browser) reference dot label was not displaying.  That was caused by the lack of support of [`paint-order`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order) attribute of SVG on Edge browser.  
The approach taken has been to create a flag that conditionally handles the `stroke-width`  of the label text to avoid that the white `stroke` covers the colored `fill`.  In other browses the original design is respected.  
  
