### PR TITLE
Feature/ Data Explorer - remove ndc source filter

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -12,6 +12,7 @@ import Loading from 'components/loading';
 import Button from 'components/button';
 import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
 import { toStartCase } from 'app/utils';
+import cx from 'classnames';
 import styles from './data-explorer-content-styles.scss';
 
 class DataExplorerContent extends PureComponent {
@@ -35,8 +36,14 @@ class DataExplorerContent extends PureComponent {
   renderMeta() {
     const { meta, loadingMeta } = this.props;
     if (loadingMeta) return <Loading light className={styles.loader} />;
-    return meta ? (
-      <MetadataText className={styles.metadataText} data={meta} />
+    return meta && meta.length > 0 ? (
+      meta.map((m, i) => (
+        <MetadataText
+          key={m.technical_title}
+          className={cx(styles.metadataText, { [styles.topPadded]: i > 0 })}
+          data={m}
+        />
+      ))
     ) : (
       <NoContent message={'Select a source'} className={styles.noData} />
     );
@@ -115,7 +122,7 @@ DataExplorerContent.propTypes = {
   filterOptions: PropTypes.object,
   metadataSection: PropTypes.bool,
   data: PropTypes.array,
-  meta: PropTypes.object,
+  meta: PropTypes.array,
   firstColumnHeaders: PropTypes.array,
   loading: PropTypes.bool,
   loadingMeta: PropTypes.bool,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -181,8 +181,11 @@ export const getMethodology = createSelector(
       !meta ||
       isEmpty(meta) ||
       !section ||
-      (sectionHasSources && isEmpty(selectedfilters))
-    ) { return null; }
+      (sectionHasSources &&
+        (isEmpty(selectedfilters) || !selectedfilters.source))
+    ) {
+      return null;
+    }
     const methodology = meta.methodology;
     let metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section];
     if (sectionHasSources) {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -94,8 +94,8 @@ export const getFilterOptions = createSelector(
     if (!filtersMeta) return null;
     if (filters.includes('regions')) filtersMeta.regions = regions;
     if (filters.includes('countries')) filtersMeta.countries = countries;
-    if (filters.includes('source_IPCC_version')) {
-      filtersMeta.source_IPCC_version = sourceVersions;
+    if (filters.includes('source')) {
+      filtersMeta.source = sourceVersions;
     }
     const filterOptions = {};
     filters.forEach(f => {
@@ -143,7 +143,7 @@ const mergeSourcesAndVersions = filters => {
   const versionFilter = filters.gwps;
   const updatedFilters = filters;
   if (dataSourceFilter) {
-    updatedFilters.source_IPCC_version = `${dataSourceFilter} - ${versionFilter}`;
+    updatedFilters.source = `${dataSourceFilter} - ${versionFilter}`;
     delete updatedFilters['data-sources'];
     delete updatedFilters.gwps;
   }
@@ -179,8 +179,8 @@ export const getMethodology = createSelector(
     if (!meta || isEmpty(meta) || !section || !selectedfilters) return null;
     const methodology = meta.methodology;
     let metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section];
-    if (selectedfilters.source_IPCC_version) {
-      const source = selectedfilters.source_IPCC_version.source_slug;
+    if (selectedfilters.source) {
+      const source = selectedfilters.source.source_slug;
       metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section][source];
     }
     if (selectedfilters.data_sources) {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -176,18 +176,20 @@ const getSelectedFilters = createSelector(
 export const getMethodology = createSelector(
   [state => state.meta, getSection, getSelectedFilters],
   (meta, section, selectedfilters) => {
-    if (!meta || isEmpty(meta) || !section || !selectedfilters) return null;
+    const sectionHasSources = section === 'historical-emissions';
+    if (
+      !meta ||
+      isEmpty(meta) ||
+      !section ||
+      (sectionHasSources && isEmpty(selectedfilters))
+    ) { return null; }
     const methodology = meta.methodology;
     let metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section];
-    if (selectedfilters.source) {
+    if (sectionHasSources) {
       const source = selectedfilters.source.source_slug;
       metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section][source];
     }
-    if (selectedfilters.data_sources) {
-      const source = selectedfilters.data_sources.value;
-      metaSource = DATA_EXPLORER_METHODOLOGY_SOURCE[section][source];
-    }
-    return methodology.find(s => s.source === metaSource);
+    return methodology.filter(s => metaSource.includes(s.source));
   }
 );
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -49,4 +49,8 @@
 
 .metadataText {
   @include xy-gutters($gutter-position: ('top', 'bottom'));
+
+  &.topPadded {
+    @include xy-gutters($gutter-position: 'top', $gutters: $gutter-padding * 3);
+  }
 }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -66,7 +66,7 @@ const mapStateToProps = (state, { section, location }) => {
 class DataExplorerContentContainer extends PureComponent {
   handleFilterChange = (filterName, value) => {
     const { section } = this.props;
-    const SOURCE_AND_VERSION_KEY = 'source_IPCC_version';
+    const SOURCE_AND_VERSION_KEY = 'source';
     if (filterName === SOURCE_AND_VERSION_KEY) {
       const values = value && value.split(' - ');
       this.updateUrlParam([

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -296,26 +296,20 @@ export const DATA_EXPLORER_SECTION_NAMES = {
 
 export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
   'historical-emissions': {
-    PIK: 'historical_emissions_pik',
-    CAIT: 'historical_emissions_cait',
-    UNFCCC: 'historical_emissions_unfccc'
+    PIK: ['historical_emissions_pik'],
+    CAIT: ['historical_emissions_cait'],
+    UNFCCC: ['historical_emissions_unfccc']
   },
-  'ndc-sdg-linkages': 'ndc_sdc_all indicators',
-  'ndc-content': { CAIT: 'ndc_cait', WB: 'ndc_wb' },
-  'emission-pathways': null // model, scenario and indicator related metadata
+  'ndc-sdg-linkages': ['ndc_sdc_all indicators'],
+  'ndc-content': ['ndc_cait', 'ndc_wb'],
+  'emission-pathways': [null] // model, scenario and indicator related metadata
 };
 
 export const DATA_EXPLORER_FILTERS = {
   'historical-emissions': ['source', 'gases', 'regions', 'sectors'],
   'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
   'emission-pathways': [],
-  'ndc-content': [
-    'data_sources',
-    'categories',
-    'indicators',
-    'sectors',
-    'countries'
-  ]
+  'ndc-content': ['categories', 'indicators', 'sectors', 'countries']
 };
 
 export const SOURCE_IPCC_VERSIONS = [

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -306,12 +306,7 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
 };
 
 export const DATA_EXPLORER_FILTERS = {
-  'historical-emissions': [
-    'source_IPCC_version',
-    'gases',
-    'regions',
-    'sectors'
-  ],
+  'historical-emissions': ['source', 'gases', 'regions', 'sectors'],
   'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
   'emission-pathways': [],
   'ndc-content': [


### PR DESCRIPTION
Some changes according to new info about the data-explorer: https://basecamp.com/1756858/projects/13795275/messages/75502613#comment_631627605

- Remove NDC Content source section and show both methodology sources in that section
- Change the 'Source + IPCCC version' filter of the Historical emissions to 'Source'

![image](https://user-images.githubusercontent.com/9701591/42229824-ad1cd6fa-7ee7-11e8-84df-a972c1901472.png)
 
![image](https://user-images.githubusercontent.com/9701591/42229783-929f8818-7ee7-11e8-8c49-0ed9db3f60d5.png)


