### PR TITLE
Fix/charts sectors legend dropdown

### DIFF
--- a/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-component.jsx
@@ -32,47 +32,52 @@ class LegendChart extends PureComponent {
     return (
       <div className={styles.legendChart}>
         <div className={styles.legendContainer}>
-          <ul className={cx(styles.tags, className)}>
-            {hasColumns &&
-              config.columns.y.map(column => (
-                <Tag
-                  className={styles.tag}
-                  key={`${column.value}`}
-                  data={{
-                    id: column.value,
-                    url: column.url || null,
-                    title: column.legendTooltip || null
-                  }}
-                  label={column.label}
-                  color={config.theme[column.value].stroke}
-                  tooltipId="legend-tooltip"
-                  onRemove={handleRemove}
-                  canRemove={
-                    hideRemoveOptions ? false : config.columns.y.length > 1
-                  }
-                />
-              ))}
-            {hasColumns && <ReactTooltip id="legend-tooltip" />}
-            {shouldShowMultiselect && (
-              <MultiSelect
-                parentClassName={styles.tagSelector}
-                values={dataSelected || []}
-                options={dataOptions || []}
-                onMultiValueChange={handleAdd}
-                hideResetButton
-                closeOnSelect
-                dropdownDirection={-1}
-                hideSelected
-                icon={plusIcon}
-                mirrorX={mirrorX}
-              />
-            )}
-          </ul>
-          {config && config.legendNote && (
-            <div className={styles.tagDescription}>
-              Click on each scenarios to see the assumptions behind it.
+          <div className={styles.tagsContainer}>
+            <div className={styles.tagsWrapper}>
+              <ul className={cx(styles.tags, className)}>
+                {hasColumns &&
+                  config.columns.y.map(column => (
+                    <Tag
+                      className={styles.tag}
+                      key={`${column.value}`}
+                      data={{
+                        id: column.value,
+                        url: column.url || null,
+                        title: column.legendTooltip || null
+                      }}
+                      label={column.label}
+                      color={config.theme[column.value].stroke}
+                      tooltipId="legend-tooltip"
+                      onRemove={handleRemove}
+                      canRemove={
+                        hideRemoveOptions ? false : config.columns.y.length > 1
+                      }
+                    />
+                  ))}
+                {hasColumns && <ReactTooltip id="legend-tooltip" />}
+                {shouldShowMultiselect && (
+                  <MultiSelect
+                    parentClassName={styles.tagSelector}
+                    values={dataSelected || []}
+                    options={dataOptions || []}
+                    onMultiValueChange={handleAdd}
+                    hideResetButton
+                    closeOnSelect
+                    dropdownDirection={-1}
+                    hideSelected
+                    icon={plusIcon}
+                    mirrorX={mirrorX}
+                  />
+                )}
+              </ul>
             </div>
-          )}
+          </div>
+          {config &&
+           config.legendNote && (
+              <div className={styles.tagDescription}>
+              Click on each scenarios to see the assumptions behind it.
+              </div>
+            )}
         </div>
         {model && (
           <div className={styles.legendLogo}>

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -43,14 +43,36 @@ $margin-container: 10px;
   }
 }
 
-.tags {
-  display: flex;
-  overflow: scroll;
-  margin-top: $margin-container;
+.tagsContainer {
+  position: relative;
+  min-height: 120px;
+  
+  @media #{$tablet-landscape} {
+    min-height: 50px;
+  }
+}
+
+.tagsWrapper {
+  position: absolute;
+  width: 100%;
+  height: 200px;
+  bottom: 0;
+  overflow-x: scroll;
 
   @media #{$tablet-landscape} {
     flex-wrap: wrap;
     overflow: visible;
+  }
+}
+
+.tags {
+  display: flex;
+  margin-top: $margin-container;
+  position: absolute;
+  bottom: 0;
+
+  @media #{$tablet-landscape} {
+    flex-wrap: wrap;
   }
 }
 

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -46,8 +46,12 @@ $margin-container: 10px;
 .tagsContainer {
   position: relative;
   min-height: 120px;
-  
+
   @media #{$tablet-landscape} {
+    min-height: 85px;
+  }
+
+  @media #{$desktop} {
     min-height: 50px;
   }
 }

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -59,7 +59,7 @@ $margin-container: 10px;
 .tagsWrapper {
   position: absolute;
   width: 100%;
-  height: 200px;
+  height: 300px;
   bottom: 0;
   overflow-x: scroll;
 

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -3,7 +3,6 @@
 $margin-container: 10px;
 
 .legendChart {
-  overflow: auto;
   margin-bottom: $margin-container;
 
   .legendContainer {
@@ -51,7 +50,7 @@ $margin-container: 10px;
 
   @media #{$tablet-landscape} {
     flex-wrap: wrap;
-    overflow: auto;
+    overflow: visible;
   }
 }
 

--- a/app/javascript/app/components/circular-chart/circular-chart-component.jsx
+++ b/app/javascript/app/components/circular-chart/circular-chart-component.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CHART_COLORS } from 'data/constants';
 import styles from './circular-chart-styles.scss';
 
 const CircularChart = ({
   value,
   index,
+  color,
   setRadius,
   setArcLength,
   normalizeCircunference
@@ -27,7 +27,7 @@ const CircularChart = ({
           value,
           index
         )}, ${normalizeCircunference(index)}`}
-        style={{ stroke: CHART_COLORS[index] }}
+        style={{ stroke: color }}
       />
     </svg>
   </div>
@@ -36,6 +36,7 @@ const CircularChart = ({
 CircularChart.propTypes = {
   value: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
+  color: PropTypes.string.isRequired,
   setRadius: PropTypes.func.isRequired,
   setArcLength: PropTypes.func.isRequired,
   normalizeCircunference: PropTypes.func.isRequired

--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
@@ -9,7 +9,7 @@ import sumBy from 'lodash/sumBy';
 import {
   CALCULATION_OPTIONS,
   DEFAULT_AXES_CONFIG,
-  CHART_COLORS,
+  COUNTRY_COMPARE_COLORS,
   DATA_SCALE,
   DEFAULT_EMISSIONS_SELECTIONS,
   ALLOWED_SECTORS_BY_SOURCE,
@@ -312,7 +312,7 @@ export const getChartConfig = createSelector(
       value: getYColumnValue(l.name),
       index: l.index
     }));
-    const theme = getThemeConfig(yColumns, CHART_COLORS);
+    const theme = getThemeConfig(yColumns, COUNTRY_COMPARE_COLORS);
     const tooltip = getTooltipConfig(yColumns);
 
     return {

--- a/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
+++ b/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { CHART_COLORS } from 'data/constants';
+import { COUNTRY_COMPARE_COLORS } from 'data/constants';
 
 const COUNTRIES_TO_SELECT = 3;
 
@@ -51,7 +51,7 @@ export const getCountryConfig = createSelector(
     if (!countries && !countries.length) return null;
     return countries.map((country, i) => ({
       country,
-      color: CHART_COLORS[i]
+      color: COUNTRY_COMPARE_COLORS[i]
     }));
   }
 );

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ReactTooltip from 'react-tooltip';
-import { CHART_COLORS } from 'data/constants';
+import { COUNTRY_COMPARE_COLORS } from 'data/constants';
 import CircularChart from 'components/circular-chart';
 import NoContent from 'components/no-content';
 import InfoButton from 'components/button/info-button';
@@ -54,7 +54,7 @@ class VulnerabilityGraph extends PureComponent {
                 key={countriesIds[index]}
                 index={index}
                 value={value}
-                color={values.length > 1 ? CHART_COLORS[index] : '#113750'}
+                color={COUNTRY_COMPARE_COLORS[index]}
               />
             ) : null)
         )}
@@ -65,7 +65,7 @@ class VulnerabilityGraph extends PureComponent {
                 <div
                   key={countriesIds[index]}
                   style={{
-                    color: values.length > 1 ? CHART_COLORS[index] : '#113750'
+                    color: COUNTRY_COMPARE_COLORS[index]
                   }}
                 >
                   {typeof value === 'number' ? `${value}%` : 'N/A'}
@@ -82,10 +82,7 @@ class VulnerabilityGraph extends PureComponent {
                   {year && (
                     <span
                       style={{
-                        color:
-                          filteredYears.length > 1
-                            ? CHART_COLORS[index]
-                            : '#113750'
+                        color: COUNTRY_COMPARE_COLORS[index]
                       }}
                     >
                       {year}
@@ -136,7 +133,7 @@ class VulnerabilityGraph extends PureComponent {
             <div
               key={countriesIds[index]}
               style={{
-                color: values.length > 1 ? CHART_COLORS[index] : '#113750'
+                color: COUNTRY_COMPARE_COLORS[index]
               }}
             >
               {value}
@@ -158,8 +155,7 @@ class VulnerabilityGraph extends PureComponent {
                   data-tip={`${countryLabel} ranked ${countrySelectedRank} of  ${maximumCountries} countries`}
                   style={{
                     [position]: `${riskAbsoluteValues[index]}%`,
-                    backgroundColor:
-                      values.length > 1 ? CHART_COLORS[index] : '#113750'
+                    backgroundColor: COUNTRY_COMPARE_COLORS[index]
                   }}
                 >
                   {showTooltip && (
@@ -218,10 +214,7 @@ class VulnerabilityGraph extends PureComponent {
                       /* eslint-disable  no-restricted-syntax */
                       for (const value of hazard.countryIndex) {
                         if (value[0] === i) {
-                          dotColor =
-                            countries.length > 1
-                              ? CHART_COLORS[value[0]]
-                              : '#113750';
+                          dotColor = COUNTRY_COMPARE_COLORS[value[0]];
                           break;
                         }
                       }

--- a/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
+++ b/app/javascript/app/components/vulnerability-graph/vulnerability-graph-component.jsx
@@ -54,6 +54,7 @@ class VulnerabilityGraph extends PureComponent {
                 key={countriesIds[index]}
                 index={index}
                 value={value}
+                color={values.length > 1 ? CHART_COLORS[index] : '#113750'}
               />
             ) : null)
         )}
@@ -63,7 +64,9 @@ class VulnerabilityGraph extends PureComponent {
               (value !== null ? (
                 <div
                   key={countriesIds[index]}
-                  style={{ color: CHART_COLORS[index] }}
+                  style={{
+                    color: values.length > 1 ? CHART_COLORS[index] : '#113750'
+                  }}
                 >
                   {typeof value === 'number' ? `${value}%` : 'N/A'}
                 </div>
@@ -132,7 +135,9 @@ class VulnerabilityGraph extends PureComponent {
           {values.map((value, index) => (
             <div
               key={countriesIds[index]}
-              style={{ color: CHART_COLORS[index] }}
+              style={{
+                color: values.length > 1 ? CHART_COLORS[index] : '#113750'
+              }}
             >
               {value}
             </div>
@@ -153,7 +158,8 @@ class VulnerabilityGraph extends PureComponent {
                   data-tip={`${countryLabel} ranked ${countrySelectedRank} of  ${maximumCountries} countries`}
                   style={{
                     [position]: `${riskAbsoluteValues[index]}%`,
-                    backgroundColor: CHART_COLORS[index]
+                    backgroundColor:
+                      values.length > 1 ? CHART_COLORS[index] : '#113750'
                   }}
                 >
                   {showTooltip && (
@@ -212,7 +218,10 @@ class VulnerabilityGraph extends PureComponent {
                       /* eslint-disable  no-restricted-syntax */
                       for (const value of hazard.countryIndex) {
                         if (value[0] === i) {
-                          dotColor = CHART_COLORS[value[0]];
+                          dotColor =
+                            countries.length > 1
+                              ? CHART_COLORS[value[0]]
+                              : '#113750';
                           break;
                         }
                       }

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -151,6 +151,8 @@ export const CHART_COLORS_EXTENDED = [
   '#E5E6E8'
 ];
 
+export const COUNTRY_COMPARE_COLORS = ['#113750', '#00B4D2', '#D2187C'];
+
 export const DEFAULT_AXES_CONFIG = {
   xBottom: {
     name: 'Year',


### PR DESCRIPTION
This PR fixes the tags on the legend of GHG emissions and Pathways chart.
[Pivotal](https://www.pivotaltracker.com/story/show/158564971)

It also fixes the colour displayed on country page (and compare) when there is just one country selcted.  
[Basecam](https://basecamp.com/1756858/projects/13795275/todos/352035002#comment_630605589) 
[Designs](https://basecamp.com/1756858/projects/13795275/todos/352035002?enlarge=334314396#attachment_334314396) 

![kapture 2018-06-26 at 14 20 21](https://user-images.githubusercontent.com/6906348/41911165-2ca60a32-794c-11e8-831c-c3219d857068.gif)
