### PR TITLE
Fix/ndc sdg filter

### DIFF
--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
+import cx from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import Loading from 'components/loading';
@@ -30,24 +31,33 @@ class CountrySDGLinkages extends PureComponent {
   getTooltip() {
     const { sectors, tooltipData, targets, tooltipSectorIds } = this.props;
     const targetsContent = targets && targets[tooltipData.goal_number];
-    const hasTooltipData = tooltipSectorIds && tooltipSectorIds.length > 0;
+    const hasTooltipData = sector => {
+      if (tooltipSectorIds) return tooltipSectorIds.includes(sector);
+      return false;
+    };
     return tooltipData && targetsContent ? (
       <div className={styles.tooltip}>
         <p className={styles.tooltipTitle}>
           <b>{tooltipData.number}: </b>
           {tooltipData.title}
         </p>
-        {hasTooltipData && (
-          <p className={styles.sectors}>
-            <b>Sectors: </b>
-            {tooltipSectorIds.map((sector, index) => (
-              <span key={`${tooltipData.targetKey}-${sector}`}>
+        <p className={styles.sectors}>
+          <b>Sectors: </b>
+          {tooltipData.sectors.map((sector, index) => (
+            <span key={`${tooltipData.targetKey}-${sector}`}>
+              <span
+                className={cx({
+                  [styles.sectorIcluded]: hasTooltipData(sector)
+                })}
+              >
                 {sectors[sector]}
-                {index === tooltipSectorIds.length - 1 ? '' : ', '}
               </span>
-            ))}
-          </p>
-        )}
+              <span>
+                {index === tooltipData.sectors.length - 1 ? '' : ', '}
+              </span>
+            </span>
+          ))}
+        </p>
       </div>
     ) : null;
   }

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -41,23 +41,25 @@ class CountrySDGLinkages extends PureComponent {
           <b>{tooltipData.number}: </b>
           {tooltipData.title}
         </p>
-        <p className={styles.sectors}>
-          <b>Sectors: </b>
-          {tooltipData.sectors.map((sector, index) => (
-            <span key={`${tooltipData.targetKey}-${sector}`}>
-              <span
-                className={cx({
-                  [styles.sectorIcluded]: hasTooltipData(sector)
-                })}
-              >
-                {sectors[sector]}
+        {!isEmpty(tooltipData.sectors) && (
+          <p className={styles.sectors}>
+            <b>Sectors: </b>
+            {tooltipData.sectors.map((sector, index) => (
+              <span key={`${tooltipData.targetKey}-${sector}`}>
+                <span
+                  className={cx({
+                    [styles.sectorIcluded]: hasTooltipData(sector)
+                  })}
+                >
+                  {sectors[sector]}
+                </span>
+                <span>
+                  {index === tooltipData.sectors.length - 1 ? '' : ', '}
+                </span>
               </span>
-              <span>
-                {index === tooltipData.sectors.length - 1 ? '' : ', '}
-              </span>
-            </span>
-          ))}
-        </p>
+            ))}
+          </p>
+        )}
       </div>
     ) : null;
   }

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -48,7 +48,7 @@ class CountrySDGLinkages extends PureComponent {
               <span key={`${tooltipData.targetKey}-${sector}`}>
                 <span
                   className={cx({
-                    [styles.sectorIcluded]: hasTooltipData(sector)
+                    [styles.sectorIncluded]: hasTooltipData(sector)
                   })}
                 >
                   {sectors[sector]}

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -90,7 +90,7 @@
   padding-top: 15px;
 }
 
-.sectorIcluded {
+.sectorIncluded {
   text-decoration: underline;
 }
 

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -90,6 +90,10 @@
   padding-top: 15px;
 }
 
+.sectorIcluded {
+  text-decoration: underline;
+}
+
 .info {
   flex-basis: 100%;
 }

--- a/app/javascript/app/components/sdg-card/dot/dot.js
+++ b/app/javascript/app/components/sdg-card/dot/dot.js
@@ -6,9 +6,11 @@ class DotContainer extends PureComponent {
   render() {
     const { target, targetData, activeSector, iso } = this.props;
     const isSmall =
-      target.sectors &&
-      activeSector &&
-      target.sectors.indexOf(parseInt(activeSector.value, 10)) === -1;
+      activeSector && targetData && targetData.targets[target.number]
+        ? targetData.targets[target.number].sectors.indexOf(
+          parseInt(activeSector.value, 10)
+        ) === -1 || !target.sectors.includes(activeSector.value)
+        : activeSector && !target.sectors.includes(activeSector.value);
     const hasSectors = !!(
       targetData &&
       targetData.targets[target.number] &&


### PR DESCRIPTION
[pivotal task](https://www.pivotaltracker.com/story/show/158298764)
[basecamp thread](https://basecamp.com/1756858/projects/13795275/todos/350915718)
Updates dots behaviour on country NDC-SDG's section and tooltip sectors data:
-  Coloured dots (SDG's selected country has on its NDC commitments) stay big when a filter sector is active only if this sector is under their commitments.
-  On the tooltip are listed all the sectors under an SDG, but only those who are under a country commitment are underlined.  


![kapture 2018-06-18 at 19 09 50](https://user-images.githubusercontent.com/6906348/41551127-3a676372-732b-11e8-9604-6f4fe88dd261.gif)
 

