### PR TITLE
https gfw env

### DIFF
--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           - name: GFW_API
             value: "https://production-api.globalforestwatch.org"
           - name: CORS_WHITELIST
-            value: http://www.globalforestwatch.org
+            value: https://www.globalforestwatch.org
 
         ports:
           - containerPort: 3000


### PR DESCRIPTION
GFW is now HTTPS friendly. So should your API whitelist.