### PR TITLE
Don't show search box on overview section

### DIFF
--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -29,7 +29,8 @@ class NDCCountry extends PureComponent {
       route,
       anchorLinks,
       documentsOptions,
-      handleDropDownChange
+      handleDropDownChange,
+      notOverview
     } = this.props;
     const countryName = country && `${country.wri_standard_name}`;
     return (
@@ -78,12 +79,14 @@ class NDCCountry extends PureComponent {
                   Compare
                 </Button>
               </TabletLandscape>
-              <Search
-                theme={lightSearch}
-                placeholder="Search"
-                value={search}
-                onChange={onSearchChange}
-              />
+              {notOverview && (
+                <Search
+                  theme={lightSearch}
+                  placeholder="Search"
+                  value={search}
+                  onChange={onSearchChange}
+                />
+              )}
             </div>
             <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
               <AnchorNav
@@ -110,7 +113,8 @@ NDCCountry.propTypes = {
   search: PropTypes.string,
   anchorLinks: PropTypes.array,
   documentsOptions: PropTypes.array,
-  handleDropDownChange: PropTypes.func
+  handleDropDownChange: PropTypes.func,
+  notOverview: PropTypes.bool
 };
 
 export default NDCCountry;

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -28,11 +28,18 @@ const mapStateToProps = (state, { match, location, route }) => {
     iso,
     data: state.ndcsDocumentsMeta.data
   };
+  const pathname = location.pathname.split('/');
+  const notOverview = [
+    'mitigation',
+    'adaptation',
+    'sectoral-information'
+  ].includes(pathname[pathname.length - 1]);
   return {
     country: getCountry(countryData),
     search: search.search,
     anchorLinks: getAnchorLinks(routeData),
-    documentsOptions: getDocumentsOptions(documentsData)
+    documentsOptions: getDocumentsOptions(documentsData),
+    notOverview
   };
 };
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157656630
This PR removes search box only from overview in NDCS country page, leaving the space blank for consistency

![image](https://user-images.githubusercontent.com/9701591/41769265-f96e4ac0-760e-11e8-9f76-506db2b54f34.png)