### PR TITLE
Fix/quantification styles

### DIFF
--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -229,11 +229,11 @@ class ChartStackedArea extends PureComponent {
               const yearLabel = isActivePoint ? (
                 <Label
                   value={`${point.x} - ${point.label}`}
-                  position="top"
+                  position="bottom"
                   fill="#8f8fa1"
                   stroke="#fff"
                   strokeWidth={isEdgeOrExplorer ? 0 : 8}
-                  style={{ paintOrder: 'stroke' }}
+                  style={{ paintOrder: 'stroke', zIndex: 500 }}
                   fontSize="13px"
                   offset={25}
                   isFront
@@ -248,7 +248,7 @@ class ChartStackedArea extends PureComponent {
               const valueLabel = isActivePoint ? (
                 <Label
                   value={valueLabelValue}
-                  position="top"
+                  position="bottom"
                   stroke="#fff"
                   strokeWidth={isEdgeOrExplorer ? 0 : 4}
                   style={{ paintOrder: 'stroke' }}
@@ -269,7 +269,7 @@ class ChartStackedArea extends PureComponent {
                     fill="transparent"
                     fillOpacity={0}
                     stroke={colorPoint}
-                    strokeOpacity={1}
+                    strokeOpacity={0.65}
                     strokeWidth={isActivePoint ? 10 : 8}
                     strokeLinejoin="round"
                     onMouseEnter={() => this.handlePointeHover(point)}
@@ -286,7 +286,7 @@ class ChartStackedArea extends PureComponent {
                     x={point.x}
                     y={point.y}
                     fill={colorPoint}
-                    fillOpacity={1}
+                    fillOpacity={0.65}
                     stroke="#fff"
                     strokeWidth={2}
                     r={isActivePoint ? 8 : 6}

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -14,7 +14,7 @@ export const CALCULATION_OPTIONS = {
 };
 
 export const QUANTIFICATION_COLORS = {
-  BAU: '#f03b21',
+  BAU: '#113750',
   QUANTIFIED: '#fecc5c',
   NOT_QUANTIFIABLE: '#b1b1c1'
 };

--- a/app/javascript/app/styles/themes/tag/quantification-tag.scss
+++ b/app/javascript/app/styles/themes/tag/quantification-tag.scss
@@ -19,6 +19,7 @@
   height: 10px;
   border-radius: 5px;
   margin-right: 5px;
+  opacity: 0.65;
 }
 
 .label {


### PR DESCRIPTION
This PR changes colours (and opacity) on quantification dots according to [design team proposal](https://zpl.io/agnJQoN)    
It also displays dots labels on the bottom of the dot to avoid overlapping issues (due to SVG ordering precedence).
![image](https://user-images.githubusercontent.com/6906348/39760887-df05be58-52d6-11e8-92f9-3a671b4755da.png)

Pivotal tasks: 
https://www.pivotaltracker.com/story/show/157391470
https://www.pivotaltracker.com/story/show/157391486