### PR TITLE
Fix/changes to filtering by 2 level filters in data explorer

### DIFF
--- a/app/services/api/v1/data/historical_emissions_filter.rb
+++ b/app/services/api/v1/data/historical_emissions_filter.rb
@@ -103,8 +103,21 @@ module Api
           @query = @query.where(data_source_id: @source_ids) if @source_ids
           @query = @query.where(gwp_id: @gwp_ids) if @gwp_ids
           @query = @query.where(gas_id: @gas_ids) if @gas_ids
-          @query = @query.where(sector_id: @sector_ids) if @sector_ids
           @query = @query.where(location_id: @location_ids) if @location_ids
+          apply_sector_filter
+        end
+
+        def apply_sector_filter
+          return unless @sector_ids
+          top_level_sector_ids = ::HistoricalEmissions::Sector.
+            where(parent_id: nil, id: @sector_ids).
+            pluck(:id)
+          subsector_ids = @sector_ids +
+            ::HistoricalEmissions::Sector.where(
+              parent_id: top_level_sector_ids
+            ).pluck(:id)
+
+          @query = @query.where(sector_id: subsector_ids)
         end
       end
     end

--- a/app/services/api/v1/data/ndc_content_filter.rb
+++ b/app/services/api/v1/data/ndc_content_filter.rb
@@ -96,7 +96,7 @@ module Api
             )
           end
           @query = @query.where(label_id: @label_ids) if @label_ids
-          @query = @query.where(sector_id: @sector_ids) if @sector_ids
+          apply_sector_filter
         end
 
         def apply_location_filter
@@ -104,6 +104,19 @@ module Api
           @query = @query.where(
             'locations.iso_code3' => @countries
           )
+        end
+
+        def apply_sector_filter
+          return unless @sector_ids
+          top_level_sector_ids = ::Indc::Sector.
+            where(parent_id: nil, id: @sector_ids).
+            pluck(:id)
+          subsector_ids = @sector_ids +
+            ::Indc::Sector.where(
+              parent_id: top_level_sector_ids
+            ).pluck(:id)
+
+          @query = @query.where(sector_id: subsector_ids)
         end
       end
     end

--- a/spec/services/api/v1/data/historical_emissions_filter_spec.rb
+++ b/spec/services/api/v1/data/historical_emissions_filter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::HistoricalEmissionsFilter do
+  include_context 'historical emissions records'
+
+  describe :call do
+    it 'filters by subsector' do
+      filter = Api::V1::Data::HistoricalEmissionsFilter.new(
+        sector_ids: [sector_energy.id]
+      )
+      expect(filter.call.length).to eq(1)
+    end
+
+    it 'filters by top level sector' do
+      filter = Api::V1::Data::HistoricalEmissionsFilter.new(
+        sector_ids: [sector_total.id]
+      )
+      expect(filter.call.length).to eq(2)
+    end
+  end
+end

--- a/spec/services/api/v1/data/ndc_content_filter_spec.rb
+++ b/spec/services/api/v1/data/ndc_content_filter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::NdcContentFilter do
+  include_context 'NDC values'
+
+  describe :call do
+    it 'filters by subsector' do
+      filter = Api::V1::Data::NdcContentFilter.new(
+        sector_ids: [vehicle_fleet.id]
+      )
+      expect(filter.call.length).to eq(1)
+    end
+
+    it 'filters by top level sector' do
+      filter = Api::V1::Data::NdcContentFilter.new(
+        sector_ids: [transport.id]
+      )
+      expect(filter.call.length).to eq(2)
+    end
+  end
+end

--- a/spec/services/api/v1/data/ndc_content_filter_spec.rb
+++ b/spec/services/api/v1/data/ndc_content_filter_spec.rb
@@ -8,12 +8,26 @@ RSpec.describe Api::V1::Data::NdcContentFilter do
       filter = Api::V1::Data::NdcContentFilter.new(
         sector_ids: [vehicle_fleet.id]
       )
-      expect(filter.call.length).to eq(1)
+      expect(filter.call.length).to eq(2)
     end
 
     it 'filters by top level sector' do
       filter = Api::V1::Data::NdcContentFilter.new(
         sector_ids: [transport.id]
+      )
+      expect(filter.call.length).to eq(3)
+    end
+
+    it 'filters by subcategory' do
+      filter = Api::V1::Data::NdcContentFilter.new(
+        category_ids: [sectoral_plans.id]
+      )
+      expect(filter.call.length).to eq(1)
+    end
+
+    it 'filters by top level category' do
+      filter = Api::V1::Data::NdcContentFilter.new(
+        category_ids: [sectoral_information.id]
       )
       expect(filter.call.length).to eq(2)
     end

--- a/spec/support/schemas/api/v1/data/historical_emissions_sectors.json
+++ b/spec/support/schemas/api/v1/data/historical_emissions_sectors.json
@@ -31,7 +31,7 @@
           },
           "parent_id": {
             "$id": "/properties/data/items/properties/parent_id",
-            "type": "null",
+            "type": ["null", "integer"],
             "title": "The Parent_id Schema ",
             "default": null,
             "examples": [

--- a/spec/support/shared_contexts/historical_emissions/sectors.rb
+++ b/spec/support/shared_contexts/historical_emissions/sectors.rb
@@ -1,8 +1,17 @@
 RSpec.shared_context 'historical emissions sectors' do
+  let(:sector_total) {
+    FactoryBot.create(
+      :historical_emissions_sector, name: 'Total including LUCF'
+    )
+  }
   let(:sector_energy) {
-    FactoryBot.create(:historical_emissions_sector, name: 'Energy')
+    FactoryBot.create(
+      :historical_emissions_sector, name: 'Energy', parent: sector_total
+    )
   }
   let(:sector_agriculture) {
-    FactoryBot.create(:historical_emissions_sector, name: 'Agriculture')
+    FactoryBot.create(
+      :historical_emissions_sector, name: 'Agriculture', parent: sector_total
+    )
   }
 end

--- a/spec/support/shared_contexts/ndc_content/categories.rb
+++ b/spec/support/shared_contexts/ndc_content/categories.rb
@@ -31,7 +31,16 @@ RSpec.shared_context 'NDC categories' do
       :indc_category,
       parent: sectoral_information,
       slug: 'sectoral_plans',
-      name: 'Sectoral Plans'
+      name: 'Sectoral Mitigation Plans'
+    )
+  }
+
+  let!(:sectoral_targets) {
+    FactoryBot.create(
+      :indc_category,
+      parent: sectoral_information,
+      slug: 'sectoral_targets',
+      name: 'Sectoral Mitigation Targets'
     )
   }
 end

--- a/spec/support/shared_contexts/ndc_content/indicators.rb
+++ b/spec/support/shared_contexts/ndc_content/indicators.rb
@@ -13,7 +13,7 @@ RSpec.shared_context 'NDC indicators' do
     i
   }
 
-  let!(:sectoral_plan_on) {
+  let!(:sectoral_plans_on) {
     i = FactoryBot.create(
       :indc_indicator,
       source: wb,
@@ -21,6 +21,17 @@ RSpec.shared_context 'NDC indicators' do
       name: 'Sectoral plans on'
     )
     i.categories = [sectoral_information, sectoral_plans]
+    i
+  }
+
+  let!(:sectoral_targets_on) {
+    i = FactoryBot.create(
+      :indc_indicator,
+      source: wb,
+      slug: 'M_SecTar1',
+      name: 'Sectoral targets on'
+    )
+    i.categories = [sectoral_information, sectoral_targets]
     i
   }
 end

--- a/spec/support/shared_contexts/ndc_content/sectors.rb
+++ b/spec/support/shared_contexts/ndc_content/sectors.rb
@@ -14,4 +14,12 @@ RSpec.shared_context 'NDC sectors' do
       name: 'Vehicle Fleet'
     )
   }
+
+  let!(:aviation) {
+    FactoryBot.create(
+      :indc_sector,
+      parent: transport,
+      name: 'Aviation'
+    )
+  }
 end

--- a/spec/support/shared_contexts/ndc_content/values.rb
+++ b/spec/support/shared_contexts/ndc_content/values.rb
@@ -18,10 +18,20 @@ RSpec.shared_context 'NDC values' do
   let!(:value_2) {
     FactoryBot.create(
       :indc_value,
-      indicator: sectoral_plan_on,
+      indicator: sectoral_plans_on,
       sector: vehicle_fleet,
       location: spain,
       value: 'Increase share of electric vehicles'
+    )
+  }
+
+  let!(:value_3) {
+    FactoryBot.create(
+      :indc_value,
+      indicator: sectoral_targets_on,
+      sector: vehicle_fleet,
+      location: spain,
+      value: '-30% in fuel consumption in 2025'
     )
   }
 end

--- a/spec/support/shared_contexts/ndc_content/values.rb
+++ b/spec/support/shared_contexts/ndc_content/values.rb
@@ -8,6 +8,7 @@ RSpec.shared_context 'NDC values' do
     FactoryBot.create(
       :indc_value,
       indicator: ghg_target_type,
+      sector: aviation,
       label: baseline_scenario_target,
       location: spain,
       value: 'Baseline scenario target'


### PR DESCRIPTION
For the following 2-level filters:

Historical emissions:
  - sector / subsector

NDC Content:
  - sector / subsector
  - category / subcategory

It is now enough to send "top level" sector / category id, and the backend will search by child subsectors / subcategories (as well as the parent)

Note: the same already applied to ESP category filter