### PR TITLE
Fix/ndc search map documents

### DIFF
--- a/app/controllers/api/v1/ndc_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_texts_controller.rb
@@ -2,7 +2,8 @@ module Api
   module V1
     class NdcTextsController < ApiController
       def index
-        total_count = Ndc.all.count
+        total_ndc_count = Ndc.all.where(document_type: 'ndc').count
+        total_indc_count = Ndc.all.where(document_type: 'indc').count
         ndcs = Ndc.includes(:location)
         ndcs =
           if params[:target] || params[:goal] || params[:sector]
@@ -17,7 +18,11 @@ module Api
                adapter: :json,
                each_serializer: Api::V1::NdcTextSearchResultSerializer,
                params: params,
-               meta: {total_count: total_count}
+               meta:
+                 {
+                   total_ndc_count: total_ndc_count,
+                   total_indc_count: total_indc_count
+                 }
       end
 
       def show
@@ -111,17 +116,9 @@ module Api
         include_not_matched = true
       )
         unless include_not_matched
-          if params[:target]
-            ndcs = ndcs.where(id: ::NdcSdg::Target.ndc_ids(params[:target]))
-          end
-
-          if params[:goal]
-            ndcs = ndcs.where(id: ::NdcSdg::Goal.ndc_ids(params[:goal]))
-          end
-
-          if params[:sector]
-            ndcs = ndcs.where(id: ::NdcSdg::Sector.ndc_ids(params[:sector]))
-          end
+          ndcs = ndcs.where(id: ::NdcSdg::Target.ndc_ids(params[:target])) if params[:target]
+          ndcs = ndcs.where(id: ::NdcSdg::Goal.ndc_ids(params[:goal])) if params[:goal]
+          ndcs = ndcs.where(id: ::NdcSdg::Sector.ndc_ids(params[:sector])) if params[:sector]
         end
 
         linkages = Ndc.linkages(params)

--- a/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
@@ -12,7 +12,7 @@ export const getTotalCountriesNumber = state =>
 export const getTotalDocumentsNumber = createSelector(
   [state => state.meta, getDocument],
   (meta, document) => {
-    if (!meta || !document) return null;
+    if (!meta) return null;
     return document && document !== 'all'
       ? meta[`total_${document}_count`]
       : meta.total_ndc_count + meta.total_indc_count;

--- a/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
@@ -6,10 +6,18 @@ import uniq from 'lodash/uniq';
 const getResultsData = state => state.data || [];
 const getLoading = state => state.loading || null;
 const getDocument = state => state.search.document || null;
-export const getTotalDocumentsNumber = state =>
-  (state.meta && state.meta.total_count) || null;
 export const getTotalCountriesNumber = state =>
   (state.countriesData && state.countriesData.length) || null;
+
+export const getTotalDocumentsNumber = createSelector(
+  [state => state.meta, getDocument],
+  (meta, document) => {
+    if (!meta || !document) return null;
+    return document && document !== 'all'
+      ? meta[`total_${document}_count`]
+      : meta.total_ndc_count + meta.total_indc_count;
+  }
+);
 
 const getIncludedDocumentsResults = createSelector(
   [getResultsData, getDocument],

--- a/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-search-map/ndcs-search-map-selectors.js
@@ -21,10 +21,13 @@ const getIncludedDocumentsResults = createSelector(
   }
 );
 
-const getIncludedCountries = createSelector([getResultsData], results => {
-  if (!results || !results.length) return [];
-  return uniq(results.map(result => result.location.iso_code3));
-});
+const getIncludedCountries = createSelector(
+  [getIncludedDocumentsResults],
+  results => {
+    if (!results || !results.length) return [];
+    return uniq(results.map(result => result.location.iso_code3));
+  }
+);
 
 export const getIncludedDocumentsCount = createSelector(
   [getIncludedDocumentsResults],

--- a/spec/controllers/api/v1/ndc_texts_controller_spec.rb
+++ b/spec/controllers/api/v1/ndc_texts_controller_spec.rb
@@ -75,6 +75,12 @@ Hello fermentum quam et nunc finibus, ac tincidunt urna mollis."
       ndcs = json_response['ndcs']
       expect(ndcs.first['matches'].last['idx']).to equal(2)
     end
+    it 'returns ndc and indc total document count as metadata' do
+      get :index
+      json_response = JSON.parse(response.body)
+      meta = json_response['meta']
+      expect(meta).to match('total_ndc_count' => 2, 'total_indc_count' => 0)
+    end
   end
 
   describe 'GET show' do


### PR DESCRIPTION
This PR fixes the map and text of the NDC Search page:

- The Map reflects the number of countries that match the search
- The text shows the total number of documents in the db depending whether ndc, indc or all is selected
- Add a backend test for the meta response

![image](https://user-images.githubusercontent.com/9701591/38691272-b6598d3c-3e80-11e8-9c27-392ef26d45e2.png)
![image](https://user-images.githubusercontent.com/9701591/38691300-c691cafc-3e80-11e8-86d5-a1d7ba5d03ae.png)
