### PR TITLE
My CW - Add padding while still selecting data so we see the full dropdown

### DIFF
--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
@@ -39,11 +39,15 @@ const Step3 = props => {
     return { options: optionsSorted, ...labels };
   };
 
-  const { spec, handleFilterSelect } = props;
+  const { spec, handleFilterSelect, hasData } = props;
 
   return (
     <li className={styles.step}>
-      <div className={styles.stepContainer}>
+      <div
+        className={cx(styles.stepContainer, {
+          [styles.openDropdownPadding]: !hasData
+        })}
+      >
         <h2 className={styles.stepTitle}>3/4 - Filter the data</h2>
         <div className="layout-item-container">
           {spec && (
@@ -97,7 +101,8 @@ const Step3 = props => {
 
 Step3.propTypes = {
   spec: PropTypes.object.isRequired,
-  handleFilterSelect: PropTypes.func.isRequired
+  handleFilterSelect: PropTypes.func.isRequired,
+  hasData: PropTypes.bool
 };
 
 export default Step3;

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
@@ -162,3 +162,7 @@
     border: solid 1px $theme-color;
   }
 }
+
+.openDropdownPadding {
+  padding-bottom: 110px;
+}

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
@@ -40,7 +40,7 @@ const VizCreator = props => {
           <Step2 {...{ visualisations, selectVisualisation }} />
         )}
         {visualisations.selected && (
-          <Step3 {...{ spec: filters, handleFilterSelect }} />
+          <Step3 {...{ spec: filters, handleFilterSelect, hasData }} />
         )}
         {hasData && (
           <Step4


### PR DESCRIPTION
This PR solves the problem with the cut dropdown in the modal when creating/editing a visualization. 
- Add padding while in step3 (selecting filters) so we can always see the full dropdown

![image](https://user-images.githubusercontent.com/9701591/40174880-b1549d42-59d6-11e8-86a0-519019cf08d6.png)
