### PR TITLE
Fix/negative quantification color

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV RACK_ENV $RAILS_ENV
 ENV NODE_ENV $RAILS_ENV
 
 ENV ESP_API https://data.emissionspathways.org/api/v1
+ENV CW_API /api/v1
+ENV GFW_API https://production-api.globalforestwatch.org
 ENV S3_BUCKET_NAME climate-watch-dev
 ENV GOOGLE_ANALYTICS_ID UA-1981881-51
 
@@ -28,6 +30,11 @@ RUN gem install bundler --no-ri --no-rdoc
 RUN mkdir -p /usr/src/$NAME
 WORKDIR /usr/src/$NAME
 # VOLUME /usr/src/$NAME
+
+# Install and run scheduling
+#RUN gem install whenever
+#RUN whenever --load-file config/schedule.rb
+#RUN whenever --update-crontab
 
 # Install app dependencies
 COPY Gemfile Gemfile.lock ./

--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -182,6 +182,7 @@ class ChartLine extends PureComponent {
                   dataKey={column.value}
                   stroke={color}
                   strokeWidth={2}
+                  type="monotone"
                 />
               );
             })}

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -227,7 +227,8 @@ class ChartStackedArea extends PureComponent {
       height,
       points,
       includeTotalLine,
-      domain
+      domain,
+      stepped
     } = this.props;
     if (!dataWithTotal.length) return null;
     const tickValues = getCustomTicks(config.columns, dataWithTotal);
@@ -285,7 +286,7 @@ class ChartStackedArea extends PureComponent {
                 stroke={'transparent' || ''}
                 strokeWidth={0}
                 fill={config.theme[column.value].fill || ''}
-                type="step"
+                type={stepped ? 'step' : 'linear'}
               />
             ))}
           {includeTotalLine && (
@@ -295,7 +296,7 @@ class ChartStackedArea extends PureComponent {
               dot={false}
               stroke="#113750"
               strokeWidth={2}
-              type="step"
+              type={stepped ? 'step' : 'linear'}
             />
           )}
           {showLastPoint && this.renderLastPoint()}
@@ -318,13 +319,15 @@ ChartStackedArea.propTypes = {
     PropTypes.string // % accepted
   ]).isRequired,
   onMouseMove: PropTypes.func.isRequired,
-  includeTotalLine: PropTypes.bool
+  includeTotalLine: PropTypes.bool.isRequired,
+  stepped: PropTypes.bool.isRequired
 };
 
 ChartStackedArea.defaultProps = {
   height: 500,
   onMouseMove: () => {},
   includeTotalLine: true,
+  stepped: false,
   points: []
 };
 

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-selectors.js
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-selectors.js
@@ -61,8 +61,8 @@ export const getDomain = createSelector(
       points.filter(p => p.y).map(p => (isArray(p.y) ? min(p.y) : p.y))
     );
     domain.x[1] = max(points.filter(p => p.x).map(p => p.x)) + 1;
-    domain.y[0] = pointsMax || dataMax;
-    domain.y[1] = pointsMin || dataMin;
+    domain.y[0] = pointsMin || dataMin;
+    domain.y[1] = pointsMax || dataMax;
     return domain;
   }
 );

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-selectors.js
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-selectors.js
@@ -1,0 +1,73 @@
+import { includeTotalData } from 'utils/stacked-area';
+import min from 'lodash/min';
+import max from 'lodash/max';
+import isArray from 'lodash/isArray';
+import { createSelector } from 'reselect';
+
+const getData = state => state.data || null;
+export const getDataWithTotal = createSelector(
+  [getData, state => state.config],
+  (data, config) => {
+    if (!data || !config) return null;
+    return includeTotalData(data, config);
+  }
+);
+
+const getDataMin = createSelector(getDataWithTotal, data => {
+  if (!data) return null;
+  return min(
+    data.map(d => {
+      let negativeSum = 0;
+      Object.keys(d).forEach(key => {
+        if (key !== 'x' && key !== 'total' && d[key] < 0) negativeSum += d[key];
+      });
+      return negativeSum;
+    })
+  );
+});
+
+const getDataMax = createSelector(getDataWithTotal, data => {
+  if (!data) return null;
+  return max(
+    data.map(d => {
+      let positiveSum = 0;
+      Object.keys(d).forEach(key => {
+        if (key !== 'x' && key !== 'total' && d[key] > 0) positiveSum += d[key];
+      });
+      return positiveSum;
+    })
+  );
+});
+
+export const getDomain = createSelector(
+  [
+    getData,
+    state => state.config,
+    state => state.points,
+    getDataMin,
+    getDataMax
+  ],
+  (data, config, points, dataMin, dataMax) => {
+    if (!data || !config) return null;
+    const domain = {
+      x: ['dataMin', 'dataMax'],
+      y: ['auto', 'auto']
+    };
+    if (!points || points.length === 0) return domain;
+    const pointsMax = max(
+      points.filter(p => p.y).map(p => (isArray(p.y) ? max(p.y) : p.y))
+    );
+    const pointsMin = min(
+      points.filter(p => p.y).map(p => (isArray(p.y) ? min(p.y) : p.y))
+    );
+    domain.x[1] = max(points.filter(p => p.x).map(p => p.x)) + 1;
+    domain.y[0] = pointsMax || dataMax;
+    domain.y[1] = pointsMin || dataMin;
+    return domain;
+  }
+);
+
+export const getDataMaxMin = createSelector(
+  [getDataMin, getDataMax],
+  (dataMin, dataMax) => ({ max: dataMax, min: dataMin })
+);

--- a/app/javascript/app/components/charts/stacked-area/stacked-area.js
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area.js
@@ -1,3 +1,37 @@
-import Component from './stacked-area-component';
+import { PureComponent, createElement } from 'react';
+import { getMaxValue } from 'utils/stacked-area';
+import PropTypes from 'prop-types';
+import {
+  getDataWithTotal,
+  getDomain,
+  getDataMaxMin
+} from './stacked-area-selectors';
+import stackedAreaComponent from './stacked-area-component';
 
-export default Component;
+class StackedAreaContainer extends PureComponent {
+  render() {
+    const { points, data, config } = this.props;
+    const stackedAreaState = {
+      points,
+      data,
+      config
+    };
+
+    const dataWithTotal = getDataWithTotal(stackedAreaState);
+    return createElement(stackedAreaComponent, {
+      ...this.props,
+      dataWithTotal,
+      domain: getDomain(stackedAreaState),
+      dataMaxMin: getDataMaxMin(stackedAreaState),
+      lastData: getMaxValue(dataWithTotal)
+    });
+  }
+}
+
+StackedAreaContainer.propTypes = {
+  points: PropTypes.array,
+  data: PropTypes.array,
+  config: PropTypes.object
+};
+
+export default StackedAreaContainer;

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -82,7 +82,8 @@ class CountryGhgEmissions extends PureComponent {
       config,
       handleYearHover,
       filtersOptions,
-      filtersSelected
+      filtersSelected,
+      sourceSelected
     } = this.props;
 
     const points =
@@ -105,6 +106,7 @@ class CountryGhgEmissions extends PureComponent {
         dataSelected={filtersSelected}
         loading={loading}
         height={360}
+        stepped={sourceSelected.label === 'UNFCCC'}
       />
     );
   }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -227,7 +227,7 @@ export const getQuantificationsData = createSelector(
               : v.value * DATA_SCALE;
             valuesParsed = {
               x: v.year,
-              y: v.value ? yValue : null,
+              y: v.value !== null || v.value !== undefined ? yValue : null,
               label: v.label,
               isRange
             };

--- a/app/javascript/app/utils/stacked-area.js
+++ b/app/javascript/app/utils/stacked-area.js
@@ -1,0 +1,24 @@
+export const includeTotalData = (data, config) =>
+  data.map(d => {
+    let total = null;
+    config.columns.y.forEach(key => {
+      if (d[key.value]) {
+        if (!total) total = 0;
+        total += d[key.value];
+      }
+    });
+    return {
+      ...d,
+      total
+    };
+  });
+
+export const getMaxValue = data => {
+  const lastData = data[data.length - 1];
+  return {
+    x: lastData.x,
+    y: lastData.total
+  };
+};
+
+export default { includeTotalData, getMaxValue };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157551941

- Show Negative BAU points in the right color
- Frame Not quantifiable range into data minimum and maximum
![image](https://user-images.githubusercontent.com/9701591/40007381-e1a30cea-579c-11e8-8a94-863337ea6e28.png)
![image](https://user-images.githubusercontent.com/9701591/40007390-ea197a44-579c-11e8-9f6a-4d55f0ec2496.png)

https://basecamp.com/1756858/projects/13795275/todos/332083809
- GHG emissions: Smooth the chart lines in all cases except for the UNFCCC data
![image](https://user-images.githubusercontent.com/9701591/40009750-26062b46-57a3-11e8-8970-206d7bd162d1.png)


https://basecamp.com/1756858/projects/13795275/todos/349822479
- Smooth lines in ESP (Using monotone type). It can't be smoother while still being accurate.
![image](https://user-images.githubusercontent.com/9701591/40009598-d147a418-57a2-11e8-8ffe-f572f8836664.png)


Extra:
- Huge needed refactor extracting the logic of the stack-area-component, creating selectors and breaking the different parts in the component (last point, quantification points, labels, ...)
- Dockerfile conflicts with sandbox fixed