### PR TITLE
Staging - Search component should have the query as a 'value' prop

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-scenario-table/emission-pathways-scenario-table-component.jsx
@@ -91,7 +91,7 @@ class EmissionPathwaysScenarioTableComponent extends PureComponent {
               value={selectedCategory}
             />
             <Search
-              input={query}
+              value={query}
               theme={darkSearch}
               onChange={handleSearchChange}
               placeholder={'Search by all fields'}

--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-component.jsx
@@ -99,7 +99,7 @@ class EmissionPathwaysTable extends PureComponent {
                 <div className="grid-column-item">
                   <div className={styles.searchLayout}>
                     <Search
-                      input={query}
+                      value={query}
                       theme={darkSearch}
                       onChange={handleSearchChange}
                       placeholder={`Search in ${categoryName}`}

--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
@@ -68,7 +68,7 @@ class NdcsAutocompleteSearch extends PureComponent {
             theme={dark ? darkSearch : lightSearch}
             className={label ? styles.search : ''}
             placeholder="e.g. “reduce emissions by 37%”"
-            input={search.searchBy === 'query' ? search.query : ''}
+            value={search.searchBy === 'query' ? search.query : ''}
             handleKeyUp={handleKeyUp}
           />
         </div>

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -81,7 +81,7 @@ class NDCCountry extends PureComponent {
               <Search
                 theme={lightSearch}
                 placeholder="Search"
-                input={search}
+                value={search}
                 onChange={onSearchChange}
               />
             </div>


### PR DESCRIPTION
In NDC search the searched query from the NDC content page was not appearing in the search box
This happened because sometimes we used input instead of value for the search component.
I will create another PR for develop to standardize the prop name as 'value'

![image](https://user-images.githubusercontent.com/9701591/38363941-d62c5496-38d6-11e8-957c-d41739c3ed9c.png)
