### PR TITLE
Fix/dots categorisation

### DIFF
--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -223,7 +223,7 @@ class ChartStackedArea extends PureComponent {
                 point.label.includes('BAU') && point.y > 0
                   ? QUANTIFICATION_COLORS.BAU
                   : QUANTIFICATION_COLORS.QUANTIFIED;
-              if (!point.y) {
+              if (point.y === null) {
                 colorPoint = QUANTIFICATION_COLORS.NOT_QUANTIFIABLE;
               }
               const yearLabel = isActivePoint ? (

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -223,7 +223,7 @@ class ChartStackedArea extends PureComponent {
                 point.label === 'BAU'
                   ? QUANTIFICATION_COLORS.BAU
                   : QUANTIFICATION_COLORS.QUANTIFIED;
-              if (point.label.includes('BAU not available')) {
+              if (!point.y || point.y === 0) {
                 colorPoint = QUANTIFICATION_COLORS.NOT_QUANTIFIABLE;
               }
               const yearLabel = isActivePoint ? (

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -220,7 +220,7 @@ class ChartStackedArea extends PureComponent {
                 activePoint &&
                 (point.x === activePoint.x && point.y === activePoint.y);
               let colorPoint =
-                point.label === 'BAU'
+                point.label.includes('BAU') && point.y > 0
                   ? QUANTIFICATION_COLORS.BAU
                   : QUANTIFICATION_COLORS.QUANTIFIED;
               if (!point.y || point.y === 0) {

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -223,7 +223,7 @@ class ChartStackedArea extends PureComponent {
                 point.label.includes('BAU') && point.y > 0
                   ? QUANTIFICATION_COLORS.BAU
                   : QUANTIFICATION_COLORS.QUANTIFIED;
-              if (!point.y || point.y === 0) {
+              if (!point.y) {
                 colorPoint = QUANTIFICATION_COLORS.NOT_QUANTIFIABLE;
               }
               const yearLabel = isActivePoint ? (

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -229,11 +229,11 @@ class ChartStackedArea extends PureComponent {
               const yearLabel = isActivePoint ? (
                 <Label
                   value={`${point.x} - ${point.label}`}
-                  position="bottom"
+                  position="top"
                   fill="#8f8fa1"
                   stroke="#fff"
                   strokeWidth={isEdgeOrExplorer ? 0 : 8}
-                  style={{ paintOrder: 'stroke', zIndex: 500 }}
+                  style={{ paintOrder: 'stroke' }}
                   fontSize="13px"
                   offset={25}
                   isFront
@@ -248,7 +248,7 @@ class ChartStackedArea extends PureComponent {
               const valueLabel = isActivePoint ? (
                 <Label
                   value={valueLabelValue}
-                  position="bottom"
+                  position="top"
                   stroke="#fff"
                   strokeWidth={isEdgeOrExplorer ? 0 : 4}
                   style={{ paintOrder: 'stroke' }}
@@ -257,15 +257,15 @@ class ChartStackedArea extends PureComponent {
                   isFront
                 />
               ) : null;
-
-              if (point.isRange) {
+              if (point.isRange || point.y === null) {
                 return (
                   <ReferenceArea
-                    key={`${point.label}-${point.x + point.y[0] + point.y[1]}`}
+                    key={`${point.label}-${point.y &&
+                      point.x + point.y[0] + point.y[1]}`}
                     x1={point.x - 0.01}
                     x2={point.x + 0.01}
-                    y1={point.y[0]}
-                    y2={point.y[1]}
+                    y1={point.y ? point.y[0] : 0}
+                    y2={point.y ? point.y[1] : maxData.y}
                     fill="transparent"
                     fillOpacity={0}
                     stroke={colorPoint}
@@ -276,7 +276,7 @@ class ChartStackedArea extends PureComponent {
                     onMouseLeave={() => this.handlePointeHover(null)}
                   >
                     {yearLabel}
-                    {valueLabel}
+                    {point.y && valueLabel}
                   </ReferenceArea>
                 );
               } else if (point.x && point.y !== null) {

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -223,7 +223,7 @@ class ChartStackedArea extends PureComponent {
                 point.label === 'BAU'
                   ? QUANTIFICATION_COLORS.BAU
                   : QUANTIFICATION_COLORS.QUANTIFIED;
-              if (point.label === 'No quantifiable target') {
+              if (point.label.includes('BAU not available')) {
                 colorPoint = QUANTIFICATION_COLORS.NOT_QUANTIFIABLE;
               }
               const yearLabel = isActivePoint ? (

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -252,7 +252,7 @@ export const getQuantificationsTagsConfig = createSelector(
     const qua = quantifications.find(
       q => q.label === 'Unconditional' || q.label === 'Conditional'
     );
-    const nq = quantifications.find(q => q.label === 'No quantifiable target');
+    const nq = quantifications.find(q => q.label.includes('BAU not available'));
     if (bau) {
       config.push(QUANTIFICATIONS_CONFIG.bau);
     }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -249,12 +249,12 @@ export const getQuantificationsTagsConfig = createSelector(
     if (!quantifications) return [];
     const config = [];
     const bau = quantifications.find(
-      q => q.label.includes('BAU') && q.value > 0
+      q => q.label.includes('BAU') && q.value !== null
     );
     const qua = quantifications.find(
       q => q.label === 'Unconditional' || q.label === 'Conditional'
     );
-    const nq = quantifications.find(q => !q.value || q.value === 0);
+    const nq = quantifications.find(q => q.value === null);
     if (bau) {
       config.push(QUANTIFICATIONS_CONFIG.bau);
     }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -248,7 +248,9 @@ export const getQuantificationsTagsConfig = createSelector(
   quantifications => {
     if (!quantifications) return [];
     const config = [];
-    const bau = quantifications.find(q => q.label === 'BAU');
+    const bau = quantifications.find(
+      q => q.label.includes('BAU') && q.value > 0
+    );
     const qua = quantifications.find(
       q => q.label === 'Unconditional' || q.label === 'Conditional'
     );

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -227,7 +227,7 @@ export const getQuantificationsData = createSelector(
               : v.value * DATA_SCALE;
             valuesParsed = {
               x: v.year,
-              y: yValue,
+              y: v.value ? yValue : null,
               label: v.label,
               isRange
             };
@@ -239,7 +239,7 @@ export const getQuantificationsData = createSelector(
       });
     });
     // Sort desc to avoid z-index problem in the graph
-    return orderBy(qParsed, 'x', 'desc');
+    return orderBy(qParsed, 'y', 'desc');
   }
 );
 

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -252,7 +252,7 @@ export const getQuantificationsTagsConfig = createSelector(
     const qua = quantifications.find(
       q => q.label === 'Unconditional' || q.label === 'Conditional'
     );
-    const nq = quantifications.find(q => q.label.includes('BAU not available'));
+    const nq = quantifications.find(q => !q.value || q.value === 0);
     if (bau) {
       config.push(QUANTIFICATIONS_CONFIG.bau);
     }

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -15,7 +15,7 @@ export const CALCULATION_OPTIONS = {
 
 export const QUANTIFICATION_COLORS = {
   BAU: '#113750',
-  QUANTIFIED: '#fecc5c',
+  QUANTIFIED: '#ffc735',
   NOT_QUANTIFIABLE: '#b1b1c1'
 };
 


### PR DESCRIPTION
This PR addresses some issues on GHG emissions chart:  
-  Changes svg quantifications dots ordering to avoid z-index problem with it's labels.  
`test it here:` http://localhost:3000/countries/TUR
-  Adds functionality to make `null` quantifications values to behave as `range` values (that is to be represented as a line instead of as a dot) . 
`test it here:` http://localhost:3000/countries/ECU  
-  Changed yellow shade used on `quantified targets` to be the same as the base theme yellow (`$theme-secondary`) . 
This last change follows a suggestion that could be checked in the last comment of this [basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/350625874)