### PR TITLE
Move timeline to last year on start

### DIFF
--- a/app/javascript/app/components/country/country-timeline/country-timeline-component.jsx
+++ b/app/javascript/app/components/country/country-timeline/country-timeline-component.jsx
@@ -10,7 +10,7 @@ class CountryTimeline extends PureComponent {
   constructor() {
     super();
     this.state = {
-      index: 0,
+      index: null,
       previous: 0,
       open: false
     };
@@ -62,7 +62,7 @@ class CountryTimeline extends PureComponent {
           </h3>
           {documentYears ? (
             <HorizontalTimeline
-              index={this.state.index}
+              index={this.state.index || documentYears.length - 1}
               indexClick={index => {
                 this.setState({
                   index,


### PR DESCRIPTION
When entering the Country pages the documents timeline should move to the last year available
I've tried to find some other solution but the library doesn't have an initial index attribute. If its not enough I could try forking the react-horizontal-timeline repository:
https://github.com/sherubthakur/react-horizontal-timeline

![image](https://user-images.githubusercontent.com/9701591/38678296-e365a240-3e60-11e8-93fa-d8d1c923e618.png)
