### PR TITLE
Fix z-index of the info-button

### DIFF
--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
@@ -16,6 +16,7 @@
   right: 0;
   padding: 0;
   width: auto;
+  z-index: 1;
 }
 
 .circularChartValues {


### PR DESCRIPTION
Tiny PR to fix the z-index od the info-button that was obstructed by the circular chart in Country Vulnerability (first chart)
![image](https://user-images.githubusercontent.com/9701591/39811398-cf4c55a0-5388-11e8-8f48-e909b98e3b06.png)
