### PR TITLE
Update quantified quantifications tag filtering

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -252,7 +252,7 @@ export const getQuantificationsTagsConfig = createSelector(
       q => q.label.includes('BAU') && q.value !== null
     );
     const qua = quantifications.find(
-      q => q.label === 'Unconditional' || q.label === 'Conditional'
+      q => q.label !== null && !q.label.includes('BAU')
     );
     const nq = quantifications.find(q => q.value === null);
     if (bau) {


### PR DESCRIPTION
This PR updates quantifications tags filtering to display the `quantified target` tag in case the quantification has values and is not a Business as Usual (`BAU`) quantification.  

http://localhost:3000/countries/MKD  

__before__
![image](https://user-images.githubusercontent.com/6906348/40613425-c16fa40a-627e-11e8-94f7-cf713be9c8b8.png)

__after__

![image](https://user-images.githubusercontent.com/6906348/40613484-ff4097ee-627e-11e8-8826-37b8d245b41b.png)

