### PR TITLE
Feature/ndcp embeds

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Dropdown from 'components/dropdown';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
@@ -49,37 +50,51 @@ class CountryGhgEmissions extends PureComponent {
   }
 
   renderActionButtons() {
-    const { iso, handleInfoClick, handleAnalyticsClick, isEmbed } = this.props;
+    const {
+      iso,
+      handleInfoClick,
+      handleAnalyticsClick,
+      isEmbed,
+      isNdcp
+    } = this.props;
+
+    const buttonGroupConfig = isEmbed
+      ? [{ type: 'info', onClick: handleInfoClick }]
+      : [
+        {
+          type: 'info',
+          onClick: handleInfoClick
+        },
+        {
+          type: 'share',
+          shareUrl: `/embed/countries/${iso}/ghg-emissions`,
+          analyticsGraphName: 'Country/Ghg-emissions',
+          reverseDropdown: !isEmbed
+        },
+        {
+          type: 'download'
+        },
+        {
+          type: 'addToUser'
+        }
+      ];
+
+    const link = `/ghg-emissions?breakBy=location&filter=${iso}`;
+    const href = `http://ndcpartnership.org/climate-watch/ghg-emissions?breakBy=location&filter=${iso}`;
 
     return [
       <ButtonGroup
         key="action1"
         className={styles.btnGroup}
-        buttonsConfig={[
-          {
-            type: 'info',
-            onClick: handleInfoClick
-          },
-          {
-            type: 'share',
-            shareUrl: `/embed/countries/${iso}/ghg-emissions`,
-            analyticsGraphName: 'Country/Ghg-emissions',
-            reverseDropdown: !isEmbed
-          },
-          {
-            type: 'download'
-          },
-          {
-            type: 'addToUser'
-          }
-        ]}
+        buttonsConfig={buttonGroupConfig}
       />,
       <Button
         key="action2"
         noSpace
         className={styles.exploreBtn}
         color="yellow"
-        link={`/ghg-emissions?breakBy=location&filter=${iso}`}
+        href={isNdcp ? href : null}
+        link={isNdcp ? null : link}
         onClick={handleAnalyticsClick}
       >
         Explore emissions
@@ -160,7 +175,11 @@ class CountryGhgEmissions extends PureComponent {
             : ''}`}
         </h3>
         <TabletLandscape>
-          <div className={styles.graphControls}>
+          <div
+            className={cx(styles.graphControls, {
+              [styles.graphControlsEmbed]: isEmbed
+            })}
+          >
             {this.renderFilterDropdowns()}
             {this.renderActionButtons()}
           </div>
@@ -184,7 +203,8 @@ class CountryGhgEmissions extends PureComponent {
 }
 
 CountryGhgEmissions.propTypes = {
-  isEmbed: PropTypes.bool.isRequired,
+  isEmbed: PropTypes.bool,
+  isNdcp: PropTypes.bool,
   loading: PropTypes.bool.isRequired,
   data: PropTypes.array.isRequired,
   config: PropTypes.object.isRequired,

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-styles.scss
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-styles.scss
@@ -29,6 +29,16 @@
   margin-bottom: 10px;
 }
 
+.graphControlsEmbed {
+  @include columns((3,3,1,3));
+
+  > :nth-child(3) {
+    @include column-offset(2);
+  }
+
+  margin-bottom: 10px;
+}
+
 .graphControlsSection {
   @include columns((6,6));
 

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -2,7 +2,11 @@ import { createElement, PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { getLocationParamUpdated, isPageContained } from 'utils/navigation';
+import {
+  getLocationParamUpdated,
+  isPageContained,
+  isEmbededComponent
+} from 'utils/navigation';
 import qs from 'query-string';
 import ReactGA from 'react-ga';
 
@@ -33,7 +37,7 @@ const mapStateToProps = (state, { location, match }) => {
   const { data, quantifications } = state.countryGhgEmissions;
   const calculationData = state.wbCountryData.data;
   const { meta } = state.ghgEmissionsMeta;
-  const isEmbed = location.pathname.includes('/embed');
+  const isEmbed = isEmbededComponent(location);
   const search = qs.parse(location.search);
   const iso = match.params.iso;
   const countryGhg = {

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -5,7 +5,8 @@ import { withRouter } from 'react-router-dom';
 import {
   getLocationParamUpdated,
   isPageContained,
-  isEmbededComponent
+  isEmbededComponent,
+  isPageNdcp
 } from 'utils/navigation';
 import qs from 'query-string';
 import ReactGA from 'react-ga';
@@ -38,6 +39,7 @@ const mapStateToProps = (state, { location, match }) => {
   const calculationData = state.wbCountryData.data;
   const { meta } = state.ghgEmissionsMeta;
   const isEmbed = isEmbededComponent(location);
+  const isNdcp = isPageNdcp(location) || isPageContained;
   const search = qs.parse(location.search);
   const iso = match.params.iso;
   const countryGhg = {
@@ -52,6 +54,7 @@ const mapStateToProps = (state, { location, match }) => {
   return {
     iso,
     isEmbed,
+    isNdcp,
     countryName: getCountryName(countryGhg),
     loading: state.countryGhgEmissions.loading || state.wbCountryData.loading,
     data: getChartData(countryGhg),

--- a/app/javascript/app/components/country/country-ghg/country-ghg.js
+++ b/app/javascript/app/components/country/country-ghg/country-ghg.js
@@ -1,12 +1,12 @@
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
+import { isEmbededComponent } from 'utils/navigation';
 import { connect } from 'react-redux';
 import Component from './country-ghg-component';
 
 const mapStateToProps = (state, { location }) => {
   const search = qs.parse(location.search);
-  const pathname = location.pathname;
-  const isEmbedded = pathname.startsWith('/embed');
+  const isEmbedded = isEmbededComponent(location);
   return { search, isEmbedded };
 };
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -25,7 +25,7 @@ class CountryNdcOverview extends PureComponent {
         { type: 'info', onClick: handleInfoClick },
         {
           type: 'share',
-          shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`
+          shareUrl: `/embed/countries/${iso}/ndc-content-overview`
         }
       ];
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -4,9 +4,10 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Intro from 'components/intro';
 import cx from 'classnames';
+import ModalMetadata from 'components/modal-metadata';
 import Loading from 'components/loading';
 import NoContent from 'components/no-content';
-import InfoButton from 'components/button/info-button';
+import ButtonGroup from 'components/button-group';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import introTheme from 'styles/themes/intro/intro-simple.scss';
 import layout from 'styles/layout.scss';
@@ -17,33 +18,53 @@ class CountryNdcOverview extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
 
   renderInfoButton() {
-    const { handleInfoClick } = this.props;
+    const { handleInfoClick, isEmbed, iso } = this.props;
+    const buttonGroupConfig = isEmbed
+      ? [{ type: 'info', onClick: handleInfoClick }]
+      : [
+        { type: 'info', onClick: handleInfoClick },
+        {
+          type: 'share',
+          shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`
+        }
+      ];
+
     return (
-      <InfoButton
-        className={styles.infoBtn}
-        infoOpen={false}
-        handleInfoClick={handleInfoClick}
-        box
+      <ButtonGroup
+        key="action1"
+        className={styles.exploreBtn}
+        buttonsConfig={buttonGroupConfig}
       />
     );
   }
 
   renderCompareButton() {
-    const { iso } = this.props;
+    const { iso, isNdcp } = this.props;
+    const href = 'http://ndcpartnership.org/climate-watch/ndcs';
+    const link = `/ndcs/compare/mitigation?locations=${iso}`;
     return (
-      <Button color="white" link={`/ndcs/compare/mitigation?locations=${iso}`}>
+      <Button
+        color="white"
+        href={isNdcp ? href : null}
+        link={isNdcp ? null : link}
+      >
         Compare
       </Button>
     );
   }
 
   renderExploreButton() {
-    const { iso, handleAnalyticsClick } = this.props;
+    const { iso, handleAnalyticsClick, isNdcp } = this.props;
+
+    const href = 'http://ndcpartnership.org/climate-watch/ndcs';
+    const link = `/ndcs/country/${iso}`;
+
     return (
       <Button
         className={styles.exploreBtn}
         color="yellow"
-        link={`/ndcs/country/${iso}`}
+        href={isNdcp ? href : null}
+        link={isNdcp ? null : link}
         onClick={handleAnalyticsClick}
       >
         Explore NDC content
@@ -153,7 +174,7 @@ class CountryNdcOverview extends PureComponent {
   }
 
   render() {
-    const { sectors, values, loading, actions, iso } = this.props;
+    const { sectors, values, loading, actions, iso, isEmbed } = this.props;
     const hasSectors = values && sectors;
     const description = hasSectors && (
       <p
@@ -166,7 +187,7 @@ class CountryNdcOverview extends PureComponent {
     );
 
     return (
-      <div className={styles.wrapper}>
+      <div className={cx(styles.wrapper, { [styles.embededWrapper]: isEmbed })}>
         <NdcContentOverviewProvider locations={[iso]} />
         {!hasSectors && !loading ? (
           <NoContent
@@ -215,6 +236,7 @@ class CountryNdcOverview extends PureComponent {
             )}
           </div>
         )}
+        <ModalMetadata />
       </div>
     );
   }
@@ -226,6 +248,8 @@ CountryNdcOverview.propTypes = {
   values: PropTypes.object,
   loading: PropTypes.bool,
   actions: PropTypes.bool,
+  isNdcp: PropTypes.bool,
+  isEmbed: PropTypes.bool,
   handleInfoClick: PropTypes.func.isRequired,
   handleAnalyticsClick: PropTypes.func.isRequired
 };

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -6,6 +6,10 @@
   min-height: 450px;
 }
 
+.embededWrapper {
+  border: none;
+}
+
 .countryOverviewPadding {
   padding-bottom: 2em;
 }

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -138,6 +138,7 @@
 
 .exploreBtn {
   margin-bottom: $gutter-padding;
+
   @media #{$tablet-landscape} {
     margin-bottom: 0;
   }

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -29,7 +29,7 @@
   @include xy-gutters($gutter-position: ('bottom'));
 
   @media #{$tablet-landscape} {
-    @include columns((2, 4, 6));
+    @include columns((2.4, 3.6, 6));
   }
 }
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
@@ -5,18 +5,23 @@ import { withRouter } from 'react-router';
 import isEmpty from 'lodash/isEmpty';
 import ReactGA from 'react-ga';
 
+import { isPageNdcp, isEmbededComponent } from 'utils/navigation';
 import { actions } from 'components/modal-metadata';
 
 import CountryNdcOverviewComponent from './country-ndc-overview-component';
 import { getValuesGrouped } from './country-ndc-overview-selectors';
 
-const mapStateToProps = (state, { match }) => {
+const mapStateToProps = (state, { location, match }) => {
   const { iso } = match.params;
   const overviewData =
     state.ndcContentOverview.data && state.ndcContentOverview.data.locations;
   const countryData = overviewData ? overviewData[iso] : null;
+  const isNdcp = isPageNdcp(location);
+  const isEmbed = isEmbededComponent(location);
   return {
     iso,
+    isNdcp,
+    isEmbed,
     values: getValuesGrouped(countryData),
     loading: state.ndcContentOverview.loading,
     sectors: countryData ? countryData.sectors : null,

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
+import cx from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import Loading from 'components/loading';
@@ -62,7 +63,8 @@ class CountrySDGLinkages extends PureComponent {
       loading,
       setTooltipData,
       handleOnDotClick,
-      iso
+      iso,
+      isEmbed
     } = this.props;
     const hasGoals = goals && goals.length > 0;
     if (loading) return <Loading light className={styles.loader} />;
@@ -77,7 +79,7 @@ class CountrySDGLinkages extends PureComponent {
     return (
       hasGoals && (
         <div>
-          <div className={styles.sdgs}>
+          <div className={cx(styles.sdgs, { [styles.sdgsEmbed]: isEmbed })}>
             {goals.map(goal => (
               <SDGCard
                 activeSector={activeSector}

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -8,9 +8,10 @@ import NdcsSdgsMetaProvider from 'providers/ndcs-sdgs-meta-provider';
 import SDGCard from 'components/sdg-card';
 import ReactTooltip from 'react-tooltip';
 import NoContent from 'components/no-content';
+import ButtonGroup from 'components/button-group';
 import Dropdown from 'components/dropdown';
+import ModalMetadata from 'components/modal-metadata';
 import isEqual from 'lodash/isEqual';
-import InfoButton from 'components/button/info-button';
 import Button from 'components/button';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import layout from 'styles/layout.scss';
@@ -107,8 +108,11 @@ class CountrySDGLinkages extends PureComponent {
 
   render() {
     const {
+      iso,
       activeSector,
       sectorOptions,
+      isNdcp,
+      isEmbed,
       handleSectorChange,
       handleInfoClick,
       handleAnalyticsClick
@@ -125,15 +129,40 @@ class CountrySDGLinkages extends PureComponent {
       </div>
     );
 
+    const href = `http://ndcpartnership.org/climate-watch/ndcs-sdg${activeSector
+      ? `?goal=${activeSector.value}`
+      : ''}`;
+    const link = `/ndcs-sdg${activeSector
+      ? `?goal=${activeSector.value}`
+      : ''}`;
+
     const exploreButton = (
       <Button
         className={styles.exploreBtn}
         color="yellow"
-        link={`/ndcs-sdg${activeSector ? `?goal=${activeSector.value}` : ''}`}
+        href={isNdcp ? href : null}
+        link={isNdcp ? null : link}
         onClick={handleAnalyticsClick}
       >
         Explore global linkages
       </Button>
+    );
+    const buttonGroupConfig = isEmbed
+      ? [{ type: 'info', onClick: handleInfoClick }]
+      : [
+        { type: 'info', onClick: handleInfoClick },
+        {
+          type: 'share',
+          shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`
+        }
+      ];
+
+    const buttonGroup = (
+      <ButtonGroup
+        key="action1"
+        className={styles.exploreBtn}
+        buttonsConfig={buttonGroupConfig}
+      />
     );
 
     return (
@@ -144,12 +173,7 @@ class CountrySDGLinkages extends PureComponent {
             <div className={styles.buttons}>
               <h3 className={styles.title}>NDC-SDG Linkages</h3>
               <TabletPortraitOnly>{description}</TabletPortraitOnly>
-              <InfoButton
-                className={styles.infoBtn}
-                infoOpen={false}
-                handleInfoClick={handleInfoClick}
-                box
-              />
+              {buttonGroup}
               <Dropdown
                 label="Filter by sector"
                 placeholder="Choose a sector"
@@ -165,6 +189,7 @@ class CountrySDGLinkages extends PureComponent {
           {this.renderCards()}
           <TabletPortraitOnly>{exploreButton}</TabletPortraitOnly>
         </div>
+        <ModalMetadata />
       </div>
     );
   }
@@ -178,6 +203,8 @@ CountrySDGLinkages.propTypes = {
   sectors: Proptypes.object,
   handleSectorChange: Proptypes.func,
   activeSector: Proptypes.object,
+  isNdcp: Proptypes.bool,
+  isEmbed: Proptypes.bool,
   loading: Proptypes.bool,
   setTooltipData: Proptypes.func,
   tooltipData: Proptypes.object,

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -29,11 +29,15 @@
   }
 }
 
+.sdgsEmbed {
+  margin-bottom: 1px;
+}
+
 .buttons {
   @include columns((12, 12, 2, 10));
 
   @media #{$tablet-landscape} {
-    @include columns((6, 1, 2, 3));
+    @include columns((6, 1.2, 1.8, 3));
   }
 
   .infoBtn,

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
@@ -1,7 +1,12 @@
 import { createElement } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { getLocationParamUpdated } from 'utils/navigation';
+import {
+  getLocationParamUpdated,
+  isPageNdcp,
+  isPageContained,
+  isEmbededComponent
+} from 'utils/navigation';
 import qs from 'query-string';
 import isEmpty from 'lodash/isEmpty';
 import ReactGA from 'react-ga';
@@ -28,6 +33,8 @@ const mapStateToProps = (state, { match, location }) => {
   const { countrySDGLinkages, ndcsSdgsMeta, ndcsSdgsData } = state;
   const { iso } = match.params;
   const search = qs.parse(location.search);
+  const isNdcp = isPageNdcp(location) || isPageContained;
+  const isEmbed = isEmbededComponent(location);
   const tooltipData = countrySDGLinkages.tooltipData;
   const targetsData =
     !isEmpty(ndcsSdgsData.data) && ndcsSdgsData.data[iso]
@@ -51,7 +58,9 @@ const mapStateToProps = (state, { match, location }) => {
     targetsData,
     loading:
       (!ndcsSdgsData.error && ndcsSdgsData.loading) || ndcsSdgsMeta.loading,
-    iso
+    iso,
+    isNdcp,
+    isEmbed
   };
 };
 

--- a/app/javascript/app/layouts/embed/embed-component.jsx
+++ b/app/javascript/app/layouts/embed/embed-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import { renderRoutes } from 'react-router-config';
 import CountriesProvider from 'providers/countries-provider';
+import { isPageNdcp } from 'utils/navigation';
 import cwLogo from 'assets/icons/cw-logo.svg';
 import cx from 'classnames';
 import Icon from 'components/icon';
@@ -13,18 +14,20 @@ class Embed extends PureComponent {
   render() {
     const { route, location } = this.props;
     const link = location.pathname.replace('/embed', '');
-
+    const isNdcp = isPageNdcp(location);
     return (
       <div className={styles.embed}>
         <CountriesProvider />
         <div className={cx(layout.content, styles.embedContent)}>
           {renderRoutes(route.routes)}
         </div>
-        <div className={styles.footer}>
-          <a href={link} target="_blank" rel="noopener noreferrer">
-            <Icon className={styles.logo} icon={cwLogo} />
-          </a>
-        </div>
+        {!isNdcp && (
+          <div className={styles.footer}>
+            <a href={link} target="_blank" rel="noopener noreferrer">
+              <Icon className={styles.logo} icon={cwLogo} />
+            </a>
+          </div>
+        )}
       </div>
     );
   }

--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -5,6 +5,8 @@ import NDCMap from 'components/ndcs/ndcs-map';
 import GhgEmissionsGraph from 'components/ghg-emissions';
 import CompareGhgChart from 'components/compare/compare-ghg-chart';
 import CountryGhg from 'components/country/country-ghg';
+import CountryNdcOverview from 'components/country/country-ndc-overview';
+import NDCSDGLinkages from 'components/country/country-ndc-sdg-linkages';
 import NdcSdgLinkagesContent from 'components/ndc-sdg/ndc-sdg-linkages-content';
 import EmissionPathwaysGraph from 'components/emission-pathways/emission-pathways-graph';
 import MyVisualisationsGraphComponent from 'components/my-climate-watch/my-visualisations/my-cw-vis-graph';
@@ -28,6 +30,16 @@ export default [
   {
     path: '/embed/countries/:iso/ghg-emissions',
     component: CountryGhg,
+    exact: true
+  },
+  {
+    path: '/embed/countries/:iso/ndc-content-overview',
+    component: CountryNdcOverview,
+    exact: true
+  },
+  {
+    path: '/embed/countries/:iso/ndc-sdg-linkages',
+    component: NDCSDGLinkages,
     exact: true
   },
   {

--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -34,8 +34,8 @@ export default [
   },
   {
     path: '/embed/countries/:iso/ndc-content-overview',
-    component: CountryNdcOverview,
-    exact: true
+    exact: true,
+    component: () => createElement(CountryNdcOverview, { actions: true })
   },
   {
     path: '/embed/countries/:iso/ndc-sdg-linkages',

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -25,7 +25,17 @@ export function getLocationParamUpdated(location, params = [], clear = false) {
 export const isPageContained =
   window.location.pathname.split('/')[1] === CONTAINED_PATHNAME;
 
+export const isPageNdcp = location => {
+  const search = qs.parse(location.search);
+  return search && search.isNdcp && search.isNdcp === 'true';
+};
+
+export const isEmbededComponent = location =>
+  location.pathname.includes('/embed');
+
 export default {
   getLocationParamUpdated,
-  isPageContained
+  isPageContained,
+  isPageNdcp,
+  isEmbededComponent
 };


### PR DESCRIPTION
This Pr updates links and some styles to behave differently if they are visited from the ndcpartnership.org site.  
It also enables two more embedded modules (NDC-SDG and NDC Overview sections from country GHG page)
[Basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/355098762)

-  Overview
 [`NOT on ndcp`](http://localhost:3000/embed/countries/USA/ndc-content-overview)
 [`on ndcp`](http://localhost:3000/embed/countries/USA/ndc-content-overview?isNdcp=true)
-  NDC-SDG
[`NOT on ndcp`](http://localhost:3000/embed/countries/USA/ndc-sdg-linkages)
[`on ndcp`](http://localhost:3000/embed/countries/USA/ndc-sdg-linkages?isNdcp=true)  

The written code assumes the existence of a flag in the URL (`?isNdcp=true`) when joining the platform from ncd partnership site 