### PR TITLE
Fix/pathways graph scale issue

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -135,6 +135,8 @@ class ChartLine extends PureComponent {
           <YAxis
             axisLine={false}
             tickLine={false}
+            scale="linear"
+            type="number"
             tick={
               <CustomizedYAxisTick
                 espGraph={espGraph}

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -34,7 +34,8 @@ const CustomizedXAxisTick = ({ x, y, payload }) => (
 
 const getYLabelformat = (unit, espGraph, precision, value) => {
   const wholeDigitsNumber = String(Math.abs(Math.trunc(value))).length;
-  const precisionNumber = espGraph && precision ? precision : wholeDigitsNumber;
+  const wholePrecision = wholeDigitsNumber < 2 ? 2 : wholeDigitsNumber;
+  const precisionNumber = espGraph && precision ? precision : wholePrecision;
   let typeValue = unit ? 'r' : 's';
   if (precision) typeValue = 'f';
   const suffix = unit ? '' : 't';

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -33,13 +33,18 @@ const CustomizedXAxisTick = ({ x, y, payload }) => (
 );
 
 const getYLabelformat = (unit, espGraph, precision, value) => {
-  const wholeDigitsNumber = String(Math.abs(Math.trunc(value))).length;
-  const wholePrecision = wholeDigitsNumber < 2 ? 2 : wholeDigitsNumber;
-  const precisionNumber = espGraph && precision ? precision : wholePrecision;
-  let typeValue = unit ? 'r' : 's';
+  let precisionNumber = '.2s';
+  if (espGraph) {
+    const wholeDigitsNumber = String(Math.abs(Math.trunc(value))).length;
+    const wholePrecision = wholeDigitsNumber < 2 ? 2 : wholeDigitsNumber;
+    precisionNumber = precision || wholePrecision;
+  }
+  let typeValue = espGraph && unit ? 'r' : 's';
   if (precision) typeValue = 'f';
   const suffix = unit ? '' : 't';
-  return `${format(`.${precisionNumber}${typeValue}`)(value)}${suffix}`;
+  return `${format(`.${espGraph ? precisionNumber : 2}${typeValue}`)(
+    value
+  )}${suffix}`;
 };
 
 const CustomizedYAxisTick = ({

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -33,11 +33,12 @@ const CustomizedXAxisTick = ({ x, y, payload }) => (
 );
 
 const getYLabelformat = (unit, espGraph, precision, value) => {
-  const decimals = espGraph && precision ? precision : '2';
+  const wholeDigitsNumber = String(Math.abs(Math.trunc(value))).length;
+  const precisionNumber = espGraph && precision ? precision : wholeDigitsNumber;
   let typeValue = unit ? 'r' : 's';
   if (precision) typeValue = 'f';
   const suffix = unit ? '' : 't';
-  return `${format(`.${decimals}${typeValue}`)(value)}${suffix}`;
+  return `${format(`.${precisionNumber}${typeValue}`)(value)}${suffix}`;
 };
 
 const CustomizedYAxisTick = ({

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -7,7 +7,7 @@ import styles from './tooltip-chart-styles.scss';
 
 class TooltipChart extends PureComponent {
   getFormat() {
-    return this.props.forceTwoDecimals ? '.2f' : '.2s';
+    return this.props.forceFourDecimals ? '.4f' : '.2s';
   }
 
   getTotal = (keys, data, unitIsCo2) => {
@@ -111,7 +111,7 @@ TooltipChart.propTypes = {
   content: Proptypes.object,
   config: Proptypes.object,
   showTotal: Proptypes.bool,
-  forceTwoDecimals: Proptypes.bool
+  forceFourDecimals: Proptypes.bool
 };
 
 export default TooltipChart;

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -150,7 +150,7 @@ class EmissionPathwayGraph extends PureComponent {
             loading={loading}
             error={error}
             targetParam="scenario"
-            forceTwoDecimals
+            forceFourDecimals
             margin={{ top: 50 }}
             espGraph
           />

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -13,7 +13,7 @@ import reducers, { initialState } from './emission-pathways-graph-reducers';
 import EmissionPathwayGraphComponent from './emission-pathways-graph-component';
 import {
   getChartData,
-  getChartDomain,
+  getChartDomainWithYMargins,
   getChartConfig,
   getFiltersOptions,
   getFiltersSelected,
@@ -57,7 +57,7 @@ const mapStateToProps = (state, { location }) => {
   const filtersSelected = getFiltersSelected(espData);
   return {
     data: getChartData(espData),
-    domain: getChartDomain(espData),
+    domain: getChartDomainWithYMargins(espData),
     config: getChartConfig(espData),
     filtersLoading: {
       timeseries: state.espTimeSeries.loading,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -13,7 +13,7 @@ import reducers, { initialState } from './emission-pathways-graph-reducers';
 import EmissionPathwayGraphComponent from './emission-pathways-graph-component';
 import {
   getChartData,
-  getChartXDomain,
+  getChartDomain,
   getChartConfig,
   getFiltersOptions,
   getFiltersSelected,
@@ -57,7 +57,7 @@ const mapStateToProps = (state, { location }) => {
   const filtersSelected = getFiltersSelected(espData);
   return {
     data: getChartData(espData),
-    domain: getChartXDomain(espData),
+    domain: getChartDomain(espData),
     config: getChartConfig(espData),
     filtersLoading: {
       timeseries: state.espTimeSeries.loading,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156008127
- Connect nulls again in all charts
- Fix n/a in 0 values
- Sort Compare graph data to fix some display error (This was already added)
- Use 4 decimals in the tooltip for Pathways chart
- Calculate precision needed within the domain of the values of the Pathways chart
- Change the format to always display the needed precision in the Y-axis ticks
- Apply margin offset needed for that precision
- Add margins to y-domain to represent the little difference between close values

![image](https://user-images.githubusercontent.com/9701591/37607196-a5ca45e8-2b97-11e8-994a-6e1c1139a855.png)
