### PR TITLE
Add sticky country selector, extract js style constants and css colors

### DIFF
--- a/app/javascript/app/pages/country-compare/country-compare-component.jsx
+++ b/app/javascript/app/pages/country-compare/country-compare-component.jsx
@@ -9,6 +9,7 @@ import CountryCompareSelector from 'components/country-compare/country-compare-s
 import CountrySelectorFooter from 'components/country-selector-footer';
 import ModalMetadata from 'components/modal-metadata';
 import { isPageContained } from 'utils/navigation';
+import { STICKY_OFFSET } from 'styles/constants';
 
 import layout from 'styles/layout.scss';
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
@@ -36,7 +37,10 @@ const CountryCompare = ({ route, anchorLinks }) => (
         <Desktop>
           {isDesktop =>
             (isLandscape ? (
-              <Sticky activeClass="sticky" top={isDesktop ? 49 : 105}>
+              <Sticky
+                activeClass="sticky"
+                top={isDesktop ? STICKY_OFFSET.desktop : STICKY_OFFSET.mobile}
+              >
                 <CountryCompareSelector className={styles.countrySelectors} />
               </Sticky>
             ) : null)}

--- a/app/javascript/app/pages/ndc-compare/ndc-compare-component.jsx
+++ b/app/javascript/app/pages/ndc-compare/ndc-compare-component.jsx
@@ -8,6 +8,8 @@ import Dropdown from 'components/dropdown';
 import sortBy from 'lodash/sortBy';
 import Sticky from 'react-stickynode';
 import AnchorNav from 'components/anchor-nav';
+import { Desktop } from 'components/responsive';
+import { STICKY_OFFSET } from 'styles/constants';
 
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import layout from 'styles/layout.scss';
@@ -40,50 +42,59 @@ class NDCCountry extends PureComponent {
             />
           </Sticky>
         </Header>
-        <div className={styles.countrySelector}>
-          <div className={styles.row}>
-            <div className="grid-layout-item">
-              <div className={styles.fourFold}>
-                <div
-                  className={cx(
-                    styles.selector,
-                    styles.offset,
-                    styles.separator
-                  )}
-                >
-                  <Dropdown
-                    placeholder="Add a country"
-                    options={sortBy(countriesOptions, ['label'])}
-                    onValueChange={selected =>
-                      handleDropDownChange(0, selected)}
-                    value={activeCountriesOptions[0]}
-                    transparent
-                  />
-                </div>
-                <div className={cx(styles.selector, styles.separator)}>
-                  <Dropdown
-                    placeholder="Add a second country"
-                    options={sortBy(countriesOptions, ['label'])}
-                    onValueChange={selected =>
-                      handleDropDownChange(1, selected)}
-                    value={activeCountriesOptions[1]}
-                    transparent
-                  />
-                </div>
-                <div className={styles.selector}>
-                  <Dropdown
-                    placeholder="Add a third country"
-                    options={sortBy(countriesOptions, ['label'])}
-                    onValueChange={selected =>
-                      handleDropDownChange(2, selected)}
-                    value={activeCountriesOptions[2]}
-                    transparent
-                  />
+        <Desktop>
+          {isDesktop => (
+            <Sticky
+              activeClass="sticky -country-selector"
+              top={isDesktop ? STICKY_OFFSET.desktop : STICKY_OFFSET.mobile}
+            >
+              <div className={styles.countrySelector}>
+                <div className={styles.row}>
+                  <div className="grid-layout-item">
+                    <div className={styles.fourFold}>
+                      <div
+                        className={cx(
+                          styles.selector,
+                          styles.offset,
+                          styles.separator
+                        )}
+                      >
+                        <Dropdown
+                          placeholder="Add a country"
+                          options={sortBy(countriesOptions, ['label'])}
+                          onValueChange={selected =>
+                            handleDropDownChange(0, selected)}
+                          value={activeCountriesOptions[0]}
+                          transparent
+                        />
+                      </div>
+                      <div className={cx(styles.selector, styles.separator)}>
+                        <Dropdown
+                          placeholder="Add a second country"
+                          options={sortBy(countriesOptions, ['label'])}
+                          onValueChange={selected =>
+                            handleDropDownChange(1, selected)}
+                          value={activeCountriesOptions[1]}
+                          transparent
+                        />
+                      </div>
+                      <div className={styles.selector}>
+                        <Dropdown
+                          placeholder="Add a third country"
+                          options={sortBy(countriesOptions, ['label'])}
+                          onValueChange={selected =>
+                            handleDropDownChange(2, selected)}
+                          value={activeCountriesOptions[2]}
+                          transparent
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
+            </Sticky>
+          )}
+        </Desktop>
         <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
       </div>
     );

--- a/app/javascript/app/styles/constants.js
+++ b/app/javascript/app/styles/constants.js
@@ -1,0 +1,8 @@
+export const STICKY_OFFSET = {
+  mobile: 105,
+  desktop: 49
+};
+
+export default {
+  STICKY_OFFSET
+};

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -49,6 +49,10 @@ $base-text: #424242;
 $bg-main: #00548b;
 $bg-blue: #1b3b5a;
 
+$teal-blue: #045f61;
+$purple: #74356a;
+$light-blue: #035388;
+
 $border-color: rgba(26, 28, 34, 0.1);
 
 // Breakpoints

--- a/app/javascript/app/styles/sticky.scss
+++ b/app/javascript/app/styles/sticky.scss
@@ -1,3 +1,5 @@
+@import 'settings';
+
 :global .sticky-outer-wrapper {
   .sticky-inner-wrapper {
     z-index: 2;
@@ -9,26 +11,32 @@
     &.-compare,
     &.-ndc-search {
       .sticky-inner-wrapper {
-        background-color: #035388;
+        background-color: $light-blue;
+      }
+    }
+
+    &.-country-selector {
+      .sticky-inner-wrapper {
+        background-color: $white;
       }
     }
 
     &.-country,
     &.-country-compare {
       .sticky-inner-wrapper {
-        background-color: #045f61;
+        background-color: $teal-blue;
       }
     }
 
     &.-about {
       .sticky-inner-wrapper {
-        background-color: #113750;
+        background-color: $theme-color;
       }
     }
 
     &.-emissions {
       .sticky-inner-wrapper {
-        background-color: #74356a;
+        background-color: $purple;
       }
     }
 


### PR DESCRIPTION
This PR makes the country selector from the NDC compare page sticky, below the anchor nav.

- Make  country sticky
- Add a constants file for js style constants
- Use the colors from the settings in the sticky CSS

Try: http://localhost:3000/ndcs/compare/mitigation?locations=DZA
![image](https://user-images.githubusercontent.com/9701591/40111418-143bd332-5903-11e8-99a5-09b3ee4207ec.png)
