### PR TITLE
Feature/data explorer metadata

### DIFF
--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -69,7 +69,11 @@ const AnchorNav = props => {
                 </NavLink>
               );
             }
-            linkProps.isActive = () => link.hash === activeSection;
+            linkProps.isActive = (match, location) =>
+              link.hash === activeSection ||
+              (link.defaultActiveHash &&
+                (`#${link.hash}` === location.hash ||
+                  (!location.hash && index === 0)));
             return (
               <NavHashLink
                 {...linkProps}

--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
@@ -69,7 +69,7 @@ class CompareSocioeconomics extends PureComponent {
               {countrySocioeconomics && countrySocioeconomics.some(c => c) ? (
                 countrySocioeconomics.map((countrySocioeconomicData, i) => (
                   <div
-                    key={`socioeconomic-${i}{${locations[i]}`}
+                    key={`socioeconomic-${i}{${locations[i]}`} //eslint-disable-line
                     className={styles.compareSocioeconomics}
                   >
                     <TabletPortraitOnly>

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DataExplorerProvider from 'providers/data-explorer-provider/data-explorer-provider';
 import Table from 'components/table';
+import MetadataText from 'components/metadata-text';
 import AnchorNav from 'components/anchor-nav';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
@@ -9,11 +10,12 @@ import Button from 'components/button';
 import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
 import styles from './data-explorer-content-styles.scss';
 
+const noData = <NoContent message={'No data'} className={styles.noData} />;
 class DataExplorerContent extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   renderContent() {
     const { metadataSection } = this.props;
-    return metadataSection ? 'meta' : this.renderTable();
+    return metadataSection ? this.renderMeta() : this.renderTable();
   }
 
   renderTable() {
@@ -27,7 +29,16 @@ class DataExplorerContent extends PureComponent {
         horizontalScroll
       />
     ) : (
-      <NoContent message={'No data'} className={styles.noData} />
+      noData
+    );
+  }
+
+  renderMeta() {
+    const { meta } = this.props;
+    return meta ? (
+      <MetadataText className={styles.metadataText} data={meta} />
+    ) : (
+      noData
     );
   }
 
@@ -67,6 +78,7 @@ DataExplorerContent.propTypes = {
   section: PropTypes.string.isRequired,
   metadataSection: PropTypes.bool,
   data: PropTypes.array,
+  meta: PropTypes.array,
   firstColumnHeaders: PropTypes.array,
   loading: PropTypes.bool,
   href: PropTypes.string,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -65,7 +65,14 @@ class DataExplorerContent extends PureComponent {
   }
 
   render() {
-    const { section, href, downloadHref, metadataSection } = this.props;
+    const {
+      section,
+      href,
+      downloadHref,
+      metadataSection,
+      anchorLinks,
+      query
+    } = this.props;
     return (
       <div>
         <DataExplorerProvider section={section} />
@@ -73,11 +80,9 @@ class DataExplorerContent extends PureComponent {
         <CountriesProvider />
         <div className={styles.filtersContainer}>{this.renderFilters()}</div>
         <AnchorNav
-          links={[
-            { label: 'Raw Data', hash: 'data', defaultActiveHash: true },
-            { label: 'Methodology', hash: 'meta', defaultActiveHash: true }
-          ]}
+          links={anchorLinks}
           theme={anchorNavLightTheme}
+          query={query}
         />
         <div className={styles.tableContainer}>
           {metadataSection ? this.renderMeta() : this.renderTable()}
@@ -108,7 +113,9 @@ DataExplorerContent.propTypes = {
   loading: PropTypes.bool,
   loadingMeta: PropTypes.bool,
   href: PropTypes.string,
-  downloadHref: PropTypes.string
+  downloadHref: PropTypes.string,
+  anchorLinks: PropTypes.array,
+  query: PropTypes.string
 };
 
 export default DataExplorerContent;

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -13,13 +13,9 @@ import styles from './data-explorer-content-styles.scss';
 const noData = <NoContent message={'No data'} className={styles.noData} />;
 class DataExplorerContent extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
-  renderContent() {
-    const { metadataSection } = this.props;
-    return metadataSection ? this.renderMeta() : this.renderTable();
-  }
-
   renderTable() {
-    const { data, firstColumnHeaders } = this.props;
+    const { data, firstColumnHeaders, loading } = this.props;
+    if (loading) return <Loading light className={styles.loader} />;
     return data ? (
       <Table
         data={data}
@@ -34,7 +30,8 @@ class DataExplorerContent extends PureComponent {
   }
 
   renderMeta() {
-    const { meta } = this.props;
+    const { meta, loadingMeta } = this.props;
+    if (loadingMeta) return <Loading light className={styles.loader} />;
     return meta ? (
       <MetadataText className={styles.metadataText} data={meta} />
     ) : (
@@ -43,7 +40,7 @@ class DataExplorerContent extends PureComponent {
   }
 
   render() {
-    const { section, loading, href, downloadHref } = this.props;
+    const { section, href, downloadHref, metadataSection } = this.props;
     return (
       <div>
         <DataExplorerProvider section={section} />
@@ -55,11 +52,7 @@ class DataExplorerContent extends PureComponent {
           theme={anchorNavLightTheme}
         />
         <div className={styles.tableContainer}>
-          {loading ? (
-            <Loading light className={styles.loader} />
-          ) : (
-            this.renderContent()
-          )}
+          {metadataSection ? this.renderMeta() : this.renderTable()}
         </div>
         <div className={styles.buttons}>
           <Button className={styles.button} href={href} color="plain">
@@ -81,6 +74,7 @@ DataExplorerContent.propTypes = {
   meta: PropTypes.object,
   firstColumnHeaders: PropTypes.array,
   loading: PropTypes.bool,
+  loadingMeta: PropTypes.bool,
   href: PropTypes.string,
   downloadHref: PropTypes.string
 };

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -49,8 +49,8 @@ class DataExplorerContent extends PureComponent {
         <DataExplorerProvider section={section} />
         <AnchorNav
           links={[
-            { label: 'Raw Data', hash: 'data' },
-            { label: 'Methodology', hash: 'meta' }
+            { label: 'Raw Data', hash: 'data', defaultActiveHash: true },
+            { label: 'Methodology', hash: 'meta', defaultActiveHash: true }
           ]}
           theme={anchorNavLightTheme}
         />

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -78,7 +78,7 @@ DataExplorerContent.propTypes = {
   section: PropTypes.string.isRequired,
   metadataSection: PropTypes.bool,
   data: PropTypes.array,
-  meta: PropTypes.array,
+  meta: PropTypes.object,
   firstColumnHeaders: PropTypes.array,
   loading: PropTypes.bool,
   href: PropTypes.string,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DataExplorerProvider from 'providers/data-explorer-provider/data-explorer-provider';
+import RegionsProvider from 'providers/regions-provider/regions-provider';
+import CountriesProvider from 'providers/countries-provider/countries-provider';
 import Table from 'components/table';
 import Dropdown from 'components/dropdown';
 import MetadataText from 'components/metadata-text';
@@ -68,6 +70,8 @@ class DataExplorerContent extends PureComponent {
     return (
       <div>
         <DataExplorerProvider section={section} />
+        <RegionsProvider />
+        <CountriesProvider />
         <div className={styles.filtersContainer}>{this.renderFilters()}</div>
         <AnchorNav
           links={[

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -2,12 +2,14 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DataExplorerProvider from 'providers/data-explorer-provider/data-explorer-provider';
 import Table from 'components/table';
+import Dropdown from 'components/dropdown';
 import MetadataText from 'components/metadata-text';
 import AnchorNav from 'components/anchor-nav';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
 import Button from 'components/button';
 import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
+import { toStartCase } from 'app/utils';
 import styles from './data-explorer-content-styles.scss';
 
 const noData = <NoContent message={'No data'} className={styles.noData} />;
@@ -39,11 +41,34 @@ class DataExplorerContent extends PureComponent {
     );
   }
 
+  renderFilters() {
+    const {
+      handleFilterChange,
+      selectedOptions,
+      filterOptions,
+      filters
+    } = this.props;
+
+    return filters.map(field => (
+      <Dropdown
+        key={field}
+        label={toStartCase(field)}
+        placeholder={`Filter by ${toStartCase(field)}`}
+        options={filterOptions ? filterOptions[field] : []}
+        onValueChange={selected =>
+          handleFilterChange(field, selected && selected.slug)}
+        value={selectedOptions ? selectedOptions[field] : null}
+        plain
+      />
+    ));
+  }
+
   render() {
     const { section, href, downloadHref, metadataSection } = this.props;
     return (
       <div>
         <DataExplorerProvider section={section} />
+        <div className={styles.filtersContainer}>{this.renderFilters()}</div>
         <AnchorNav
           links={[
             { label: 'Raw Data', hash: 'data', defaultActiveHash: true },
@@ -69,6 +94,10 @@ class DataExplorerContent extends PureComponent {
 
 DataExplorerContent.propTypes = {
   section: PropTypes.string.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+  filters: PropTypes.array,
+  selectedOptions: PropTypes.object,
+  filterOptions: PropTypes.object,
   metadataSection: PropTypes.bool,
   data: PropTypes.array,
   meta: PropTypes.object,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -2,13 +2,20 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DataExplorerProvider from 'providers/data-explorer-provider/data-explorer-provider';
 import Table from 'components/table';
+import AnchorNav from 'components/anchor-nav';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
 import Button from 'components/button';
+import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
 import styles from './data-explorer-content-styles.scss';
 
 class DataExplorerContent extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
+  renderContent() {
+    const { metadataSection } = this.props;
+    return metadataSection ? 'meta' : this.renderTable();
+  }
+
   renderTable() {
     const { data, firstColumnHeaders } = this.props;
     return data ? (
@@ -23,16 +30,24 @@ class DataExplorerContent extends PureComponent {
       <NoContent message={'No data'} className={styles.noData} />
     );
   }
+
   render() {
     const { section, loading, href, downloadHref } = this.props;
     return (
       <div>
         <DataExplorerProvider section={section} />
+        <AnchorNav
+          links={[
+            { label: 'Raw Data', hash: 'data' },
+            { label: 'Methodology', hash: 'meta' }
+          ]}
+          theme={anchorNavLightTheme}
+        />
         <div className={styles.tableContainer}>
           {loading ? (
             <Loading light className={styles.loader} />
           ) : (
-            this.renderTable()
+            this.renderContent()
           )}
         </div>
         <div className={styles.buttons}>
@@ -50,6 +65,7 @@ class DataExplorerContent extends PureComponent {
 
 DataExplorerContent.propTypes = {
   section: PropTypes.string.isRequired,
+  metadataSection: PropTypes.bool,
   data: PropTypes.array,
   firstColumnHeaders: PropTypes.array,
   loading: PropTypes.bool,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -14,7 +14,6 @@ import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss'
 import { toStartCase } from 'app/utils';
 import styles from './data-explorer-content-styles.scss';
 
-const noData = <NoContent message={'No data'} className={styles.noData} />;
 class DataExplorerContent extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   renderTable() {
@@ -29,7 +28,7 @@ class DataExplorerContent extends PureComponent {
         horizontalScroll
       />
     ) : (
-      noData
+      <NoContent message={'No data'} className={styles.noData} />
     );
   }
 
@@ -39,7 +38,7 @@ class DataExplorerContent extends PureComponent {
     return meta ? (
       <MetadataText className={styles.metadataText} data={meta} />
     ) : (
-      noData
+      <NoContent message={'Select a source'} className={styles.noData} />
     );
   }
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -1,7 +1,11 @@
 import { createSelector } from 'reselect';
 import remove from 'lodash/remove';
+import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
-import { DATA_EXPLORER_BLACKLIST } from 'data/constants';
+import {
+  DATA_EXPLORER_BLACKLIST,
+  DATA_EXPLORER_METADATA_SOURCE
+} from 'data/constants';
 
 export const getData = createSelector(
   [state => state.data, state => state.section],
@@ -12,10 +16,13 @@ export const getData = createSelector(
 );
 
 export const getMeta = createSelector(
-  [state => state.data, state => state.section],
-  (data, section) => {
-    if (!data || !section) return null;
-    return (data && data[section] && data[section].meta) || null;
+  [state => state.meta, state => state.section],
+  (meta, section) => {
+    if (!meta || isEmpty(meta) || !section) return null;
+    const sectionMetadata = meta['section-metadata'];
+    return sectionMetadata.find(
+      s => s.source === DATA_EXPLORER_METADATA_SOURCE[section]
+    );
   }
 );
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -4,11 +4,15 @@ import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import {
   DATA_EXPLORER_BLACKLIST,
-  DATA_EXPLORER_METADATA_SOURCE
+  DATA_EXPLORER_METADATA_SOURCE,
+  DATA_EXPLORER_FILTERS
 } from 'data/constants';
 
+const getSection = state => state.section || null;
+const getSearch = state => state.search || null;
+
 export const getData = createSelector(
-  [state => state.data, state => state.section],
+  [state => state.data, getSection],
   (data, section) => {
     if (!data || !section) return null;
     return (data && data[section] && data[section].data) || null;
@@ -16,13 +20,85 @@ export const getData = createSelector(
 );
 
 export const getMeta = createSelector(
-  [state => state.meta, state => state.section],
+  [state => state.meta, getSection],
   (meta, section) => {
     if (!meta || isEmpty(meta) || !section) return null;
     const sectionMetadata = meta['section-metadata'];
     return sectionMetadata.find(
       s => s.source === DATA_EXPLORER_METADATA_SOURCE[section]
     );
+  }
+);
+
+export const getFilterOptions = createSelector(
+  [state => state.meta, getSection],
+  (meta, section) => {
+    if (!section || isEmpty(meta)) return null;
+    const filters = DATA_EXPLORER_FILTERS[section];
+    const filtersMeta = meta[section];
+    if (!filtersMeta) return null;
+
+    const filterOptions = {};
+    filters.forEach(f => {
+      const options = filtersMeta[f];
+      if (options) {
+        const parsedOptions = options.map(option => ({
+          slug: option.slug || option.name || option.value,
+          value: option.name || option.value,
+          label: option.name || option.value
+        }));
+        filterOptions[f] = parsedOptions;
+      }
+    });
+    return filterOptions;
+  }
+);
+
+const removeSelectedFiltersPrefix = (selectedFields, prefix) => {
+  const fieldsWithoutPrefix = {};
+  Object.keys(selectedFields).forEach(k => {
+    const keyWithoutPrefix = k.replace(`${prefix}-`, '');
+    fieldsWithoutPrefix[keyWithoutPrefix] = selectedFields[k];
+  });
+  return fieldsWithoutPrefix;
+};
+
+const getSelectedFilters = createSelector(
+  [getSearch, getSection, getFilterOptions],
+  (search, section, filterOptions) => {
+    if (!search || !section || !filterOptions) return null;
+    let selectedFields = search;
+    const selectedKeys = Object.keys(selectedFields).filter(k =>
+      k.startsWith(section)
+    );
+    selectedFields = pick(selectedFields, selectedKeys);
+    const cleanSelectedFilters = removeSelectedFiltersPrefix(
+      selectedFields,
+      section
+    );
+    const selectedFilterObjects = {};
+    Object.keys(cleanSelectedFilters).forEach(filterKey => {
+      selectedFilterObjects[filterKey] = filterOptions[filterKey].find(
+        f => f.slug === cleanSelectedFilters[filterKey]
+      );
+    });
+    return selectedFilterObjects;
+  }
+);
+
+export const getSelectedOptions = createSelector(
+  [getSelectedFilters],
+  selectedFields => {
+    if (!selectedFields) return null;
+    const selectedOptions = {};
+
+    Object.keys(selectedFields).forEach(key => {
+      selectedOptions[key] = {
+        value: selectedFields[key].slug || selectedFields[key].label,
+        label: selectedFields[key].label
+      };
+    });
+    return selectedOptions;
   }
 );
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -11,6 +11,14 @@ export const getData = createSelector(
   }
 );
 
+export const getMeta = createSelector(
+  [state => state.data, state => state.section],
+  (data, section) => {
+    if (!data || !section) return null;
+    return (data && data[section] && data[section].meta) || null;
+  }
+);
+
 export const parseData = createSelector([getData], data => {
   if (!data || !data.length) return null;
   const updatedData = data;

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -10,6 +10,8 @@ import {
 
 const getSection = state => state.section || null;
 const getSearch = state => state.search || null;
+const getCountries = state => state.countries || null;
+const getRegions = state => state.regions || null;
 
 export const getData = createSelector(
   [state => state.data, getSection],
@@ -31,21 +33,27 @@ export const getMeta = createSelector(
 );
 
 export const getFilterOptions = createSelector(
-  [state => state.meta, getSection],
-  (meta, section) => {
+  [state => state.meta, getSection, getCountries, getRegions],
+  (meta, section, countries, regions) => {
     if (!section || isEmpty(meta)) return null;
     const filters = DATA_EXPLORER_FILTERS[section];
     const filtersMeta = meta[section];
     if (!filtersMeta) return null;
 
     const filterOptions = {};
+    if (filters.includes('regions')) filtersMeta.regions = regions;
+    if (filters.includes('countries')) filtersMeta.countries = countries;
     filters.forEach(f => {
       const options = filtersMeta[f];
       if (options) {
         const parsedOptions = options.map(option => ({
-          slug: option.slug || option.name || option.value,
-          value: option.name || option.value,
-          label: option.name || option.value
+          slug:
+            option.slug ||
+            option.name ||
+            option.value ||
+            option.wri_standard_name,
+          value: option.name || option.value || option.wri_standard_name,
+          label: option.name || option.value || option.wri_standard_name
         }));
         filterOptions[f] = parsedOptions;
       }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -17,3 +17,7 @@
 .tableContainer {
   @include xy-gutters($gutter-position: 'bottom');
 }
+
+.metadataText {
+  @include xy-gutters($gutter-position: ('top', 'bottom'));
+}

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -21,6 +21,10 @@
 .filtersContainer {
   @include columns(3);
   @include xy-gutters($gutter-position: 'bottom');
+
+   > :nth-child(5) {
+    @include xy-gutters($gutter-position: 'top');
+  }
 }
 
 .metadataText {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -18,6 +18,11 @@
   @include xy-gutters($gutter-position: 'bottom');
 }
 
+.filtersContainer {
+  @include columns(3);
+  @include xy-gutters($gutter-position: 'bottom');
+}
+
 .metadataText {
   @include xy-gutters($gutter-position: ('top', 'bottom'));
 }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -22,7 +22,7 @@
   @include columns(3);
   @include xy-gutters($gutter-position: 'bottom');
 
-   > :nth-child(5) {
+  > :nth-child(5) {
     @include xy-gutters($gutter-position: 'top');
   }
 }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -21,6 +21,8 @@ const mapStateToProps = (state, { section, location }) => {
   const search = qs.parse(location.search);
   const dataState = {
     data: state.dataExplorer && state.dataExplorer.data,
+    countries: state.countries && state.countries.data,
+    regions: state.regions && state.regions.data,
     meta: state.dataExplorer && state.dataExplorer.metadata,
     section,
     search

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -33,6 +33,15 @@ const mapStateToProps = (state, { section, location }) => {
     'ndc-content': '/ndcs-content',
     'emission-pathways': '/pathways'
   };
+  const anchorLinks = [
+    {
+      label: 'Raw Data',
+      hash: 'data',
+      defaultActiveHash: true
+    },
+    { label: 'Methodology', hash: 'meta', defaultActiveHash: true }
+  ];
+
   return {
     data: parseData(dataState),
     meta: getInfoMetadata(dataState),
@@ -46,7 +55,9 @@ const mapStateToProps = (state, { section, location }) => {
     ]}/download.csv`,
     filters: DATA_EXPLORER_FILTERS[section],
     filterOptions: getFilterOptions(dataState),
-    selectedOptions: getSelectedOptions(dataState)
+    selectedOptions: getSelectedOptions(dataState),
+    anchorLinks,
+    query: location.search
   };
 };
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import { DATA_EXPLORER_FIRST_COLUMN_HEADERS } from 'data/constants';
 import DataExplorerComponent from './data-explorer-content-component';
 
-import { parseData } from './data-explorer-content-selectors';
+import { parseData, getMeta } from './data-explorer-content-selectors';
 
-const mapStateToProps = (state, { section }) => {
+const mapStateToProps = (state, { section, location }) => {
   const dataState = {
     data: state.dataExplorer && state.dataExplorer.data,
     section
@@ -12,6 +13,8 @@ const mapStateToProps = (state, { section }) => {
 
   return {
     data: parseData(dataState),
+    meta: getMeta(dataState),
+    metadataSection: location.hash && location.hash === '#meta',
     loading: state.dataExplorer && state.dataExplorer.loading,
     firstColumnHeaders: DATA_EXPLORER_FIRST_COLUMN_HEADERS,
     href: '/ghg-emissions',
@@ -19,4 +22,6 @@ const mapStateToProps = (state, { section }) => {
   };
 };
 
-export default connect(mapStateToProps, null)(DataExplorerComponent);
+export default withRouter(
+  connect(mapStateToProps, null)(DataExplorerComponent)
+);

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -26,6 +26,7 @@ const mapStateToProps = (state, { section, location }) => {
     meta: getMeta(dataState),
     metadataSection: !!location.hash && location.hash === '#meta',
     loading: state.dataExplorer && state.dataExplorer.loading,
+    loadingMeta: state.dataExplorer && state.dataExplorer.loadingMeta,
     firstColumnHeaders: DATA_EXPLORER_FIRST_COLUMN_HEADERS,
     href: SECTION_HREFS[section],
     downloadHref: `/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -11,6 +11,7 @@ import { parseData, getMeta } from './data-explorer-content-selectors';
 const mapStateToProps = (state, { section, location }) => {
   const dataState = {
     data: state.dataExplorer && state.dataExplorer.data,
+    meta: state.dataExplorer && state.dataExplorer.metadata,
     section
   };
   const SECTION_HREFS = {
@@ -23,7 +24,7 @@ const mapStateToProps = (state, { section, location }) => {
   return {
     data: parseData(dataState),
     meta: getMeta(dataState),
-    metadataSection: location.hash && location.hash === '#meta',
+    metadataSection: !!location.hash && location.hash === '#meta',
     loading: state.dataExplorer && state.dataExplorer.loading,
     firstColumnHeaders: DATA_EXPLORER_FIRST_COLUMN_HEADERS,
     href: SECTION_HREFS[section],

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -12,7 +12,7 @@ import {
 import DataExplorerContentComponent from './data-explorer-content-component';
 import {
   parseData,
-  getMeta,
+  getInfoMetadata,
   getFilterOptions,
   getSelectedOptions
 } from './data-explorer-content-selectors';
@@ -35,7 +35,7 @@ const mapStateToProps = (state, { section, location }) => {
   };
   return {
     data: parseData(dataState),
-    meta: getMeta(dataState),
+    meta: getInfoMetadata(dataState),
     metadataSection: !!location.hash && location.hash === '#meta',
     loading: state.dataExplorer && state.dataExplorer.loading,
     loadingMeta: state.dataExplorer && state.dataExplorer.loadingMeta,

--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -1,0 +1,96 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import styles from './metadata-text-styles.scss';
+
+const MetadataProp = ({ title, children }) => (
+  <p className={styles.text}>
+    <span className={styles.textHighlight}>{title}: </span>
+    {children}
+  </p>
+);
+
+MetadataProp.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node
+};
+
+class MetadataText extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const { showDisclaimer, disclaimer, data } = this.props;
+    const {
+      learn_more_link,
+      source_organization,
+      technical_title,
+      summary,
+      citation,
+      cautions,
+      geographic_coverage,
+      description,
+      date_of_content,
+      summary_of_licenses,
+      terms_of_service_link
+    } = this.props.data;
+
+    return (
+      <div key={data.source} className={styles.textContainer}>
+        {technical_title && (
+          <MetadataProp title="Title">{technical_title}</MetadataProp>
+        )}
+        {date_of_content && (
+          <MetadataProp title="Date of content">{date_of_content}</MetadataProp>
+        )}
+        {source_organization && (
+          <MetadataProp title="Source organization">
+            {source_organization}
+          </MetadataProp>
+        )}
+        {summary && <MetadataProp title="Summary">{summary}</MetadataProp>}
+        {description && (
+          <MetadataProp title="Description">{description}</MetadataProp>
+        )}
+        {geographic_coverage && (
+          <MetadataProp title="Geographic Coverage">
+            {geographic_coverage}
+          </MetadataProp>
+        )}
+        {cautions && <MetadataProp title="Cautions">{cautions}</MetadataProp>}
+        {learn_more_link && (
+          <MetadataProp title="Read more">
+            <a key="link" className={styles.link} href={learn_more_link}>
+              {' '}
+              {learn_more_link}{' '}
+            </a>
+          </MetadataProp>
+        )}
+        {summary_of_licenses && (
+          <MetadataProp title="Summary of licenses">
+            {summary_of_licenses}
+          </MetadataProp>
+        )}
+        {citation && <MetadataProp title="Citation">{citation}</MetadataProp>}
+        {terms_of_service_link && (
+          <MetadataProp title="Terms of service link">
+            <a key="link" className={styles.link} href={terms_of_service_link}>
+              {' '}
+              {terms_of_service_link}{' '}
+            </a>
+          </MetadataProp>
+        )}
+        {showDisclaimer && disclaimer}
+      </div>
+    );
+  }
+}
+
+MetadataText.propTypes = {
+  data: PropTypes.object,
+  showDisclaimer: PropTypes.bool.isRequired,
+  disclaimer: PropTypes.node
+};
+
+MetadataText.defaultProps = {
+  showDisclaimer: false
+};
+
+export default MetadataText;

--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import styles from './metadata-text-styles.scss';
 
 const MetadataProp = ({ title, children }) => (
@@ -17,7 +18,7 @@ MetadataProp.propTypes = {
 class MetadataText extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { showDisclaimer, disclaimer, data } = this.props;
+    const { showDisclaimer, disclaimer, data, className } = this.props;
     const {
       learn_more_link,
       source_organization,
@@ -33,7 +34,7 @@ class MetadataText extends PureComponent {
     } = this.props.data;
 
     return (
-      <div key={data.source} className={styles.textContainer}>
+      <div key={data.source} className={cx(styles.textContainer, className)}>
         {technical_title && (
           <MetadataProp title="Title">{technical_title}</MetadataProp>
         )}
@@ -86,7 +87,8 @@ class MetadataText extends PureComponent {
 MetadataText.propTypes = {
   data: PropTypes.object,
   showDisclaimer: PropTypes.bool.isRequired,
-  disclaimer: PropTypes.node
+  disclaimer: PropTypes.node,
+  className: PropTypes.string
 };
 
 MetadataText.defaultProps = {

--- a/app/javascript/app/components/metadata-text/metadata-text-styles.scss
+++ b/app/javascript/app/components/metadata-text/metadata-text-styles.scss
@@ -1,0 +1,21 @@
+@import '~styles/layout.scss';
+
+.text {
+  font-size: $font-size;
+  line-height: $line-height-modal;
+  color: $theme-color;
+  margin-bottom: 5px;
+
+  &Highlight {
+    font-weight: $font-weight-bold;
+  }
+}
+
+.link {
+  font-size: $font-size;
+  line-height: $line-height-medium;
+  height: 1.62;
+  color: $theme-color;
+  border-bottom: 1px solid $theme-secondary;
+}
+

--- a/app/javascript/app/components/metadata-text/metadata-text.js
+++ b/app/javascript/app/components/metadata-text/metadata-text.js
@@ -1,0 +1,3 @@
+import Component from './metadata-text-component';
+
+export default Component;

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import CustomModal from 'components/modal/modal-component';
 import ModalHeader from 'components/modal/modal-header-component';
+import MetadataText from 'components/metadata-text';
 import Loading from 'components/loading';
 import NoContent from 'components/no-content';
 
@@ -39,67 +40,12 @@ class ModalMetadata extends PureComponent {
     }
 
     const selectedIndexData = data[this.state.selectedIndex];
-    const {
-      learn_more_link,
-      source_organization,
-      technical_title,
-      summary,
-      citation,
-      cautions,
-      geographic_coverage,
-      description,
-      date_of_content,
-      summary_of_licenses,
-      terms_of_service_link
-    } = selectedIndexData;
-
     return (
-      <div key={selectedIndexData.source} className={styles.textContainer}>
-        {technical_title && (
-          <MetadataProp title="Title">{technical_title}</MetadataProp>
-        )}
-        {date_of_content && (
-          <MetadataProp title="Date of content">{date_of_content}</MetadataProp>
-        )}
-        {source_organization && (
-          <MetadataProp title="Source organization">
-            {source_organization}
-          </MetadataProp>
-        )}
-        {summary && <MetadataProp title="Summary">{summary}</MetadataProp>}
-        {description && (
-          <MetadataProp title="Description">{description}</MetadataProp>
-        )}
-        {geographic_coverage && (
-          <MetadataProp title="Geographic Coverage">
-            {geographic_coverage}
-          </MetadataProp>
-        )}
-        {cautions && <MetadataProp title="Cautions">{cautions}</MetadataProp>}
-        {learn_more_link && (
-          <MetadataProp title="Read more">
-            <a key="link" className={styles.link} href={learn_more_link}>
-              {' '}
-              {learn_more_link}{' '}
-            </a>
-          </MetadataProp>
-        )}
-        {summary_of_licenses && (
-          <MetadataProp title="Summary of licenses">
-            {summary_of_licenses}
-          </MetadataProp>
-        )}
-        {citation && <MetadataProp title="Citation">{citation}</MetadataProp>}
-        {terms_of_service_link && (
-          <MetadataProp title="Terms of service link">
-            <a key="link" className={styles.link} href={terms_of_service_link}>
-              {' '}
-              {terms_of_service_link}{' '}
-            </a>
-          </MetadataProp>
-        )}
-        {showDisclaimer && disclaimer}
-      </div>
+      <MetadataText
+        data={selectedIndexData}
+        showDisclaimer={showDisclaimer}
+        disclaimer={disclaimer}
+      />
     );
   }
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -8,18 +8,6 @@ import NoContent from 'components/no-content';
 
 import styles from './modal-metadata-styles.scss';
 
-const MetadataProp = ({ title, children }) => (
-  <p className={styles.text}>
-    <span className={styles.textHighlight}>{title}: </span>
-    {children}
-  </p>
-);
-
-MetadataProp.propTypes = {
-  title: PropTypes.string,
-  children: PropTypes.node
-};
-
 class ModalMetadata extends PureComponent {
   constructor() {
     super();

--- a/app/javascript/app/components/modal-metadata/modal-metadata-styles.scss
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-styles.scss
@@ -4,22 +4,3 @@
   min-height: 200px;
   position: relative;
 }
-
-.text {
-  font-size: $font-size;
-  line-height: $line-height-modal;
-  color: $theme-color;
-  margin-bottom: 5px;
-
-  &Highlight {
-    font-weight: $font-weight-bold;
-  }
-}
-
-.link {
-  font-size: $font-size;
-  line-height: $line-height-medium;
-  height: 1.62;
-  color: $theme-color;
-  border-bottom: 1px solid $theme-secondary;
-}

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -305,7 +305,7 @@ export const DATA_EXPLORER_FILTERS = {
   'historical-emissions': [
     'source_IPCC_version',
     'gases',
-    'locations',
+    'regions',
     'sectors'
   ],
   'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
@@ -315,7 +315,7 @@ export const DATA_EXPLORER_FILTERS = {
     'categories',
     'indicators',
     'sectors',
-    'labels'
+    'countries'
   ]
 };
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -301,6 +301,24 @@ export const DATA_EXPLORER_METADATA_SOURCE = {
   'emission-pathways': null // model, scenario and indicator related metadata
 };
 
+export const DATA_EXPLORER_FILTERS = {
+  'historical-emissions': [
+    'source_IPCC_version',
+    'gases',
+    'locations',
+    'sectors'
+  ],
+  'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
+  'emission-pathways': [],
+  'ndc-content': [
+    'data_sources',
+    'categories',
+    'indicators',
+    'sectors',
+    'labels'
+  ]
+};
+
 export default {
   CALCULATION_OPTIONS,
   QUANTIFICATION_COLORS,

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -294,6 +294,13 @@ export const DATA_EXPLORER_SECTION_NAMES = {
   'ndc-content': 'ndc_content'
 };
 
+export const DATA_EXPLORER_METADATA_SOURCE = {
+  'historical-emissions': 'historical_emissions_pik', // source: pik, cait, unfccc,
+  'ndc-sdg-linkages': 'ndc_sdc_all_indicators',
+  'ndc-content': 'ndc_cait', // or 'ndc_wb'
+  'emission-pathways': null // model, scenario and indicator related metadata
+};
+
 export default {
   CALCULATION_OPTIONS,
   QUANTIFICATION_COLORS,
@@ -322,5 +329,6 @@ export default {
   DATA_EXPLORER_BLACKLIST,
   DATA_EXPLORER_FIRST_COLUMN_HEADERS,
   DATA_EXPLORER_SECTION_NAMES,
+  DATA_EXPLORER_METADATA_SOURCE,
   USERS_PROFESIONAL_SECTORS
 };

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -295,9 +295,13 @@ export const DATA_EXPLORER_SECTION_NAMES = {
 };
 
 export const DATA_EXPLORER_METADATA_SOURCE = {
-  'historical-emissions': 'historical_emissions_pik', // source: pik, cait, unfccc,
+  'historical-emissions': {
+    PIK: 'historical_emissions_pik',
+    CAIT: 'historical_emissions_cait',
+    UNFCCC: 'historical_emissions_unfccc'
+  },
   'ndc-sdg-linkages': 'ndc_sdc_all_indicators',
-  'ndc-content': 'ndc_cait', // or 'ndc_wb'
+  'ndc-content': { CAIT: 'ndc_cait', WB: 'ndc_wb' },
   'emission-pathways': null // model, scenario and indicator related metadata
 };
 
@@ -318,6 +322,15 @@ export const DATA_EXPLORER_FILTERS = {
     'countries'
   ]
 };
+
+export const DATA_EXPLORER_SOURCE_IPCC_VERSIONS = [
+  { name: 'PIK - AR2', source_slug: 'PIK', version_slug: 'AR2' },
+  { name: 'PIK - AR4', source_slug: 'PIK', version_slug: 'AR4' },
+  { name: 'CAIT - AR2', source_slug: 'CAIT', version_slug: 'AR2' },
+  { name: 'CAIT - AR4', source_slug: 'CAIT', version_slug: 'AR4' },
+  { name: 'UNFCCC - AR2', source_slug: 'UNFCCC', version_slug: 'AR2' },
+  { name: 'UNFCCC - AR4', source_slug: 'UNFCCC', version_slug: 'AR4' }
+];
 
 export default {
   CALCULATION_OPTIONS,
@@ -348,5 +361,6 @@ export default {
   DATA_EXPLORER_FIRST_COLUMN_HEADERS,
   DATA_EXPLORER_SECTION_NAMES,
   DATA_EXPLORER_METADATA_SOURCE,
+  DATA_EXPLORER_SOURCE_IPCC_VERSIONS,
   USERS_PROFESIONAL_SECTORS
 };

--- a/app/javascript/app/pages/data-explorer/data-explorer-component.jsx
+++ b/app/javascript/app/pages/data-explorer/data-explorer-component.jsx
@@ -9,13 +9,13 @@ import anchorNavThemeColorTheme from 'styles/themes/anchor-nav/anchor-nav-theme-
 import layout from 'styles/layout.scss';
 import styles from './data-explorer-styles';
 
-const DataExplorer = ({ route }) => (
+const DataExplorer = ({ navLinks, route }) => (
   <div>
     <Header theme={styles}>
       <Intro theme={styles} className={styles.intro} title="Data Explorer" />
       <AnchorNav
         useRoutes
-        links={route.routes.filter(r => r.anchor)}
+        links={navLinks}
         theme={anchorNavThemeColorTheme}
         className={styles.anchorNav}
       />
@@ -27,6 +27,7 @@ const DataExplorer = ({ route }) => (
 );
 
 DataExplorer.propTypes = {
+  navLinks: PropTypes.array,
   route: PropTypes.object.isRequired
 };
 

--- a/app/javascript/app/pages/data-explorer/data-explorer.js
+++ b/app/javascript/app/pages/data-explorer/data-explorer.js
@@ -1,5 +1,13 @@
 import { withRouter } from 'react-router';
-
+import { connect } from 'react-redux';
 import DataExplorer from './data-explorer-component';
 
-export default withRouter(DataExplorer);
+const mapStateToProps = (state, { route, location }) => ({
+  navLinks: route.routes.filter(r => r.anchor).map(r => {
+    const updatedR = r;
+    updatedR.hash = location.hash;
+    return updatedR;
+  })
+});
+
+export default withRouter(connect(mapStateToProps, null)(DataExplorer));

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
@@ -2,20 +2,25 @@ import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import { DATA_EXPLORER_SECTION_NAMES } from 'data/constants';
 import isEmpty from 'lodash/isEmpty';
+import { parseLinkHeader } from 'utils/utils';
 
 export const fetchDataExplorerInit = createAction('fetchDataExplorerInit');
 export const fetchDataExplorerReady = createAction('fetchDataExplorerReady');
 export const fetchDataExplorerFail = createAction('fetchDataExplorerFail');
 
-export const fetchInitialMetadataInit = createAction(
-  'fetchInitialMetadataInit'
+export const fetchSectionMetadataInit = createAction(
+  'fetchSectionMetadataInit'
 );
-export const fetchInitialMetadataReady = createAction(
-  'fetchInitialMetadataReady'
+export const fetchSectionMetadataReady = createAction(
+  'fetchSectionMetadataReady'
 );
-export const fetchInitialMetadataFail = createAction(
-  'fetchInitialMetadataFail'
+export const fetchSectionMetadataFail = createAction(
+  'fetchSectionMetadataFail'
 );
+
+export const fetchMetadataInit = createAction('fetchMetadataInit');
+export const fetchMetadataReady = createAction('fetchMetadataReady');
+export const fetchMetadataFail = createAction('fetchMetadataFail');
 
 export const fetchDataExplorer = createThunkAction(
   'fetchDataExplorer',
@@ -51,30 +56,87 @@ export const fetchDataExplorer = createThunkAction(
   }
 );
 
-export const fetchInitialMetadata = createThunkAction(
-  'fetchInitialMetadata',
+export const fetchSectionMetadata = createThunkAction(
+  'fetchSectionMetadata',
   () => dispatch => {
-    dispatch(fetchInitialMetadataInit());
-    const promises = [
-      fetch('/api/v1/metadata').then(response => {
-        if (response.ok) return response.json();
+    dispatch(fetchSectionMetadataInit());
+    fetch('/api/v1/metadata')
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        }
         throw Error(response.statusText);
       })
-    ];
-
-    Promise.all(promises)
-      .then(response => {
-        const responseSections = ['section-metadata'];
-        const metadata = {};
-        responseSections.forEach((section, index) => {
-          metadata[section] = response[index];
-        });
-        dispatch(fetchInitialMetadataReady({ metadata }));
+      .then(data => {
+        if (data) {
+          dispatch(
+            fetchSectionMetadataReady({
+              metadata: { 'section-metadata': data }
+            })
+          );
+        } else {
+          dispatch(fetchSectionMetadataReady({}));
+        }
       })
       .catch(error => {
         console.warn(error);
-        dispatch(fetchInitialMetadataFail());
+        dispatch(fetchSectionMetadataFail());
       });
+  }
+);
+
+export const fetchMetadata = createThunkAction(
+  'fetchMetadata',
+  section => (dispatch, state) => {
+    dispatch(fetchMetadataInit());
+    const { dataExplorer } = state();
+    if (
+      dataExplorer &&
+      (isEmpty(dataExplorer) ||
+        isEmpty(dataExplorer.metadata) ||
+        !dataExplorer.metadata[section])
+    ) {
+      fetch(`/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[section]}/meta`)
+        .then(response => {
+          if (response.ok && response.headers.get('Link')) {
+            return parseLinkHeader(response.headers.get('Link'));
+          }
+          throw Error(response.statusText);
+        })
+        .then(links => {
+          const parsedLinks = links;
+          delete parsedLinks['meta locations']; // We aready should have locations in the store
+          return Object.keys(parsedLinks).map(key => ({
+            rel: key.substring('meta '.length),
+            href: parsedLinks[key].href
+          }));
+        })
+        .then(parsedLinks => {
+          const promises = parsedLinks.map(l =>
+            fetch(l.href).then(response => {
+              if (response.ok) return response.json();
+              throw Error(response.statusText);
+            })
+          );
+          Promise.all(promises)
+            .then(response => {
+              const responseSections = parsedLinks.map(l => l.rel);
+              const metadata = {};
+              responseSections.forEach((s, index) => {
+                metadata[s] = response[index].data;
+              });
+              dispatch(fetchMetadataReady({ metadata, section }));
+            })
+            .catch(error => {
+              console.warn(error);
+              dispatch(fetchMetadataFail());
+            });
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchMetadataFail());
+        });
+    }
   }
 );
 
@@ -83,8 +145,12 @@ export default {
   fetchDataExplorerInit,
   fetchDataExplorerReady,
   fetchDataExplorerFail,
-  fetchInitialMetadata,
-  fetchInitialMetadataInit,
-  fetchInitialMetadataReady,
-  fetchInitialMetadataFail
+  fetchSectionMetadata,
+  fetchSectionMetadataInit,
+  fetchSectionMetadataReady,
+  fetchSectionMetadataFail,
+  fetchMetadata,
+  fetchMetadataInit,
+  fetchMetadataReady,
+  fetchMetadataFail
 };

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
@@ -1,36 +1,79 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
+import { DATA_EXPLORER_SECTION_NAMES } from 'data/constants';
+import isEmpty from 'lodash/isEmpty';
 
 export const fetchDataExplorerInit = createAction('fetchDataExplorerInit');
 export const fetchDataExplorerReady = createAction('fetchDataExplorerReady');
 export const fetchDataExplorerFail = createAction('fetchDataExplorerFail');
 
-const SECTION_NAMES = {
-  'historical-emissions': 'historical_emissions',
-  'ndc-sdg-linkages': 'ndc_sdg',
-  'emission-pathways': 'emission_pathways'
-};
+export const fetchInitialMetadataInit = createAction(
+  'fetchInitialMetadataInit'
+);
+export const fetchInitialMetadataReady = createAction(
+  'fetchInitialMetadataReady'
+);
+export const fetchInitialMetadataFail = createAction(
+  'fetchInitialMetadataFail'
+);
+
 export const fetchDataExplorer = createThunkAction(
   'fetchDataExplorer',
-  section => dispatch => {
-    dispatch(fetchDataExplorerInit());
-    fetch(`/api/v1/data/${SECTION_NAMES[section]}`)
-      .then(response => {
-        if (response.ok) {
-          return response.json();
-        }
+  section => (dispatch, state) => {
+    const { dataExplorer } = state();
+    if (
+      dataExplorer &&
+      (isEmpty(dataExplorer) ||
+        (dataExplorer.data && !dataExplorer.data[section]) ||
+        (dataExplorer.data &&
+          (isEmpty(dataExplorer.data[section].data) && !dataExplorer.loading)))
+    ) {
+      dispatch(fetchDataExplorerInit());
+      fetch(`/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[section]}`)
+        .then(response => {
+          if (response.ok) {
+            return response.json();
+          }
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          if (data) {
+            dispatch(fetchDataExplorerReady({ data, section }));
+          } else {
+            dispatch(fetchDataExplorerReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchDataExplorerFail());
+        });
+    }
+  }
+);
+
+export const fetchInitialMetadata = createThunkAction(
+  'fetchInitialMetadata',
+  () => dispatch => {
+    dispatch(fetchInitialMetadataInit());
+    const promises = [
+      fetch('/api/v1/metadata').then(response => {
+        if (response.ok) return response.json();
         throw Error(response.statusText);
       })
-      .then(data => {
-        if (data) {
-          dispatch(fetchDataExplorerReady({ data, section }));
-        } else {
-          dispatch(fetchDataExplorerReady({}));
-        }
+    ];
+
+    Promise.all(promises)
+      .then(response => {
+        const responseSections = ['section-metadata'];
+        const metadata = {};
+        responseSections.forEach((section, index) => {
+          metadata[section] = response[index];
+        });
+        dispatch(fetchInitialMetadataReady({ metadata }));
       })
       .catch(error => {
         console.warn(error);
-        dispatch(fetchDataExplorerFail());
+        dispatch(fetchInitialMetadataFail());
       });
   }
 );
@@ -39,5 +82,9 @@ export default {
   fetchDataExplorer,
   fetchDataExplorerInit,
   fetchDataExplorerReady,
-  fetchDataExplorerFail
+  fetchDataExplorerFail,
+  fetchInitialMetadata,
+  fetchInitialMetadataInit,
+  fetchInitialMetadataReady,
+  fetchInitialMetadataFail
 };

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
@@ -105,7 +105,6 @@ export const fetchMetadata = createThunkAction(
         })
         .then(links => {
           const parsedLinks = links;
-          delete parsedLinks['meta locations']; // We aready should have locations in the store
           return Object.keys(parsedLinks).map(key => ({
             rel: key.substring('meta '.length),
             href: parsedLinks[key].href

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-reducers.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-reducers.js
@@ -1,5 +1,13 @@
 import * as actions from './data-explorer-provider-actions';
 
+export const initialState = {
+  loading: false,
+  metadataLoading: false,
+  loaded: false,
+  error: false,
+  data: {},
+  metadata: {}
+};
 export default {
   [actions.fetchDataExplorerInit]: state => ({ ...state, loading: true }),
   [actions.fetchDataExplorerReady]: (state, { payload }) => ({
@@ -11,6 +19,21 @@ export default {
   [actions.fetchDataExplorerFail]: state => ({
     ...state,
     loading: false,
+    error: true
+  }),
+  [actions.fetchInitialMetadataInit]: state => ({
+    ...state,
+    metadataLoading: true
+  }),
+  [actions.fetchInitialMetadataReady]: (state, { payload }) => ({
+    ...state,
+    metadataLoading: false,
+    metadata: { ...state.metadata, ...payload.metadata },
+    error: false
+  }),
+  [actions.fetchInitialMetadataFail]: state => ({
+    ...state,
+    metadataLoading: false,
     error: true
   })
 };

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-reducers.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-reducers.js
@@ -21,17 +21,32 @@ export default {
     loading: false,
     error: true
   }),
-  [actions.fetchInitialMetadataInit]: state => ({
+  [actions.fetchSectionMetadataInit]: state => ({
     ...state,
     metadataLoading: true
   }),
-  [actions.fetchInitialMetadataReady]: (state, { payload }) => ({
+  [actions.fetchSectionMetadataReady]: (state, { payload }) => ({
     ...state,
     metadataLoading: false,
     metadata: { ...state.metadata, ...payload.metadata },
     error: false
   }),
-  [actions.fetchInitialMetadataFail]: state => ({
+  [actions.fetchSectionMetadataFail]: state => ({
+    ...state,
+    metadataLoading: false,
+    error: true
+  }),
+  [actions.fetchMetadataInit]: state => ({
+    ...state,
+    metadataLoading: true
+  }),
+  [actions.fetchMetadataReady]: (state, { payload }) => ({
+    ...state,
+    metadataLoading: false,
+    metadata: { ...state.metadata, ...{ [payload.section]: payload.metadata } },
+    error: false
+  }),
+  [actions.fetchMetadataFail]: state => ({
     ...state,
     metadataLoading: false,
     error: true

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
@@ -6,8 +6,9 @@ import * as actions from './data-explorer-provider-actions';
 
 class DataExplorerProvider extends PureComponent {
   componentDidMount() {
-    const { fetchDataExplorer, section } = this.props;
+    const { fetchDataExplorer, fetchInitialMetadata, section } = this.props;
     fetchDataExplorer(section);
+    fetchInitialMetadata();
   }
 
   render() {
@@ -17,6 +18,7 @@ class DataExplorerProvider extends PureComponent {
 
 DataExplorerProvider.propTypes = {
   fetchDataExplorer: PropTypes.func.isRequired,
+  fetchInitialMetadata: PropTypes.func.isRequired,
   section: PropTypes.string
 };
 

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
@@ -6,9 +6,15 @@ import * as actions from './data-explorer-provider-actions';
 
 class DataExplorerProvider extends PureComponent {
   componentDidMount() {
-    const { fetchDataExplorer, fetchInitialMetadata, section } = this.props;
+    const {
+      fetchDataExplorer,
+      fetchSectionMetadata,
+      fetchMetadata,
+      section
+    } = this.props;
     fetchDataExplorer(section);
-    fetchInitialMetadata();
+    fetchSectionMetadata();
+    fetchMetadata(section);
   }
 
   render() {
@@ -18,7 +24,8 @@ class DataExplorerProvider extends PureComponent {
 
 DataExplorerProvider.propTypes = {
   fetchDataExplorer: PropTypes.func.isRequired,
-  fetchInitialMetadata: PropTypes.func.isRequired,
+  fetchSectionMetadata: PropTypes.func.isRequired,
+  fetchMetadata: PropTypes.func.isRequired,
   section: PropTypes.string
 };
 

--- a/app/javascript/app/styles/themes/anchor-nav/anchor-nav-light.scss
+++ b/app/javascript/app/styles/themes/anchor-nav/anchor-nav-light.scss
@@ -6,6 +6,6 @@
   cursor: pointer;
 
   &Active {
-    color: $base-text;
+    color: $theme-color;
   }
 }

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -137,6 +137,40 @@ export const wordWrap = (long_string, max_char) => {
   return split_out;
 };
 
+const unquote = value => {
+  if (value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') { return value.substring(1, value.length - 1); }
+  return value;
+};
+
+export const parseLinkHeader = header => {
+  // eslint-disable-next-line no-useless-escape
+  const linkexp = /<[^>]*>\s*(\s*;\s*[^\(\)<>@,;:"\/\[\]\?={} \t]+=(([^\(\)<>@,;:"\/\[\]\?={} \t]+)|("[^"]*")))*(,|$)/g;
+  const paramexp = /[^\(\)<>@,;:"\/\[\]\?={} \t]+=(([^\(\)<>@,;:"\/\[\]\?={} \t]+)|("[^"]*"))/g; // eslint-disable-line no-useless-escape
+
+  const matches = header.match(linkexp);
+  const rels = {};
+  for (let i = 0; i < matches.length; i++) {
+    const split = matches[i].split('>');
+    const href = split[0].substring(1);
+    const ps = split[1];
+    const link = {};
+    link.href = href;
+    const s = ps.match(paramexp);
+    for (let j = 0; j < s.length; j++) {
+      const p = s[j];
+      const paramsplit = p.split('=');
+      const name = paramsplit[0];
+      link[name] = unquote(paramsplit[1]);
+    }
+
+    if (link.rel !== undefined) {
+      rels[link.rel] = link;
+    }
+  }
+
+  return rels;
+};
+
 export default {
   compareIndexByKey,
   deburrUpper,
@@ -145,5 +179,6 @@ export default {
   truncateDecimals,
   isMicrosoftBrowser,
   toStartCase,
-  wordWrap
+  wordWrap,
+  parseLinkHeader
 };


### PR DESCRIPTION
This PR shows the metadata depending on the selected source:

- Fetch methodology metadata
- 'Raw Data - Methodology' menu with hashes
- Fetch metadata for the different filters depending on the section
- Create selectors and change URL when the selection changes
- Select metadata depending on the selected source

Note: Still no filtering to the data is applied

![image](https://user-images.githubusercontent.com/9701591/41656330-db4d7078-748f-11e8-9716-fefcf76b768e.png)
