### PR TITLE
Fix socioeconomics mobile error

### DIFF
--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
@@ -69,7 +69,7 @@ class CompareSocioeconomics extends PureComponent {
               {countrySocioeconomics && countrySocioeconomics.some(c => c) ? (
                 countrySocioeconomics.map((countrySocioeconomicData, i) => (
                   <div
-                    key={`socioeconomic-${locations[i]}`}
+                    key={`socioeconomic-${i}{${locations[i]}`}
                     className={styles.compareSocioeconomics}
                   >
                     <TabletPortraitOnly>

--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
@@ -73,15 +73,19 @@ class CompareSocioeconomics extends PureComponent {
                     className={styles.compareSocioeconomics}
                   >
                     <TabletPortraitOnly>
-                      <div className={cx(styles.countryHeader)}>
-                        <div
-                          className={styles.dot}
-                          style={{ backgroundColor: COUNTRY_COMPARE_COLORS[i] }}
-                        />
-                        <div className={styles.countryName}>
-                          {locationNames[i]}
+                      {locationNames[i] && (
+                        <div className={cx(styles.countryHeader)}>
+                          <div
+                            className={styles.dot}
+                            style={{
+                              backgroundColor: COUNTRY_COMPARE_COLORS[i]
+                            }}
+                          />
+                          <div className={styles.countryName}>
+                            {locationNames[i]}
+                          </div>
                         </div>
-                      </div>
+                      )}
                     </TabletPortraitOnly>
                     {renderSocioeconomics(countrySocioeconomicData, i)}
                   </div>

--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-selectors.js
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-selectors.js
@@ -38,10 +38,11 @@ export const getCountrySocioeconomics = createSelector(
 export const getLocationNames = createSelector(
   [getLocations, getCountriesData],
   (locations, countries) => {
-    if (!locations || !locations.length || !countries || !countries.length) { return null; }
+    if (!locations || !locations.length || !countries || !countries.length)
+      return null;
     return locations.map(location => {
       const country = countries.find(c => location === c.iso_code3);
-      return country.wri_standard_name || null;
+      return (country && country.wri_standard_name) || null;
     });
   }
 );

--- a/app/javascript/app/components/country-selector-footer/country-selector-footer.js
+++ b/app/javascript/app/components/country-selector-footer/country-selector-footer.js
@@ -47,10 +47,10 @@ class CountrySelectorFooterContainer extends PureComponent {
   };
 
   handleRemove = target => {
-    const unselected = target.value;
-    const { locations } = this.props;
-    const newLocations = locations.map(
-      country => (country !== unselected ? country : null)
+    const unselected = target;
+    const { activeCountryOptions } = this.props;
+    const newLocations = activeCountryOptions.map(
+      country => country && (country.label !== unselected ? country.value : null)
     );
     this.updateUrlParam({ name: 'locations', value: newLocations.toString() });
   };
@@ -67,7 +67,8 @@ class CountrySelectorFooterContainer extends PureComponent {
 CountrySelectorFooterContainer.propTypes = {
   history: Proptypes.object.isRequired,
   location: Proptypes.object.isRequired,
-  locations: Proptypes.array
+  locations: Proptypes.array,
+  activeCountryOptions: Proptypes.array
 };
 
 export default withRouter(


### PR DESCRIPTION
The socioeconomic section in the mobile version was not behaving correctly when we had empty countries in the location
- Fix empty countries error in mobile display of socioeconomics
- Fix remove country from the countries compare selector in the mobile version