### PR TITLE
Fix ndc compare update

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -52,7 +52,11 @@ class NdcsCountryAccordionContainer extends PureComponent {
     const newLocations = qs.parse(nextProps.location.search).locations;
     const oldLocations = qs.parse(this.props.location.search).locations;
     if (newLocations !== oldLocations) {
-      fetchNdcsCountryAccordion(newLocations, nextProps.category, compare);
+      fetchNdcsCountryAccordion({
+        locations: newLocations,
+        category: nextProps.category,
+        compare
+      });
     }
   }
 


### PR DESCRIPTION
Little PR fixing the update in the NDC compare country selectors. It was not updating when we added a country until we changed the tab. This was due to a change of format in the createThunkAction which now only accepts one param. So all the params that are passed to the actions must be inside an object.

![image](https://user-images.githubusercontent.com/9701591/38610114-27d4372a-3d80-11e8-8a20-f1db11cbb0e9.png)
