### PR TITLE
Feature/poverty for year

### DIFF
--- a/app/serializers/api/v1/adaptation/value_serializer.rb
+++ b/app/serializers/api/v1/adaptation/value_serializer.rb
@@ -5,6 +5,7 @@ module Api
         attribute :location
         attribute :value
         attribute :rank, if: -> { object.absolute_rank }
+        attribute :year, if: -> { object.year? }
 
         def location
           object.location.iso_code3

--- a/app/services/import_adaptation.rb
+++ b/app/services/import_adaptation.rb
@@ -52,13 +52,16 @@ class ImportAdaptation
     end
   end
 
+  # rubocop:disable Naming/UncommunicativeMethodParamName
   def variable_attributes(m)
     {
       slug: m[:column_name],
       name: m[:long_name]
     }
   end
+  # rubocop:enable Naming/UncommunicativeMethodParamName
 
+  # rubocop:disable Naming/UncommunicativeMethodParamName
   def value_attributes(k, d, l, r)
     s = {
       location: l,
@@ -72,6 +75,7 @@ class ImportAdaptation
     return s.merge(number_value: d[k]) if d[k].numeric?
     return s.merge(string_value: d[k]) if d[k] != '#N/A'
   end
+  # rubocop:enable Naming/UncommunicativeMethodParamName
 
   def update_ranks
     sql = <<~END

--- a/app/services/import_adaptation.rb
+++ b/app/services/import_adaptation.rb
@@ -67,6 +67,7 @@ class ImportAdaptation
     }
 
     return nil if d[k].nil?
+    s[:year] = d[:poverty_year] if k == :poverty_14
     return s.merge(boolean_value: d[k] == 'YES') if %w(YES NO).include?(d[k])
     return s.merge(number_value: d[k]) if d[k].numeric?
     return s.merge(string_value: d[k]) if d[k] != '#N/A'

--- a/db/migrate/20180615113815_add_year_to_adaptation_values.rb
+++ b/db/migrate/20180615113815_add_year_to_adaptation_values.rb
@@ -1,0 +1,5 @@
+class AddYearToAdaptationValues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :adaptation_values, :year, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -60,7 +60,8 @@ CREATE TABLE adaptation_values (
     absolute_rank integer,
     relative_rank double precision,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    year integer
 );
 
 
@@ -2798,6 +2799,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180612074749'),
 ('20180613114503'),
 ('20180613114709'),
-('20180613124118');
+('20180613124118'),
+('20180615113815');
 
 

--- a/spec/factories/adaptation_variable.rb
+++ b/spec/factories/adaptation_variable.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :adaptation_variable, class: 'Adaptation::Variable' do
     name 'MyText'
-    sequence :slug { |n| ('aa'..'zz').to_a[n] }
+    sequence(:slug) { |n| ('aa'..'zz').to_a[n] }
   end
 end


### PR DESCRIPTION
For now there's only one year / country in the [available data](https://basecamp.com/1756858/projects/13795275/todos/352035002#comment_620174986)

Data file updated in S3, need to: `bundle exec rake adaptation:import`

The response for adaptation values includes the year:

`{location: "AFG", value: 35.8, year: 2011}`


