### PR TITLE
Info tooltip on multiple location charts selectors (`locations` and `models`)

### DIFF
--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
@@ -45,7 +45,7 @@ const Step3 = props => {
   const selectorClearable = (type, selection) =>
     type !== 'locations' || _isEmpty(selection);
 
-  const { spec, handleFilterSelect, hasData } = props;
+  const { spec, handleFilterSelect, hasData, isMultipleLocationVis } = props;
 
   return (
     <li className={styles.step}>
@@ -69,11 +69,12 @@ const Step3 = props => {
                         selectProps(f, 'value').hidden
                     })}
                   >
-                    {f.info && (
-                      <div data-tip={f.info} className={styles.infoContainer}>
-                        <Icon icon={infoIcon} className={styles.infoIcon} />
-                      </div>
-                    )}
+                    {f.info &&
+                    isMultipleLocationVis && (
+                    <div data-tip={f.info} className={styles.infoContainer}>
+                          <Icon icon={infoIcon} className={styles.infoIcon} />
+                        </div>
+                      )}
                     {f.multi ? (
                       <MultiSelect
                         className={styles.dropDowns}
@@ -114,7 +115,8 @@ const Step3 = props => {
 Step3.propTypes = {
   spec: PropTypes.object.isRequired,
   handleFilterSelect: PropTypes.func.isRequired,
-  hasData: PropTypes.bool
+  hasData: PropTypes.bool,
+  isMultipleLocationVis: PropTypes.bool
 };
 
 export default Step3;

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-three.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import _map from 'lodash/map';
@@ -13,104 +13,110 @@ import Icon from 'components/icon';
 import infoIcon from 'assets/icons/info.svg';
 import styles from './steps-styles';
 
-const Step3 = props => {
-  const selectProps = (f, format) => {
-    let value = f.selected;
-    if (!value) {
-      value = f.multi ? [] : {};
-    }
-    const disabled = _isUndefined(f.disabled) ? _isEmpty(f.data) : f.disabled;
-    return {
-      disabled,
-      [format]: value,
-      options: (f.data || []).map(d => ({
-        ...d,
-        label: d.label || '',
-        key: `${d.label}-${Date.now()}`
-      })),
-      placeholder: f.placeholder || f.name,
-      hidden: f.hidden,
-      loading: f.loading
+class Step3 extends Component {
+  componentDidUpdate() {
+    ReactTooltip.rebuild();
+  }
+
+  render() {
+    const selectProps = (f, format) => {
+      let value = f.selected;
+      if (!value) {
+        value = f.multi ? [] : {};
+      }
+      const disabled = _isUndefined(f.disabled) ? _isEmpty(f.data) : f.disabled;
+      return {
+        disabled,
+        [format]: value,
+        options: (f.data || []).map(d => ({
+          ...d,
+          label: d.label || '',
+          key: `${d.label}-${Date.now()}`
+        })),
+        placeholder: f.placeholder || f.name,
+        hidden: f.hidden,
+        loading: f.loading
+      };
     };
-  };
 
-  const sortMultiselectLabels = (f, format) => {
-    const labels = selectProps(f, format);
-    const optionsSorted = labels.options.sort(
-      (a, b) => (a.label > b.label ? 1 : -1)
-    );
-    return { options: optionsSorted, ...labels };
-  };
+    const sortMultiselectLabels = (f, format) => {
+      const labels = selectProps(f, format);
+      const optionsSorted = labels.options.sort(
+        (a, b) => (a.label > b.label ? 1 : -1)
+      );
+      return { options: optionsSorted, ...labels };
+    };
 
-  const selectorClearable = (type, selection) =>
-    type !== 'locations' || _isEmpty(selection);
+    const selectorClearable = (type, selection) =>
+      type !== 'locations' || _isEmpty(selection);
 
-  const { spec, handleFilterSelect, hasData, isMultipleLocationVis } = props;
+    const { spec, handleFilterSelect, hasData, isMultipleLocationVis } = this.props;
 
-  return (
-    <li className={styles.step}>
-      <div
-        className={cx(styles.stepContainer, {
-          [styles.openDropdownPadding]: !hasData
-        })}
-      >
-        <h2 className={styles.stepTitle}>3/4 - Filter the data</h2>
-        <div className="layout-item-container">
-          {spec && (
-            <ul className={styles.selectsContainer}>
-              {_map(spec, (f, i) => {
-                if (!f.data) return null;
-                return (
-                  <li
-                    key={f.name || i}
-                    className={cx(styles.selectsItem, {
-                      [styles.selectsItemHidden]:
-                        selectProps(f, 'values').hidden ||
-                        selectProps(f, 'value').hidden
-                    })}
-                  >
-                    {f.info &&
-                    isMultipleLocationVis && (
-                    <div data-tip={f.info} className={styles.infoContainer}>
+    return (
+      <li className={styles.step}>
+        <div
+          className={cx(styles.stepContainer, {
+            [styles.openDropdownPadding]: !hasData
+          })}
+        >
+          <h2 className={styles.stepTitle}>3/4 - Filter the data</h2>
+          <div className="layout-item-container">
+            {spec && (
+              <ul className={styles.selectsContainer}>
+                {_map(spec, (f, i) => {
+                  if (!f.data) return null;
+                  return (
+                    <li
+                      key={f.name || i}
+                      className={cx(styles.selectsItem, {
+                        [styles.selectsItemHidden]:
+                          selectProps(f, 'values').hidden ||
+                          selectProps(f, 'value').hidden
+                      })}
+                    >
+                      {f.info && isMultipleLocationVis && (
+                        <div data-tip={f.info} className={styles.infoContainer}>
                           <Icon icon={infoIcon} className={styles.infoIcon} />
                         </div>
                       )}
-                    {f.multi ? (
-                      <MultiSelect
-                        className={styles.dropDowns}
-                        {...sortMultiselectLabels(f, 'values')}
-                        label={upperFirst(f.name)}
-                        onMultiValueChange={e =>
-                          handleFilterSelect({
-                            values: e,
-                            type: f.name,
-                            multi: f.multi
-                          })}
-                      />
-                    ) : (
-                      <Dropdown
-                        {...selectProps(f, 'value')}
-                        className={styles.dropDowns}
-                        label={upperFirst(f.label)}
-                        onValueChange={e =>
-                          handleFilterSelect({
-                            ...e,
-                            type: f.name
-                          })}
-                        hideResetButton={selectorClearable(f.name, f.selected)}
-                      />
-                    )}
-                    <ReactTooltip />
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+                      {f.multi ? (
+                        <MultiSelect
+                          className={styles.dropDowns}
+                          {...sortMultiselectLabels(f, 'values')}
+                          label={upperFirst(f.name)}
+                          onMultiValueChange={e =>
+                            handleFilterSelect({
+                              values: e,
+                              type: f.name,
+                              multi: f.multi
+                            })}
+                        />
+                      ) : (
+                        <Dropdown
+                          {...selectProps(f, 'value')}
+                          className={styles.dropDowns}
+                          label={upperFirst(f.label)}
+                          onValueChange={e =>
+                            handleFilterSelect({
+                              ...e,
+                              type: f.name
+                            })}
+                          hideResetButton={selectorClearable(f.name, f.selected)}
+                        />
+                      )}
+                      <ReactTooltip />
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
         </div>
-      </div>
-    </li>
-  );
-};
+      </li>
+    );
+  }
+}
+
 
 Step3.propTypes = {
   spec: PropTypes.object.isRequired,

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
@@ -20,6 +20,7 @@ const VizCreator = props => {
     visualisations,
     visualisationType,
     visualisationOptions,
+    isMultipleLocationVis,
     hasData,
     chartData,
     legends,
@@ -40,7 +41,14 @@ const VizCreator = props => {
           <Step2 {...{ visualisations, selectVisualisation }} />
         )}
         {visualisations.selected && (
-          <Step3 {...{ spec: filters, handleFilterSelect, hasData }} />
+          <Step3
+            {...{
+              spec: filters,
+              handleFilterSelect,
+              hasData,
+              isMultipleLocationVis
+            }}
+          />
         )}
         {hasData && (
           <Step4
@@ -76,6 +84,7 @@ VizCreator.propTypes = {
   visualisations: PropTypes.object,
   visualisationType: PropTypes.string,
   visualisationOptions: PropTypes.object,
+  isMultipleLocationVis: PropTypes.bool,
   timeseries: PropTypes.object,
   hasData: PropTypes.bool,
   chartData: PropTypes.object,

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-selectors.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-selectors.js
@@ -38,6 +38,18 @@ export const titleSelector = state => state.title;
 export const placeholderSelector = state => state.placeholder;
 export const editingSelector = state => state.creatorIsEditing;
 
+export const isMultipleLocationVis = createSelector(
+  visualisationsSelector,
+  vis => {
+    if (vis && vis.data && vis.selected) {
+      return _isEmpty(
+        vis.data[0].visualisations.filter(v => v.id === vis.selected)
+      );
+    }
+    return false;
+  }
+);
+
 export const hasDataSelector = createSelector(
   [timeseriesSelector, scenariosSelector],
   (timeseries, scenarios) =>

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator.js
@@ -10,6 +10,7 @@ import initialState from './viz-creator-initial-state';
 import {
   datasetsSelector,
   visualisationsSelector,
+  isMultipleLocationVis,
   locationsSelector,
   modelsSelector,
   scenariosSelector,
@@ -38,6 +39,7 @@ const mapStateToProps = ({ vizCreator }) => ({
   visualisations: visualisationsSelector(vizCreator),
   visualisationType: getVisualisationType(vizCreator),
   visualisationOptions: getVisualisationOptions(vizCreator),
+  isMultipleLocationVis: isMultipleLocationVis(vizCreator),
   locations: locationsSelector(vizCreator),
   models: modelsSelector(vizCreator),
   scenarios: scenariosSelector(vizCreator),
@@ -165,14 +167,14 @@ class VizCreator extends Component {
     const actionName = toSelector(filter.type);
     if (this.props[actionName]) {
       if (filter.multi) {
-        this.props[actionName](filter.values)
+        this.props[actionName](filter.values);
       } else if (filter.value) {
         this.props[actionName]({
           value: filter.value,
           label: filter.label
-        })
+        });
       } else {
-        this.props[actionName](null)
+        this.props[actionName](null);
       }
     }
   };


### PR DESCRIPTION
This PR fixes Viscreator info tooltip to display only in charts that allow multiple locations selection.

https://basecamp.com/1756858/projects/13795275/todos/354837515 
 


![kapture 2018-06-18 at 15 33 58](https://user-images.githubusercontent.com/6906348/41539052-14bef4d2-730d-11e8-82fd-82d79b07de6e.gif)
