### PR TITLE
Feature/ndc sdg sort tooltip sectors

### DIFF
--- a/app/javascript/app/components/countries-select/countries-select-component.jsx
+++ b/app/javascript/app/components/countries-select/countries-select-component.jsx
@@ -21,6 +21,7 @@ class CountriesSelect extends PureComponent {
       className,
       autofocus,
       opened,
+      isCompareVisible,
       countrySelectFilter,
       countriesList,
       onCountryClick,
@@ -28,11 +29,16 @@ class CountriesSelect extends PureComponent {
       onCountryMouseLeave,
       handleClickAnalytics
     } = this.props;
+
     return (
       <div className={cx(styles.wrapper, className)}>
         <div className={cx(layout.content, styles.content)}>
           <div className="grid-layout-element">
-            <div className={styles.searchAndCompare}>
+            <div
+              className={cx({
+                [styles.searchAndCompare]: isCompareVisible
+              })}
+            >
               <Search
                 placeholder="Search a country"
                 value={query}
@@ -40,9 +46,11 @@ class CountriesSelect extends PureComponent {
                 theme={searchCountriesTheme}
                 autofocus={opened || autofocus}
               />
-              <Button color="plain" link="/countries/compare">
-                Compare
-              </Button>
+              {isCompareVisible && (
+                <Button color="plain" link="/countries/compare">
+                  Compare
+                </Button>
+              )}
             </div>
           </div>
           <div className="grid-colum-item">
@@ -85,6 +93,7 @@ CountriesSelect.propTypes = {
   onCountryMouseLeave: Proptypes.func.isRequired,
   handleClickAnalytics: Proptypes.func.isRequired,
   opened: Proptypes.bool,
+  isCompareVisible: Proptypes.bool,
   countriesList: Proptypes.array,
   paths: Proptypes.array
 };

--- a/app/javascript/app/components/countries-select/countries-select.js
+++ b/app/javascript/app/components/countries-select/countries-select.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { isCountryIncluded } from 'app/utils';
 import ReactGA from 'react-ga';
+import { isPageContained, isPageNdcp } from 'utils/navigation';
 
 import actions from './countries-select-actions';
 import reducers, { initialState } from './countries-select-reducers';
@@ -16,7 +17,7 @@ import {
   getPathsWithStyles
 } from './countries-select-selectors';
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, { location }) => {
   const { countrySelect, countries } = state;
   const stateWithFilters = {
     ...countrySelect,
@@ -28,7 +29,8 @@ const mapStateToProps = state => {
     query: getFilterUpper(stateWithFilters),
     preSelect: getPreSelect(stateWithFilters),
     isoCountries: getISOCountries(stateWithFilters),
-    countriesList: getFilteredCountriesWithPath(stateWithFilters)
+    countriesList: getFilteredCountriesWithPath(stateWithFilters),
+    isCompareVisible: !isPageNdcp(location) && !isPageContained
   };
 };
 

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -33,9 +33,12 @@ class CountrySDGLinkages extends PureComponent {
     const { sectors, tooltipData, targets, tooltipSectorIds } = this.props;
     const targetsContent = targets && targets[tooltipData.goal_number];
     const hasTooltipData = sector => {
-      if (tooltipSectorIds) return tooltipSectorIds.includes(sector);
+      if (tooltipSectorIds) { return !!tooltipSectorIds.find(id => sectors[id] === sector); }
       return false;
     };
+    const sectorsLabels =
+      !isEmpty(tooltipData.sectors) &&
+      (tooltipData.sectors.map(sector => sectors[sector]) || []).sort();
     return tooltipData && targetsContent ? (
       <div className={styles.tooltip}>
         <p className={styles.tooltipTitle}>
@@ -45,14 +48,14 @@ class CountrySDGLinkages extends PureComponent {
         {!isEmpty(tooltipData.sectors) && (
           <p className={styles.sectors}>
             <b>Sectors: </b>
-            {tooltipData.sectors.map((sector, index) => (
+            {sectorsLabels.map((sector, index) => (
               <span key={`${tooltipData.targetKey}-${sector}`}>
                 <span
                   className={cx({
                     [styles.sectorIncluded]: hasTooltipData(sector)
                   })}
                 >
-                  {sectors[sector]}
+                  {sector}
                 </span>
                 <span>
                   {index === tooltipData.sectors.length - 1 ? '' : ', '}


### PR DESCRIPTION
This PR sorts NDC-SDG's indicators tooltip sectors alphabetically.
[Pivotal](https://www.pivotaltracker.com/story/show/158467512)

It also removes compare button from `country-select` component on NDCP context (`contained` and NDCP web `embed`)