### PR TITLE
Feature/date on poverty data chart

### DIFF
--- a/app/javascript/app/components/circular-chart/circular-chart-component.jsx
+++ b/app/javascript/app/components/circular-chart/circular-chart-component.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 import styles from './circular-chart-styles.scss';
 
 const CircularChart = ({
@@ -27,7 +27,7 @@ const CircularChart = ({
           value,
           index
         )}, ${normalizeCircunference(index)}`}
-        style={{ stroke: COUNTRY_COMPARE_COLORS[index] }}
+        style={{ stroke: CHART_COLORS[index] }}
       />
     </svg>
   </div>

--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
@@ -9,7 +9,7 @@ import sumBy from 'lodash/sumBy';
 import {
   CALCULATION_OPTIONS,
   DEFAULT_AXES_CONFIG,
-  COUNTRY_COMPARE_COLORS,
+  CHART_COLORS,
   DATA_SCALE,
   DEFAULT_EMISSIONS_SELECTIONS,
   ALLOWED_SECTORS_BY_SOURCE,
@@ -312,7 +312,7 @@ export const getChartConfig = createSelector(
       value: getYColumnValue(l.name),
       index: l.index
     }));
-    const theme = getThemeConfig(yColumns, COUNTRY_COMPARE_COLORS);
+    const theme = getThemeConfig(yColumns, CHART_COLORS);
     const tooltip = getTooltipConfig(yColumns);
 
     return {

--- a/app/javascript/app/components/compare/compare-ndc-content-overview/compare-ndc-content-overview-component.jsx
+++ b/app/javascript/app/components/compare/compare-ndc-content-overview/compare-ndc-content-overview-component.jsx
@@ -8,7 +8,7 @@ import cx from 'classnames';
 import NdcContentOverviewProvider from 'providers/ndc-content-overview-provider';
 import iconDocument from 'assets/icons/document.svg';
 import { TabletPortraitOnly, TabletLandscape } from 'components/responsive';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 import styles from './compare-ndc-content-overview-styles.scss';
 
 class CompareNDCContentOverview extends PureComponent {
@@ -24,7 +24,7 @@ class CompareNDCContentOverview extends PureComponent {
               <div className={cx(styles.countryHeader)}>
                 <div
                   className={styles.dot}
-                  style={{ backgroundColor: COUNTRY_COMPARE_COLORS[i] }}
+                  style={{ backgroundColor: CHART_COLORS[i] }}
                 />
                 <div className={styles.countryName}>{summary.name}</div>
               </div>

--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
@@ -4,7 +4,7 @@ import layout from 'styles/layout';
 import Loading from 'components/loading';
 import SocioeconomicsProvider from 'providers/socioeconomics-provider';
 import { TabletPortraitOnly } from 'components/responsive';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 import cx from 'classnames';
 import NoContent from 'components/no-content';
 import styles from './compare-socioeconomics-styles.scss';
@@ -78,7 +78,7 @@ class CompareSocioeconomics extends PureComponent {
                           <div
                             className={styles.dot}
                             style={{
-                              backgroundColor: COUNTRY_COMPARE_COLORS[i]
+                              backgroundColor: CHART_COLORS[i]
                             }}
                           />
                           <div className={styles.countryName}>

--- a/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
+++ b/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 
 const COUNTRIES_TO_SELECT = 3;
 
@@ -51,7 +51,7 @@ export const getCountryConfig = createSelector(
     if (!countries && !countries.length) return null;
     return countries.map((country, i) => ({
       country,
-      color: COUNTRY_COMPARE_COLORS[i]
+      color: CHART_COLORS[i]
     }));
   }
 );

--- a/app/javascript/app/components/country-selector-footer/country-selector-footer-component.jsx
+++ b/app/javascript/app/components/country-selector-footer/country-selector-footer-component.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import MultiSelect from 'components/multiselect';
 import plusIcon from 'assets/icons/plus.svg';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 
 import styles from './country-selector-footer-styles.scss';
 
@@ -27,7 +27,7 @@ const CountrySelectorFooter = ({
                   <Tag
                     key={`${country.label}`}
                     label={country.label}
-                    color={COUNTRY_COMPARE_COLORS[index]}
+                    color={CHART_COLORS[index]}
                     data={{
                       id: country.label,
                       value: country.value

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -31,12 +31,12 @@ class VulnerabilityGraph extends PureComponent {
       }
       return null;
     });
-    const years = sectionData.data.map(country => {
+    const years = sectionData.data.reduce((acc, country) => {
       if (country.location) {
-        return country.year || null;
+        acc.push(country.year);
       }
-      return null;
-    });
+      return acc;
+    }, []);
     const filteredYears =
       years && years.every(y => y === years[0]) ? [years[0]] : years;
     return values.filter(value => value != null).length > 0 ? (

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -75,10 +75,9 @@ class VulnerabilityGraph extends PureComponent {
             <span>Data from </span>
             <div className={styles.circularChartDatesYears}>
               {filteredYears.map((year, index) => (
-                <span>
+                <span key={countriesIds[index]}>
                   {year && (
                     <span
-                      key={countriesIds[index]}
                       style={{
                         color:
                           filteredYears.length > 1

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ReactTooltip from 'react-tooltip';
-import { COUNTRY_COMPARE_COLORS } from 'data/constants';
+import { CHART_COLORS } from 'data/constants';
 import CircularChart from 'components/circular-chart';
 import NoContent from 'components/no-content';
 import InfoButton from 'components/button/info-button';
@@ -31,6 +31,14 @@ class VulnerabilityGraph extends PureComponent {
       }
       return null;
     });
+    const years = sectionData.data.map(country => {
+      if (country.location) {
+        return country.year || null;
+      }
+      return null;
+    });
+    const filteredYears =
+      years && years.every(y => y === years[0]) ? [years[0]] : years;
     return values.filter(value => value != null).length > 0 ? (
       <div className={styles.circularChartContainer}>
         <InfoButton
@@ -55,13 +63,38 @@ class VulnerabilityGraph extends PureComponent {
               (value !== null ? (
                 <div
                   key={countriesIds[index]}
-                  style={{ color: COUNTRY_COMPARE_COLORS[index] }}
+                  style={{ color: CHART_COLORS[index] }}
                 >
                   {typeof value === 'number' ? `${value}%` : 'N/A'}
                 </div>
               ) : null)
           )}
         </div>
+        {filteredYears && (
+          <div className={styles.circularChartDates}>
+            <span>Data from </span>
+            <div className={styles.circularChartDatesYears}>
+              {filteredYears.map((year, index) => (
+                <span>
+                  {year && (
+                    <span
+                      key={countriesIds[index]}
+                      style={{
+                        color:
+                          filteredYears.length > 1
+                            ? CHART_COLORS[index]
+                            : '#113750'
+                      }}
+                    >
+                      {year}
+                    </span>
+                  )}
+                  {year && index < filteredYears.length - 1 && <span>, </span>}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     ) : (
       <NoContent message={'No data'} className={styles.noContent} />
@@ -100,7 +133,7 @@ class VulnerabilityGraph extends PureComponent {
           {values.map((value, index) => (
             <div
               key={countriesIds[index]}
-              style={{ color: COUNTRY_COMPARE_COLORS[index] }}
+              style={{ color: CHART_COLORS[index] }}
             >
               {value}
             </div>
@@ -121,7 +154,7 @@ class VulnerabilityGraph extends PureComponent {
                   data-tip={`${countryLabel} ranked ${countrySelectedRank} of  ${maximumCountries} countries`}
                   style={{
                     [position]: `${riskAbsoluteValues[index]}%`,
-                    backgroundColor: COUNTRY_COMPARE_COLORS[index]
+                    backgroundColor: CHART_COLORS[index]
                   }}
                 >
                   {showTooltip && (
@@ -180,7 +213,7 @@ class VulnerabilityGraph extends PureComponent {
                       /* eslint-disable  no-restricted-syntax */
                       for (const value of hazard.countryIndex) {
                         if (value[0] === i) {
-                          dotColor = COUNTRY_COMPARE_COLORS[value[0]];
+                          dotColor = CHART_COLORS[value[0]];
                           break;
                         }
                       }

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-styles.scss
@@ -27,6 +27,27 @@
   font-weight: $font-weight-bold;
 }
 
+.circularChartDates {
+  position: absolute;
+  font-size: $font-size-xs;
+  text-align: right;
+  color: $theme-color;
+  bottom: -10px;
+  right: -10px;
+
+  @media #{$tablet-landscape} {
+    font-size: $font-size-s;
+  }
+}
+
+.circularChartDatesYears {
+  display: block;
+
+  @media #{$tablet-landscape} {
+    display: inline;
+  }
+}
+
 .list {
   font-size: $font-size;
   line-height: $line-height-medium;

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -151,8 +151,6 @@ export const CHART_COLORS_EXTENDED = [
   '#E5E6E8'
 ];
 
-export const COUNTRY_COMPARE_COLORS = ['#113750', '#b25bd0', '#f1933b'];
-
 export const DEFAULT_AXES_CONFIG = {
   xBottom: {
     name: 'Year',

--- a/app/services/import_stories.rb
+++ b/app/services/import_stories.rb
@@ -28,7 +28,7 @@ class ImportStories
       story = Story.find_or_initialize_by(title: title,
                                           published_at: published_at)
       story.link = feed.channel.link + item.link.split(/href="|">/)[1].sub!(/^\//, '')
-      story.background_image_url = item.enclosure ? item.enclosure.url : ''
+      story.background_image_url = item.enclosure ? item.enclosure.url : nil
       story.tags = item.category ? item.category.content.split(',').map(&:strip) : nil
       story.save
     end


### PR DESCRIPTION
This PR adds year data to poverty chart on Country compare 'Climate Vulnerability and Readiness' section. 
[Pivotal](https://www.pivotaltracker.com/story/show/158389868) and [designs](https://zpl.io/agXL5Ob).  
-  _Extra_  
It also updates Stories import to return `nil` instead of an empty string in case there is no background image provided during the import process.   

![kapture 2018-06-22 at 17 10 52](https://user-images.githubusercontent.com/6906348/41784199-481553b4-763f-11e8-8b1b-481214fac855.gif)
