### PR TITLE
Use correct data to display the tooltip sectors text

### DIFF
--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -28,10 +28,9 @@ class CountrySDGLinkages extends PureComponent {
   }
 
   getTooltip() {
-    const { sectors, tooltipData, targets } = this.props;
+    const { sectors, tooltipData, targets, tooltipSectorIds } = this.props;
     const targetsContent = targets && targets[tooltipData.goal_number];
-    const hasTooltipData =
-      tooltipData.sectors && tooltipData.sectors.length > 0;
+    const hasTooltipData = tooltipSectorIds && tooltipSectorIds.length > 0;
     return tooltipData && targetsContent ? (
       <div className={styles.tooltip}>
         <p className={styles.tooltipTitle}>
@@ -41,10 +40,10 @@ class CountrySDGLinkages extends PureComponent {
         {hasTooltipData && (
           <p className={styles.sectors}>
             <b>Sectors: </b>
-            {tooltipData.sectors.map((sector, index) => (
+            {tooltipSectorIds.map((sector, index) => (
               <span key={`${tooltipData.targetKey}-${sector}`}>
                 {sectors[sector]}
-                {index === tooltipData.sectors.length - 1 ? '' : ', '}
+                {index === tooltipSectorIds.length - 1 ? '' : ', '}
               </span>
             ))}
           </p>
@@ -64,7 +63,6 @@ class CountrySDGLinkages extends PureComponent {
       handleOnDotClick,
       iso
     } = this.props;
-
     const hasGoals = goals && goals.length > 0;
     if (loading) return <Loading light className={styles.loader} />;
     if (isEmpty(goals) || isEmpty(targetsData)) {
@@ -183,6 +181,7 @@ CountrySDGLinkages.propTypes = {
   loading: Proptypes.bool,
   setTooltipData: Proptypes.func,
   tooltipData: Proptypes.object,
+  tooltipSectorIds: Proptypes.array,
   targetsMeta: Proptypes.object,
   iso: Proptypes.string,
   handleInfoClick: Proptypes.func.isRequired,

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-selectors.js
@@ -1,12 +1,16 @@
 import { createSelector } from 'reselect';
 import upperFirst from 'lodash/upperFirst';
 import groupBy from 'lodash/groupBy';
+import isEmpty from 'lodash/isEmpty';
 import { compareIndexByKey } from 'utils/utils';
 
 const getSectors = state => {
   if (!state.data) return null;
   return state.data.sectors;
 };
+
+const getTooltipData = state => state.tooltipData || null;
+const getTargetsData = state => state.targetsData || null;
 
 const getTargets = state => {
   if (!state.data.targets) return null;
@@ -62,9 +66,24 @@ export const groupTargetsMeta = createSelector([getTargets], targets => {
   return groupBy(targets.sort(compareIndexByKey('number')), 'goal_number');
 });
 
+export const getTooltipSectorIds = createSelector(
+  [getTooltipData, getTargetsData],
+  (tooltip, targets) => {
+    if (!tooltip || !targets || isEmpty(tooltip) || isEmpty(targets)) { return null; }
+    return (
+      (targets[tooltip.goal_number] &&
+        targets[tooltip.goal_number].targets &&
+        targets[tooltip.goal_number].targets[tooltip.number] &&
+        targets[tooltip.goal_number].targets[tooltip.number].sectors) ||
+      null
+    );
+  }
+);
+
 export default {
   getSectorOptionsSorted,
   groupTargetsMeta,
   getSectorSelected,
-  getSectorsMapped
+  getSectorsMapped,
+  getTooltipSectorIds
 };

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
@@ -15,7 +15,8 @@ import {
   getSectorOptionsSorted,
   groupTargetsMeta,
   getSectorSelected,
-  getSectorsMapped
+  getSectorsMapped,
+  getTooltipSectorIds
 } from './country-ndc-sdg-linkages-selectors';
 
 const actions = {
@@ -27,23 +28,27 @@ const mapStateToProps = (state, { match, location }) => {
   const { countrySDGLinkages, ndcsSdgsMeta, ndcsSdgsData } = state;
   const { iso } = match.params;
   const search = qs.parse(location.search);
+  const tooltipData = countrySDGLinkages.tooltipData;
+  const targetsData =
+    !isEmpty(ndcsSdgsData.data) && ndcsSdgsData.data[iso]
+      ? ndcsSdgsData.data[iso].sdgs
+      : {};
   const sdgsData = {
     data: ndcsSdgsMeta.data,
-    activeSector: search.sector
+    activeSector: search.sector,
+    tooltipData,
+    targetsData
   };
-
   return {
     fetched: ndcsSdgsData.data[iso],
     activeSector: getSectorSelected(sdgsData),
-    tooltipData: countrySDGLinkages.tooltipData,
+    tooltipData,
     sectors: getSectorsMapped(sdgsData),
+    tooltipSectorIds: getTooltipSectorIds(sdgsData),
     sectorOptions: getSectorOptionsSorted(sdgsData),
     goals: (!isEmpty(ndcsSdgsData.data) && ndcsSdgsMeta.data.goals) || [],
     targets: groupTargetsMeta(ndcsSdgsMeta),
-    targetsData:
-      !isEmpty(ndcsSdgsData.data) && ndcsSdgsData.data[iso]
-        ? ndcsSdgsData.data[iso].sdgs
-        : {},
+    targetsData,
     loading:
       (!ndcsSdgsData.error && ndcsSdgsData.loading) || ndcsSdgsMeta.loading,
     iso


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157552133

This PR fixes the country/NDC-SDG Linkages tooltip text. All the sectors were displayed without being filtered by the country

Try: http://localhost:3000/countries/BRA

Before: 
![image](https://user-images.githubusercontent.com/9701591/40113940-61cc09d4-590b-11e8-95fb-bc2bab57e550.png)

After:
![image](https://user-images.githubusercontent.com/9701591/40113807-efd8eaea-590a-11e8-9882-404492b2a97a.png)
![image](https://user-images.githubusercontent.com/9701591/40113894-3899cf10-590b-11e8-92d0-a40883a7bed1.png)

