### PR TITLE
fix chart label without dot

### DIFF
--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -42,9 +42,11 @@ export const getThemeConfig = (columns, colors) => {
   const theme = {};
   columns.forEach((column, i) => {
     const index = column.index || i;
+    const correctedIndex =
+      index < colors.length ? index : index - colors.length;
     theme[column.value] = {
-      stroke: colors[index],
-      fill: colors[index]
+      stroke: colors[correctedIndex],
+      fill: colors[correctedIndex]
     };
   });
   return theme;


### PR DESCRIPTION
This PR avoids the creation of tags without colour dot on `ghg-emissions` when adding more countries than existing colours on the `CHART_COLORS` constant.  
  #### before 
![kapture 2018-03-20 at 12 28 05](https://user-images.githubusercontent.com/6906348/37651971-3993cf86-2c3a-11e8-8378-6aea1f257bab.gif)

  #### after  
![kapture 2018-03-20 at 12 33 14](https://user-images.githubusercontent.com/6906348/37652291-4f4fd58a-2c3b-11e8-9593-22becf1185fd.gif)


