### PR TITLE
Fix/modal metadata empty

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -11,7 +11,6 @@ import EmissionsMetaProvider from 'providers/ghg-emissions-meta-provider';
 import WbCountryDataProvider from 'providers/wb-country-data-provider';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import ModalMetadata from 'components/modal-metadata';
-import Disclaimer from 'components/disclaimer';
 import { isPageContained } from 'utils/navigation';
 
 import quantificationTagTheme from 'styles/themes/tag/quantification-tag.scss';
@@ -196,7 +195,7 @@ class CountryGhgEmissions extends PureComponent {
             {this.renderActionButtons()}
           </div>
         </TabletPortraitOnly>
-        <ModalMetadata disclaimer={<Disclaimer onlyText />} />
+        <ModalMetadata />
       </div>
     );
   }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -115,7 +115,10 @@ class CountryGhgEmissionsContainer extends PureComponent {
         category: 'Country',
         slugs: isPageContained ? [source] : [source, 'ndc_quantification_UNDP'],
         customTitle: 'Greenhouse Gas Emissions and Emissions Targets',
-        showDisclaimer: !isPageContained,
+        disclaimerConfig: {
+          display: !isPageContained,
+          onlyText: true
+        },
         open: true
       });
     }

--- a/app/javascript/app/components/country/country-ghg/country-ghg-component.jsx
+++ b/app/javascript/app/components/country/country-ghg/country-ghg-component.jsx
@@ -59,7 +59,7 @@ class CountryGhg extends PureComponent {
         {showDisclaimer && (
           <Disclaimer className={cx(styles.disclaimer, layout.content)} />
         )}
-        <ModalMetadata disclaimer={<Disclaimer onlyText />} />
+        <ModalMetadata />
       </div>
     );
   }

--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import Disclaimer from 'components/disclaimer';
 import styles from './metadata-text-styles.scss';
 
 const MetadataProp = ({ title, children }) => (
@@ -18,7 +19,7 @@ MetadataProp.propTypes = {
 class MetadataText extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { showDisclaimer, disclaimer, data, className } = this.props;
+    const { disclaimerConfig, data, className } = this.props;
     const {
       learn_more_link,
       source_organization,
@@ -78,7 +79,9 @@ class MetadataText extends PureComponent {
             </a>
           </MetadataProp>
         )}
-        {showDisclaimer && disclaimer}
+        {disclaimerConfig && disclaimerConfig.display && (
+          <Disclaimer onlyText={disclaimerConfig.onlyText} />
+        )}
       </div>
     );
   }
@@ -86,13 +89,8 @@ class MetadataText extends PureComponent {
 
 MetadataText.propTypes = {
   data: PropTypes.object,
-  showDisclaimer: PropTypes.bool.isRequired,
-  disclaimer: PropTypes.node,
+  disclaimerConfig: PropTypes.object,
   className: PropTypes.string
-};
-
-MetadataText.defaultProps = {
-  showDisclaimer: false
 };
 
 export default MetadataText;

--- a/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
@@ -48,7 +48,7 @@ const fetchModalMetaData = createThunkAction(
 
       Promise.all(promises)
         .then(data => {
-          dispatch(fetchModalMetaDataReady({ slugs, data }));
+          dispatch(fetchModalMetaDataReady({ slugs: slugsToFetch, data }));
         })
         .catch(error => {
           console.warn(error);

--- a/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-component.jsx
@@ -18,7 +18,7 @@ class ModalMetadata extends PureComponent {
   }
 
   getContent() {
-    const { data, loading, showDisclaimer, disclaimer } = this.props;
+    const { data, loading, disclaimerConfig } = this.props;
     if (loading) {
       return <Loading className={styles.loadingContainer} />;
     }
@@ -31,8 +31,7 @@ class ModalMetadata extends PureComponent {
     return (
       <MetadataText
         data={selectedIndexData}
-        showDisclaimer={showDisclaimer}
-        disclaimer={disclaimer}
+        disclaimerConfig={disclaimerConfig}
       />
     );
   }
@@ -67,15 +66,10 @@ ModalMetadata.propTypes = {
   title: PropTypes.string,
   tabTitles: PropTypes.array,
   data: PropTypes.array,
-  disclaimer: PropTypes.node,
-  showDisclaimer: PropTypes.bool.isRequired,
+  disclaimerConfig: PropTypes.object,
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
-};
-
-ModalMetadata.defaultProps = {
-  showDisclaimer: false
 };
 
 export default ModalMetadata;

--- a/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-reducers.js
@@ -3,7 +3,7 @@ export const initialState = {
   loading: false,
   isOpen: false,
   customTitle: '',
-  showDisclaimer: false,
+  disclaimerConfig: { display: false, onlyText: false },
   active: [],
   data: {}
 };
@@ -12,7 +12,12 @@ const setModalMetadataParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
   active: typeof payload.slugs === 'string' ? [payload.slugs] : payload.slugs,
-  showDisclaimer: payload.showDisclaimer || false,
+  disclaimerConfig: {
+    display:
+      (payload.disclaimerConfig && payload.disclaimerConfig.display) || false,
+    onlyText:
+      (payload.disclaimerConfig && payload.disclaimerConfig.onlyText) || false
+  },
   customTitle: payload.customTitle || state.title
 });
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { withHandlers } from 'recompose';
-
 import actions from './modal-metadata-actions';
 import reducers, { initialState } from './modal-metadata-reducers';
 
@@ -17,7 +16,8 @@ const mapStateToProps = ({ modalMetadata }) => ({
   title: getModalTitle(modalMetadata),
   tabTitles: getTabTitles(modalMetadata),
   data: getModalData(modalMetadata),
-  showDisclaimer: modalMetadata.showDisclaimer
+  disclaimerConfig: modalMetadata.disclaimerConfig,
+  mounted: modalMetadata.mounted
 });
 
 const includeActions = withHandlers({

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
@@ -119,6 +119,7 @@ class NDCMapContainer extends PureComponent {
 
   handleInfoClick = () => {
     this.props.setModalMetadata({
+      customTitle: 'NDC Content',
       category: 'NDC Content Map',
       slugs: ['ndc_cait', 'ndc_wb'],
       open: true


### PR DESCRIPTION
The metadata modal was not working as expected. Try: Open country/Greenhouse Gas Emissions and Emissions Targets info modal -> Change the source -> open it again -> change the source -> open it again

- The metadata modal reducer had a problem and was storing some undefined data instead of keeping the already fetched data

![image](https://user-images.githubusercontent.com/9701591/41926532-e9105b00-796f-11e8-986f-f559c5b2fb3d.png)

Extra: 
- NDC page modal needed a custom title
![image](https://user-images.githubusercontent.com/9701591/41926705-60fcfd8a-7970-11e8-8b0a-76758c559cc0.png)

- Disclaimer was not being shown in the metadata modal
![image](https://user-images.githubusercontent.com/9701591/41926721-703622ea-7970-11e8-86d1-ea83d75f7ffa.png)
