### PR TITLE
Feature/search improvements

### DIFF
--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -104,14 +104,16 @@ class Ndc < ApplicationRecord
         ]
       )
 
+    # rubocop:disable Style/IfUnlessModifier
     if document_type && language
       ndc = ndc.where(document_type: document_type, language: language)
     end
+    # rubocop:enable Style/IfUnlessModifier
 
     ndc.where(
-        locations: {
-          iso_code3: iso_code3.upcase
-        }
-      )
+      locations: {
+        iso_code3: iso_code3.upcase
+      }
+    )
   end
 end

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -47,7 +47,15 @@ class Ndc < ApplicationRecord
 
   def self.refresh_full_text_tsv
     sql = <<~EOT
-      full_text_tsv = to_tsvector('#{PG_SEARCH_TSEARCH_DICTIONARY}', COALESCE(full_text, ''))
+      full_text_tsv = to_tsvector(
+        '#{PG_SEARCH_TSEARCH_DICTIONARY}',
+        REGEXP_REPLACE(
+          COALESCE(full_text, ''),
+          '<sub>(\d+?)</sub>',
+          E'\\1',
+          'g'
+        )
+      )
     EOT
     update_all(sql)
   end

--- a/app/services/import_ndc_texts.rb
+++ b/app/services/import_ndc_texts.rb
@@ -13,6 +13,9 @@ class ImportNdcTexts
 
   private
 
+  # rubocop:disable Naming/UncommunicativeMethodParamName
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def import_object(s3, bucket_name, object)
     object.key =~
       /#{CW_FILES_PREFIX}ndc_texts\/(.+?)-(.+?)-(.+?)(-.+?)?(\.md)?\.html/
@@ -45,6 +48,9 @@ class ImportNdcTexts
       translated: translated
     )
   end
+  # rubocop:enable Naming/UncommunicativeMethodParamName
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def html_content_with_resolved_image_paths(html_content)
     begin

--- a/config/initializers/tsearch.rb
+++ b/config/initializers/tsearch.rb
@@ -3,6 +3,8 @@
 # currently not possible to specify this through pg_search options
 # https://github.com/Casecommons/pg_search/issues/173
 
+# another patch to allow "phrase searching" to sequences of terms in
+# double quotes, using the <-> (followed by) search operator
 require "active_support/core_ext/module/delegation"
 
 module PgSearch
@@ -16,6 +18,46 @@ module PgSearch
           arel_wrap(tsquery),
           normalization
         ]).to_sql
+      end
+
+      def tsquery
+        return "''" if query.blank?
+        tsquery_terms.join(options[:any_word] ? ' || ' : ' && ')
+      end
+
+      PHRASE_REGEXP = /".+?"/
+
+      def tsquery_terms
+        # match all phrases in query - sequences in double quotes
+        phrases = query.to_enum(:scan, PHRASE_REGEXP).map do
+          md = Regexp.last_match
+          offset = md.offset(0)
+          {start: offset[0], end: offset[1]}
+        end
+        term_sequences = []
+        start_idx = 0
+        phrases.each do |phrase|
+          term_sequences << {
+            type: :term,
+            body: query.slice(start_idx, phrase[:start] - start_idx)
+          } unless (phrase[:start] - start_idx).zero?
+          term_sequences << {
+            type: :phrase,
+            body: query.slice(phrase[:start], phrase[:end] - phrase[:start])
+          }
+          start_idx = phrase[:end]
+        end
+        term_sequences << {type: :term, body: query} unless phrases.any?
+
+        term_sequences.map do |term_sequence|
+          query_terms = term_sequence[:body].split(' ')
+          tsquery_terms = query_terms.map { |term| tsquery_for_term(term) }
+          if term_sequence[:type] == :term
+            tsquery_terms.join(options[:any_word] ? ' || ' : ' && ')
+          else
+            '(' + tsquery_terms.join(' <-> ') + ')'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
2 improvements for full text search:
* Search for the sequence of words in quotes - this is supported by postgres when using the `<->` "followed by" search operator; however, I had to monkey-patch pg_search in order to make it apply this operator. it's the second monkey patch we applied to pg_search already, which looks like an opportunity to contribute to that project (please note: results look much better, with exact phrase matches at top, but it still highlights parts of the phrase in the results)
* Search for terms with subscripts (CO2) - this requires reindexing the documents. It can be done either by running `Ndc.refresh_full_text_tsv` in the console or by running `bundle exec rake ndcs:full:index`; the result is that subscripts used for formatting the symbols in html are stripped for purposes of indexing, so that searching by CO2, N2O actually retrieves all relevant documents