### PR TITLE
Add cleanup task to SDGs goals and targets import.

### DIFF
--- a/app/services/import_sdgs.rb
+++ b/app/services/import_sdgs.rb
@@ -3,11 +3,18 @@ class ImportSdgs
   SDG_TARGETS_FILEPATH = "#{CW_FILES_PREFIX}sdgs/sdg_targets.csv"
 
   def call
+    cleanup
+
     import_sdgs(S3CSVReader.read(SDGS_FILEPATH))
     import_sdg_targets(S3CSVReader.read(SDG_TARGETS_FILEPATH))
   end
 
   private
+
+  def cleanup
+    NdcSdg::Target.delete_all
+    NdcSdg::Goal.delete_all
+  end
 
   def import_sdgs(content)
     content.each.with_index(2) do |row|


### PR DESCRIPTION
There was a stray target on my local database, as well as staging and
production, and it was going to stay there until the end of times,
because we didn't have the cleanup method on this import.

Now we have, so we should be all good.

We will need to run the sdg related tasks after deploy:

```
rails sdgs:import ndc_sdg_targets:import
```

We need both, as this import will regenerate the ids of the SDG goals and targets.

This fixes this issue: https://www.pivotaltracker.com/story/show/156570488