### PR TITLE
Cache user selections when building visualisations

### DIFF
--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactTooltip from 'react-tooltip';
 import _map from 'lodash/map';
 import _isUndefined from 'lodash/isUndefined';
 import _isEmpty from 'lodash/isEmpty';
@@ -8,6 +9,8 @@ import cx from 'classnames';
 
 import MultiSelect from 'components/multiselect';
 import Dropdown from 'components/dropdown';
+import Icon from 'components/icon';
+import infoIcon from 'assets/icons/info.svg';
 import styles from './steps-styles';
 
 const Step3 = props => {
@@ -39,6 +42,9 @@ const Step3 = props => {
     return { options: optionsSorted, ...labels };
   };
 
+  const selectorClearable = (type, selection) =>
+    type !== 'locations' || _isEmpty(selection);
+
   const { spec, handleFilterSelect, hasData } = props;
 
   return (
@@ -63,6 +69,11 @@ const Step3 = props => {
                         selectProps(f, 'value').hidden
                     })}
                   >
+                    {f.info && (
+                      <div data-tip={f.info} className={styles.infoContainer}>
+                        <Icon icon={infoIcon} className={styles.infoIcon} />
+                      </div>
+                    )}
                     {f.multi ? (
                       <MultiSelect
                         className={styles.dropDowns}
@@ -85,9 +96,10 @@ const Step3 = props => {
                             ...e,
                             type: f.name
                           })}
-                        hideResetButton
+                        hideResetButton={selectorClearable(f.name, f.selected)}
                       />
                     )}
+                    <ReactTooltip />
                   </li>
                 );
               })}

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
@@ -70,6 +70,8 @@
 }
 
 .selectsItem {
+  position: relative;
+
   &Hidden {
     display: none;
   }
@@ -165,4 +167,15 @@
 
 .openDropdownPadding {
   padding-bottom: 110px;
+}
+
+.infoContainer {
+  position: absolute;
+  right: 0;
+  z-index: 10;
+  cursor: pointer;
+}
+
+.infoIcon {
+  fill: $gray;
 }

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-actions.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-actions.js
@@ -161,6 +161,8 @@ export const fetchVisualisation = createThunkAction(
 export const openCreator = createAction('openCreator');
 export const closeCreator = createAction('closeCreator');
 
+export const editVisualisationData = createAction('editVisualisationData');
+
 export const gotDatasets = createAction('gotDatasets');
 export const selectDataset = createAction('selectDataset');
 

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-utils.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-utils.js
@@ -1,7 +1,11 @@
 import isFunction from 'lodash/isFunction';
+import isArray from 'lodash/isArray';
+import findIndex from 'lodash/findIndex';
+import isEmpty from 'lodash/isEmpty';
+import uniqBy from 'lodash/uniqBy';
 import _startCase from 'lodash/startCase';
 import _ from 'lodash-inflection';
-import { update } from 'js-lenses';
+import { update, get } from 'js-lenses';
 import { assign } from 'app/utils';
 
 export const toFetcher = name => `fetch${_.pluralize(_startCase(name))}`;
@@ -23,9 +27,84 @@ export const flatMapVis = (vis = []) =>
 export const updateIn = (l, payload, state) =>
   update(l, s => assign(s, isFunction(payload) ? payload(s) : payload), state);
 
-// CHARTS
-// --
+export function getCachedSelectedProperty(lense, data) {
+  const cachedSelection = lense.selected;
+  const val = lense.name === 'years' ? 'value' : 'id';
+  if (cachedSelection) {
+    if (isArray(cachedSelection)) {
+      return findIndex(data, item => item[val] === cachedSelection[0].value) !==
+      -1
+        ? cachedSelection
+        : [];
+    }
+    return findIndex(data, item => item[val] === cachedSelection.value) !== -1
+      ? cachedSelection
+      : {};
+  }
+}
 
-export const pieChart2Data = () => {
-  // console.log(scn, idc); //eslint-disable-line
+export function buildChildLense(childLense, selected, state, initialState) {
+  // sanitizes the selection to avoid an empty object going down the line
+  let selection;
+  if (isArray(selected)) {
+    selection = !isEmpty(selected);
+  } else if (selected && !isEmpty(selected)) {
+    selection = true;
+  } else {
+    selection = false;
+  }
+
+  return {
+    ...get(childLense, selection === false ? initialState : state),
+    loaded: false,
+    loading: false
+  };
+}
+
+function isEqual(model, location) {
+  return model === location;
+}
+
+function isIncluded(model, location) {
+  return model.includes(location);
+}
+
+export function getCoverage(data, selected) {
+  if (isEmpty(selected)) {
+    return [];
+  }
+  return data.filter(m => m.id === selected.value)[0].geographic_coverage;
+}
+
+export function filterLocationsByModel(
+  locations,
+  modelsCoverage,
+  cb = isEqual
+) {
+  if (!modelsCoverage || isEmpty(modelsCoverage)) return locations;
+  const locationsArray = locations.filter(location =>
+    modelsCoverage.reduce(
+      (acc, model) => acc || cb(model, location.name),
+      false
+    )
+  );
+  return uniqBy(locationsArray, 'id');
+}
+
+export const filterLocationsByMultipleModels = (locations, models) => {
+  if (!locations || !locations.length) return null;
+  if (!models || isEmpty(models)) return locations;
+
+  const modelsCoverage = models.map(m => m.geographic_coverage);
+  return filterLocationsByModel(locations, modelsCoverage, isIncluded);
+};
+
+export const filterModelsByLocations = (modelsData, locationSelected) => {
+  const locationsSelected = [...locationSelected].map(l => l.label);
+  return modelsData.filter(model =>
+    locationsSelected.reduce(
+      (acc, location) => acc && model.geographic_coverage.includes(location),
+      true
+    )
+  );
 };

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator.js
@@ -7,7 +7,6 @@ import VizCreatorComponent from './viz-creator-component';
 import * as reducers from './viz-creator-reducers';
 import * as actions from './viz-creator-actions';
 import initialState from './viz-creator-initial-state';
-
 import {
   datasetsSelector,
   visualisationsSelector,
@@ -31,6 +30,7 @@ import {
 const mapStateToProps = ({ vizCreator }) => ({
   id: vizCreator.id,
   title: vizCreator.title,
+  creatorIsEditing: vizCreator.creatorIsEditing,
   placeholder: getPlaceholder(vizCreator),
   description: vizCreator.description,
   creationStatus: vizCreator.creationStatus,
@@ -133,7 +133,6 @@ class VizCreator extends Component {
                       stackable: onlyStackableIndicators
                     });
                   }
-
                   if (!isEmpty(indicators.selected)) {
                     if (!years.loading && !years.loaded) {
                       fetchYears({
@@ -142,7 +141,6 @@ class VizCreator extends Component {
                         scenarios: scenarios.selected
                       });
                     }
-
                     if (!isEmpty(years.selected)) {
                       if (!timeseries.loading && !timeseries.loaded) {
                         fetchTimeseries({
@@ -166,13 +164,16 @@ class VizCreator extends Component {
   handleFilterSelect = filter => {
     const actionName = toSelector(filter.type);
     if (this.props[actionName]) {
-      const filterParsed = filter.multi
-        ? filter.values
-        : {
+      if (filter.multi) {
+        this.props[actionName](filter.values)
+      } else if (filter.value) {
+        this.props[actionName]({
           value: filter.value,
           label: filter.label
-        };
-      this.props[actionName](filterParsed);
+        })
+      } else {
+        this.props[actionName](null)
+      }
     }
   };
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -259,6 +259,14 @@ export const NDC_DOCUMENT_OPTIONS = [
 export const LATEST_VERSION = 'AR4';
 export const CONTAINED_PATHNAME = 'contained';
 
+export const LENSES_SELECTOR_INFO = {
+  locations: `Every model has only a certain range of locations available. After one location is selected, 
+      all the locations which do not have a model in common with the selected location are filtered out. 
+      Hence, only the locations which have a model in common are displayed and are available for selection. `,
+  models: `This drop-down menu shows only models which have information for all of the locations selected 
+      in the locations menu. You can select fewer locations to get a wider range of models.`
+};
+
 export default {
   CALCULATION_OPTIONS,
   QUANTIFICATION_COLORS,
@@ -282,5 +290,6 @@ export default {
   DISCLAIMER_SHOWN,
   NDC_DOCUMENT_OPTIONS,
   LATEST_VERSION,
-  CONTAINED_PATHNAME
+  CONTAINED_PATHNAME,
+  LENSES_SELECTOR_INFO
 };


### PR DESCRIPTION
# This PR replaces this other one: https://github.com/Vizzuality/climate-watch/pull/554, but with squashed commits.

[Basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/349879565) .  

This PR implements a cache to avoid that when is a change on user selection of a given field on Visualisations Creator all the fields should be filled again. 
So for example if a user adds a second (third...) country in a multi-location chart the subsequents fields (models, scenarios, categories...) will display the cached selection.
-  It updates the filter logic on the selectors and moves it to the reducers.
-  It also adds some info tooltips explaining the behaviour of some filtered selectors.
https://basecamp.com/1756858/projects/13795275/todos/354837515