### PR TITLE
Feature/visualizations delete button

### DIFF
--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Button from 'components/button';
+import Icon from 'components/icon';
+import deleteIcon from 'assets/icons/delete.svg';
 
 import RenderChart from 'components/my-climate-watch/viz-creator/components/render-chart';
 import {
@@ -16,26 +18,35 @@ class MyVisCard extends PureComponent {
     this.props.onClick();
   };
   render() {
-    const { data, className } = this.props;
+    const { data, className, deleteVisualisation } = this.props;
     const datasets = data.json_body;
     // Object with datasets key to reuse the selector keeping the same format that the reducer
     const chart = datasets ? getVisualisationType({ datasets }) : null;
     const chartData = datasets
       ? chartDataSelector({ datasets, small: true })
       : null;
+    const id = data.id;
 
     return (
-      <Button
-        onClick={this.handleOnClick}
-        className={cx(styles.card, className)}
-      >
-        <div className={styles.chart}>
-          {datasets && (
-            <RenderChart chart={chart} config={chartData} height={200} />
-          )}
-        </div>
-        <h2 className={styles.cardTitle}>{data.title}</h2>
-      </Button>
+      <div className={styles.cardContainer}>
+        <Button
+          onClick={this.handleOnClick}
+          className={cx(styles.card, className)}
+        >
+          <div className={styles.chart}>
+            {datasets && (
+              <RenderChart chart={chart} config={chartData} height={200} />
+            )}
+          </div>
+          <h2 className={styles.cardTitle}>{data.title}</h2>
+        </Button>
+        <button
+          className={styles.cardDelete}
+          onClick={() => deleteVisualisation({ id })}
+        >
+          <Icon icon={deleteIcon} className={styles.icon} />
+        </button>
+      </div>
     );
   }
 }
@@ -43,6 +54,7 @@ class MyVisCard extends PureComponent {
 MyVisCard.propTypes = {
   className: PropTypes.string,
   onClick: PropTypes.func.isRequired,
+  deleteVisualisation: PropTypes.func.isRequired,
   data: PropTypes.shape({
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
@@ -1,14 +1,19 @@
 @import '~styles/layout.scss';
 $padding: 20px;
 
-.card {
+.cardContainer {
+  position: relative;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
   border: solid 1px rgba(26, 28, 34, 0.1);
-  display: inline-block;
-  padding: 0;
-  height: 100%;
   min-height: 270px;
   background-color: $light-gray;
+}
+
+.card {
+  display: inline-block;
+  padding: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .cardTitle {
@@ -20,6 +25,15 @@ $padding: 20px;
   text-align: left;
   min-height: 106px;
   background-color: $white;
+}
+
+.cardDelete {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  fill: #8f8fa1;
+  z-index: 3;
+  cursor: pointer;
 }
 
 .chart {

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card.js
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card.js
@@ -1,1 +1,5 @@
-export { default } from './my-cw-vis-card-component';
+import { connect } from 'react-redux';
+import * as actions from 'components/my-climate-watch/viz-creator/viz-creator-actions';
+import Component from './my-cw-vis-card-component';
+
+export default connect(null, actions)(Component);

--- a/app/javascript/app/pages/my-climate-watch/my-climate-watch-component.jsx
+++ b/app/javascript/app/pages/my-climate-watch/my-climate-watch-component.jsx
@@ -17,12 +17,10 @@ import styles from './my-climate-watch-styles';
 const MyCw = ({ location, route, login, openCreator }) => {
   let button = null;
   if (login.logged) {
-    if (location.pathname.indexOf('visualisations') > -1) {
-      button = { text: 'Create a visualisation', onClick: () => openCreator() };
-    } else if (location.pathname.indexOf('account-settings') > -1) {
+    if (location.pathname.indexOf('account-settings') > -1) {
       button = { text: 'Logout' };
     } else {
-      button = { text: 'Create an insight', link: '/my-climate-watch/editor' };
+      button = { text: 'Create a visualisation', onClick: () => openCreator() };
     }
   }
   let content = <Loading className={styles.loading} height={300} />;

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -39,6 +39,9 @@ import emissionPathwaysScenarioSections from './emission-pathways-scenario-secti
 import emissionPathwaysSections from './emission-pathways-sections';
 import countryCompareSections from './country-compare-sections';
 
+// flags
+const MYCW_INSIGHTS = process.env.MYCW_INSIGHTS === 'true';
+
 export default [
   {
     path: '/',
@@ -186,7 +189,9 @@ export default [
   {
     path: '/my-climate-watch',
     component: MyClimateWatch,
-    routes: MyCwRoutes
+    routes: MYCW_INSIGHTS
+      ? MyCwRoutes
+      : MyCwRoutes.filter(route => route.label !== 'My Insights')
   },
   {
     path: '/about',

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -39,9 +39,6 @@ import emissionPathwaysScenarioSections from './emission-pathways-scenario-secti
 import emissionPathwaysSections from './emission-pathways-sections';
 import countryCompareSections from './country-compare-sections';
 
-// flags
-const MYCW_INSIGHTS = process.env.MYCW_INSIGHTS === 'true';
-
 export default [
   {
     path: '/',
@@ -189,9 +186,7 @@ export default [
   {
     path: '/my-climate-watch',
     component: MyClimateWatch,
-    routes: MYCW_INSIGHTS
-      ? MyCwRoutes
-      : MyCwRoutes.filter(route => route.label !== 'My Insights')
+    routes: MyCwRoutes
   },
   {
     path: '/about',

--- a/app/javascript/app/routes/app-routes/my-cw-routes/my-cw-routes.js
+++ b/app/javascript/app/routes/app-routes/my-cw-routes/my-cw-routes.js
@@ -1,17 +1,10 @@
-import MyInsights from 'components/my-climate-watch/my-insights';
 import MyVisualisations from 'components/my-climate-watch/my-visualisations';
 import MyAccount from 'components/my-climate-watch/my-account';
 
 export default [
   {
-    label: 'My Insights',
-    path: '/my-climate-watch',
-    component: MyInsights,
-    exact: true
-  },
-  {
     label: 'Visualisations',
-    path: '/my-climate-watch/visualisations',
+    path: '/my-climate-watch',
     component: MyVisualisations,
     exact: true
   },


### PR DESCRIPTION
This PR adds `delete visualisation` functionality on visualisation cards on  My Climatewatch dashboard.
It also hides `My Insights` from the menu (anchor navigation) from My Climatewatch.  

![kapture 2018-05-17 at 16 19 28](https://user-images.githubusercontent.com/6906348/40183444-21182d30-59ee-11e8-87fd-1e53df4b7665.gif)

Basecamp threads:   
-  [remove button](https://basecamp.com/1756858/projects/13795275/todos/352584528)
-  [hide my insights](https://basecamp.com/1756858/projects/13795275/todos/352477738) 

[pivotal tracker](https://www.pivotaltracker.com/story/show/157657755)
