### PR TITLE
Add a new "real" Overview tab and rename old overview to summary

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -209,7 +209,7 @@ class CountryNdcOverview extends PureComponent {
                         actions ? (
                           'Nationally Determined Contribution (NDC) Overview'
                         ) : (
-                          'Overview'
+                          'Summary'
                         )
                       }
                     />

--- a/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
@@ -112,7 +112,7 @@ export const getTitleLinks = createSelector([getFilteredData], data => {
   return data.map(d => [
     {
       columnName: 'country',
-      url: `country/${d.iso}`
+      url: `/ndcs/country/${d.iso}`
     }
   ]);
 });

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -30,7 +30,7 @@ class NDCCountry extends PureComponent {
       anchorLinks,
       documentsOptions,
       handleDropDownChange,
-      notOverview
+      notSummary
     } = this.props;
     const countryName = country && `${country.wri_standard_name}`;
     return (
@@ -79,7 +79,7 @@ class NDCCountry extends PureComponent {
                   Compare
                 </Button>
               </TabletLandscape>
-              {notOverview && (
+              {notSummary && (
                 <Search
                   theme={lightSearch}
                   placeholder="Search"
@@ -114,7 +114,7 @@ NDCCountry.propTypes = {
   anchorLinks: PropTypes.array,
   documentsOptions: PropTypes.array,
   handleDropDownChange: PropTypes.func,
-  notOverview: PropTypes.bool
+  notSummary: PropTypes.bool
 };
 
 export default NDCCountry;

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -29,7 +29,8 @@ const mapStateToProps = (state, { match, location, route }) => {
     data: state.ndcsDocumentsMeta.data
   };
   const pathname = location.pathname.split('/');
-  const notOverview = [
+  const notSummary = [
+    'overview',
     'mitigation',
     'adaptation',
     'sectoral-information'
@@ -39,7 +40,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     search: search.search,
     anchorLinks: getAnchorLinks(routeData),
     documentsOptions: getDocumentsOptions(documentsData),
-    notOverview
+    notSummary
   };
 };
 

--- a/app/javascript/app/routes/app-routes/NDCCompare-routes/NDCCompare-routes.js
+++ b/app/javascript/app/routes/app-routes/NDCCompare-routes/NDCCompare-routes.js
@@ -5,6 +5,18 @@ import NDCCountryAccordion from 'components/ndcs/ndcs-country-accordion';
 
 export default [
   {
+    path: '/ndcs/compare/overview',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'overview',
+        compare: true
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Overview',
+    param: 'overview'
+  },
+  {
     path: '/ndcs/compare/mitigation',
     component: () =>
       createElement(NDCCountryAccordion, {

--- a/app/javascript/app/routes/app-routes/NDCCountry-routes/NDCCountry-routes.js
+++ b/app/javascript/app/routes/app-routes/NDCCountry-routes/NDCCountry-routes.js
@@ -10,7 +10,18 @@ export default [
     component: () => createElement(CountryNdcOverview, { textColumns: true }),
     exact: true,
     anchor: true,
-    label: 'Overview'
+    label: 'Summary'
+  },
+  {
+    path: '/ndcs/country/:iso/overview',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'overview'
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Overview',
+    param: 'overview'
   },
   {
     path: '/ndcs/country/:iso/mitigation',


### PR DESCRIPTION
They updated the data to include an actual overview category and
moved the old tab that was called overview to Summary tab, and this one
includes the same data present in the country page NDC Content.

This also meant changing the "notOverview" to "notSummary" as the search is now needed on the overview but not on the summary tab.