### PR TITLE
Add definitioin on pathways indicators default columns

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-table/emission-pathways-table-selectors.js
@@ -27,7 +27,7 @@ export const getDefaultColumns = createSelector([getCategory], category => {
     case 'scenarios':
       return ['model', 'name', 'category', 'url'];
     case 'indicators':
-      return ['category', 'subcategory', 'name'];
+      return ['category', 'subcategory', 'name', 'definition'];
     default:
       return null;
   }


### PR DESCRIPTION
This PR is a small change to add `definition` as a default field on `/pathways/indicators` table .  
[Pivotal task](https://www.pivotaltracker.com/n/projects/2083759/stories/156723677)
[Basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/340176518#comment_613270670) . 
Check it on [`http://localhost:3000/pathways/indicators`](http://localhost:3000/pathways/indicators)