### PR TITLE
Fix/country legend and quantifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,34 @@
 
 Table of Contents:
 
+- [Domain description](#domain-description)
 - [Local Setup](#local-setup)
 - [Modules](#modules)
 - [API](#api)
+
+### Domain description
+
+- UNFCCC - United nations framework climate change convention - Organization of parties
+
+- INDC: Intended Nationally Determined Contributions (INDCs) is a term used under the United Nations Framework Convention on Climate Change (UNFCCC) for reductions in greenhouse gas emissions that all countries that signed the UNFCCC were asked to publish in the lead up to the 2015 United Nations Climate Change Conference held in Paris
+
+- NDC: Nationally Determined Contributions (NDCs) Doument that the country issue towards the UNFCCC convention
+
+- SDG: The Sustainable Development Goals (SDGs) are a set of 17 "Global Goals" with 169 targets. These goals and targets cover a broad range of sustainable development issues.
+
+- GHG - Greenhouse gas emissions
+
+- GDP - Gross Domestic Product
+
+- Category: (in Emission Pathways Section) Different models related to the ESP data. i.e models, scenarios and indicators
+
+- CO2e - Equivalent CO2 emissions regardless of the gas
+
+- SDG - Sustainable development goals - Goals and targets created by the UN
+
+- IPCC version == GWP (Global Warming Potential) - Versions of the data created for UNFCCC
+
+- ANNEX 1 and non-ANNEX 2 (UNFCCC) - Different groups of parties of the convention
 
 ## Local setup
 
@@ -257,15 +282,6 @@ format:
     }, ...
 ]
 ```
-
-### Domain description
-
-- NDC: Intended Nationally Determined Contributions (INDCs) is a term used under the United Nations Framework Convention on Climate Change (UNFCCC) for reductions in greenhouse gas emissions that all countries that signed the UNFCCC were asked to publish in the lead up to the 2015 United Nations Climate Change Conference held in Paris
-
-- SDG: The Sustainable Development Goals (SDGs) are a set of 17 "Global Goals" with 169 targets. These goals and targets cover a broad range of sustainable development issues.
-
-- Category: (in Emission Pathways Section) stand for the different models related to the ESP data. i.e models, scenarios and indicators
-
 
 ### Release
 To release using a [fork of zeit release](https://github.com/vizzuality/release) to generate the changelog automatically with all of the PR included since the last release just run:

--- a/app/javascript/app/components/button-group/button-group-component.jsx
+++ b/app/javascript/app/components/button-group/button-group-component.jsx
@@ -40,6 +40,7 @@ const ButtonGroup = ({ className, buttonsConfig, disabled }) => (
             inButtonGroup
             analyticsGraphName={buttonConfig.analyticsGraphName}
             reverse={buttonConfig.reverseDropdown}
+            positionRight={buttonConfig.positionRight}
           />
         );
       } else {

--- a/app/javascript/app/components/button-group/button-group-styles.scss
+++ b/app/javascript/app/components/button-group/button-group-styles.scss
@@ -40,6 +40,7 @@
   box-shadow: none;
   fill: rgba($theme-color, 0.7);
   transition: fill 150ms ease-out;
+  min-width: 20px;
 
   &:hover {
     box-shadow: none;

--- a/app/javascript/app/components/button/button-styles.scss
+++ b/app/javascript/app/components/button/button-styles.scss
@@ -15,6 +15,7 @@
   cursor: pointer;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
   transition: box-shadow 150ms ease-out;
+  min-width: 25px;
 
   &:hover {
     box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.09);

--- a/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
+++ b/app/javascript/app/components/charts/legend-chart/legend-chart-styles.scss
@@ -66,6 +66,8 @@ $margin-container: 10px;
   @media #{$tablet-landscape} {
     flex-wrap: wrap;
     overflow: visible;
+    position: relative;
+    height: unset;
   }
 }
 
@@ -77,6 +79,7 @@ $margin-container: 10px;
 
   @media #{$tablet-landscape} {
     flex-wrap: wrap;
+    position: relative;
   }
 }
 

--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
@@ -20,7 +20,7 @@ import styles from './compare-ghg-chart-styles.scss';
 
 class CompareGhgChart extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
-  renderButtonGroup(reverseDropdown) {
+  renderButtonGroup() {
     return (
       <ButtonGroup
         className={styles.colEnd}
@@ -33,7 +33,7 @@ class CompareGhgChart extends PureComponent {
             type: 'share',
             shareUrl: '/embed/ghg-emissions',
             analyticsGraphName: 'Ghg-emissions',
-            reverseDropdown
+            positionRight: true
           },
           {
             type: 'download'
@@ -46,7 +46,7 @@ class CompareGhgChart extends PureComponent {
     );
   }
 
-  renderActionButtons(reverseDropdown) {
+  renderActionButtons() {
     const {
       handleInfoClick,
       handleAnalyticsClick,
@@ -65,7 +65,7 @@ class CompareGhgChart extends PureComponent {
             type: 'share',
             shareUrl: '/embed/compare-ghg-chart',
             analyticsGraphName: 'Ghg-emissions',
-            reverseDropdown
+            positionRight: true
           },
           {
             type: 'download'

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -66,7 +66,7 @@ class CountryGhgEmissions extends PureComponent {
           type: 'share',
           shareUrl: `/embed/countries/${iso}/ghg-emissions`,
           analyticsGraphName: 'Country/Ghg-emissions',
-          reverseDropdown: !isEmbed
+          positionRight: true
         },
         {
           type: 'download'

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -26,7 +26,7 @@ class CountryNdcOverview extends PureComponent {
         {
           type: 'share',
           shareUrl: `/embed/countries/${iso}/ndc-content-overview`,
-          reverseDropdown: true
+          positionRight: true
         }
       ];
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -25,7 +25,8 @@ class CountryNdcOverview extends PureComponent {
         { type: 'info', onClick: handleInfoClick },
         {
           type: 'share',
-          shareUrl: `/embed/countries/${iso}/ndc-content-overview`
+          shareUrl: `/embed/countries/${iso}/ndc-content-overview`,
+          reverseDropdown: true
         }
       ];
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -25,7 +25,7 @@
 }
 
 .actions {
-  @include columns((2, 6));
+  @include columns((6, 6));
   @include xy-gutters($gutter-position: ('bottom'));
 
   @media #{$tablet-landscape} {

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -172,7 +172,7 @@ class CountrySDGLinkages extends PureComponent {
         {
           type: 'share',
           shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`,
-          reverseDropdown: true
+          positionRight: true
         }
       ];
 

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -33,7 +33,9 @@ class CountrySDGLinkages extends PureComponent {
     const { sectors, tooltipData, targets, tooltipSectorIds } = this.props;
     const targetsContent = targets && targets[tooltipData.goal_number];
     const hasTooltipData = sector => {
-      if (tooltipSectorIds) { return !!tooltipSectorIds.find(id => sectors[id] === sector); }
+      if (tooltipSectorIds) {
+        return !!tooltipSectorIds.find(id => sectors[id] === sector);
+      }
       return false;
     };
     const sectorsLabels =
@@ -169,7 +171,8 @@ class CountrySDGLinkages extends PureComponent {
         { type: 'info', onClick: handleInfoClick },
         {
           type: 'share',
-          shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`
+          shareUrl: `/embed/countries/${iso}/ndc-sdg-linkages`,
+          reverseDropdown: true
         }
       ];
 

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-styles.scss
@@ -34,10 +34,10 @@
 }
 
 .buttons {
-  @include columns((12, 12, 2, 10));
+  @include columns((12, 12, 4, 8));
 
   @media #{$tablet-landscape} {
-    @include columns((6, 1.2, 1.8, 3));
+    @include columns((6, 1, 2, 3));
   }
 
   .infoBtn,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -89,7 +89,8 @@ class EmissionPathwayGraph extends PureComponent {
                     {
                       type: 'share',
                       shareUrl: '/embed/pathways',
-                      analyticsGraphName: 'Pathways'
+                      analyticsGraphName: 'Pathways',
+                      positionRight: true
                     },
                     {
                       type: 'download'
@@ -182,7 +183,7 @@ class EmissionPathwayGraph extends PureComponent {
                   type: 'share',
                   shareUrl: '/embed/pathways',
                   analyticsGraphName: 'Pathways',
-                  reverseDropdown: true
+                  positionRight: true
                 },
                 {
                   type: 'download'

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -38,7 +38,7 @@ class GhgEmissions extends PureComponent {
       activeFilterRegion
     } = this.props;
 
-    const renderButtonGroup = reverseDropdown => (
+    const renderButtonGroup = () => (
       <ButtonGroup
         className={styles.colEnd}
         buttonsConfig={[
@@ -50,7 +50,7 @@ class GhgEmissions extends PureComponent {
             type: 'share',
             shareUrl: '/embed/ghg-emissions',
             analyticsGraphName: 'Ghg-emissions',
-            reverseDropdown
+            positionRight: true
           },
           {
             type: 'download'

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
@@ -81,7 +81,8 @@ class NdcSdgLinkagesMap extends PureComponent {
                     {
                       type: 'share',
                       shareUrl: '/embed/ndcs-sdg',
-                      analyticsGraphName: 'Ndcs-Sdg'
+                      analyticsGraphName: 'Ndcs-Sdg',
+                      positionRight: true
                     },
                     {
                       type: 'download'

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
@@ -25,7 +25,7 @@ const getTooltip = (country, tooltipTxt) => (
   </Link>
 );
 
-const renderButtonGroup = (clickHandler, reverseDropdown = false) => (
+const renderButtonGroup = clickHandler => (
   <ButtonGroup
     className={styles.buttonGroup}
     buttonsConfig={[
@@ -37,7 +37,7 @@ const renderButtonGroup = (clickHandler, reverseDropdown = false) => (
         type: 'share',
         shareUrl: '/embed/ndcs',
         analyticsGraphName: 'Ndcs',
-        reverseDropdown
+        positionRight: true
       },
       {
         type: 'download'

--- a/app/javascript/app/components/simple-menu/simple-menu-styles.scss
+++ b/app/javascript/app/components/simple-menu/simple-menu-styles.scss
@@ -70,6 +70,7 @@
 
   &.inButtonGroup {
     width: 100%;
+    min-width: 25px;
 
     .links {
       top: 48px;
@@ -97,7 +98,7 @@
     top: 60px;
     right: 0;
     width: 210px;
-    z-index: 20;
+    z-index: 11;
     border-top: 1px solid $theme-border;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
 


### PR DESCRIPTION
Recent changes had created some bug in the Countries/GHG emissions legend. The legend was overlapping in two line legends and some quantifications couldn't be hovered into.
Try: http://localhost:3000/countries/BRA?source=23
Also fixed this: https://www.pivotaltracker.com/story/show/158557025

- Fix legend (quantifications was fixed too)
- Fix group buttons (info and share) in country/ndc and ndc-linkages sections
![image](https://user-images.githubusercontent.com/9701591/42175964-9b8ce0f8-7e27-11e8-9d94-15dffedb9065.png)


Extra: 
- Update some terms for the domain in the Readme
- Fix dropdown direction on mobile on that page

Before:

![image](https://user-images.githubusercontent.com/9701591/42174616-40d4fbfe-7e23-11e8-9016-933c81ccb51f.png)

After:
![image](https://user-images.githubusercontent.com/9701591/42174589-2aaf6dc8-7e23-11e8-9e20-9266ceded0cf.png)
