### PR TITLE
Trend data action params were not passed in the correct format

### DIFF
--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -94,7 +94,10 @@ class NDCCountryFull extends PureComponent {
               <NdcsAutocompleteSearch
                 className={styles.select}
                 fetchSearchResults={fetchCountryNDCFull}
-                document={search.document}
+                document={
+                  search.document ||
+                  (contentOptionSelected && contentOptionSelected.value)
+                }
                 dark
                 label
               />

--- a/app/javascript/app/providers/esp-indicators-trend-provider/esp-indicators-trend-provider-actions.js
+++ b/app/javascript/app/providers/esp-indicators-trend-provider/esp-indicators-trend-provider-actions.js
@@ -8,7 +8,7 @@ const { ESP_API } = process.env;
 
 const getIndicatorsTrendData = createThunkAction(
   'getIndicatorsTrendData',
-  (locationId, scenarioId) => (dispatch, state) => {
+  ({ locationId, scenarioId }) => (dispatch, state) => {
     const { espIndicatorsTrend } = state();
     if (
       espIndicatorsTrend &&

--- a/app/javascript/app/providers/esp-indicators-trend-provider/esp-indicators-trend-provider.js
+++ b/app/javascript/app/providers/esp-indicators-trend-provider/esp-indicators-trend-provider.js
@@ -11,13 +11,13 @@ import reducers, {
 class EspIndicatorsTrendDataProvider extends PureComponent {
   componentDidMount() {
     const { getIndicatorsTrendData, locationId, scenarioId } = this.props;
-    getIndicatorsTrendData(locationId, scenarioId);
+    getIndicatorsTrendData({ locationId, scenarioId });
   }
 
   componentWillReceiveProps(nextProps) {
     const { getIndicatorsTrendData, locationId, scenarioId } = nextProps;
     if (locationId !== this.props.locationId) {
-      getIndicatorsTrendData(locationId, scenarioId);
+      getIndicatorsTrendData({ locationId, scenarioId });
     }
   }
 

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider-actions.js
@@ -8,7 +8,7 @@ const { ESP_API } = process.env;
 
 const getEspTimeSeries = createThunkAction(
   'getEspTimeSeries',
-  (location, model) => (dispatch, state) => {
+  ({ location, model }) => (dispatch, state) => {
     const { espTimeSeries } = state();
     if (espTimeSeries && !espTimeSeries.loading) {
       dispatch(getEspTimeSeriesInit());

--- a/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
+++ b/app/javascript/app/providers/esp-time-series-provider/esp-time-series-provider.js
@@ -8,7 +8,7 @@ import reducers, { initialState } from './esp-time-series-provider-reducers';
 class EspTimeSeriesProvider extends PureComponent {
   componentDidMount() {
     const { location, model, getEspTimeSeries } = this.props;
-    getEspTimeSeries(location, model);
+    getEspTimeSeries({ location, model });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -17,7 +17,7 @@ class EspTimeSeriesProvider extends PureComponent {
       nextProps.model !== this.props.model
     ) {
       const { location, model, getEspTimeSeries } = nextProps;
-      getEspTimeSeries(location, model);
+      getEspTimeSeries({ location, model });
     }
   }
 

--- a/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider-actions.js
+++ b/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider-actions.js
@@ -6,7 +6,7 @@ const getNdcsSdgsDataReady = createAction('getNdcsSdgsDataReady');
 
 const getNdcsSdgsData = createThunkAction(
   'getNdcsSdgsData',
-  (iso, document) => (dispatch, state) => {
+  ({ iso, document }) => (dispatch, state) => {
     const { ndcsSdgsData } = state();
     if (ndcsSdgsData) {
       dispatch(getNdcsSdgsDataInit());

--- a/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider.js
+++ b/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider.js
@@ -9,7 +9,7 @@ import reducers, { initialState } from './ndcs-sdgs-data-provider-reducers';
 class NdcsSdgsDataProvider extends PureComponent {
   componentDidMount() {
     const { getNdcsSdgsData, match, document } = this.props;
-    getNdcsSdgsData(match.params.iso, document);
+    getNdcsSdgsData({ iso: match.params.iso, document });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -17,7 +17,10 @@ class NdcsSdgsDataProvider extends PureComponent {
     const nextIso = nextProps.match.params.iso;
 
     if (iso !== nextIso || this.props.document !== nextProps.document) {
-      this.props.getNdcsSdgsData(nextIso, nextProps.document);
+      this.props.getNdcsSdgsData({
+        iso: nextIso,
+        document: nextProps.document
+      });
     }
   }
 


### PR DESCRIPTION
Since we make some changes in the redux utils library it appears that most of the time only the first param of createThunkAction is read. So we have to pass the params as an object. Some other actions with two params are changed in this PR.

- Change 2 params actions from the providers into 1 object.
- Get default NDC document in the NDC full document view when there is no related url parameter


![image](https://user-images.githubusercontent.com/9701591/41902343-7c8d0e24-7933-11e8-8b87-803135ceda8e.png)
