### PR TITLE
hide quantifications if featur flag is false

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -111,9 +111,12 @@ class CountryGhgEmissions extends PureComponent {
 
   renderQuantificationsTags() {
     const { loading, quantificationsTagsConfig } = this.props;
+    const showQuantifications =
+      FEATURE_QUANTIFICATIONS === 'true' && !isPageContained;
     return (
       <ul>
         {!loading &&
+          showQuantifications &&
           quantificationsTagsConfig.map(q => (
             <Tag
               theme={quantificationTagTheme}


### PR DESCRIPTION
Add a condition to hide the quantifications legend when `FEATURE_QUANTIFICATIONS` flag is set to true and page `isContained`