### PR TITLE
Fix dropdown scrollbar inside modal

### DIFF
--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -5,6 +5,7 @@ import { themr } from 'react-css-themr';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import closeIcon from 'assets/icons/sidebar-close.svg';
+import cx from 'classnames';
 import styles from './modal-styles.scss';
 
 class CustomModal extends PureComponent {
@@ -35,7 +36,7 @@ class CustomModal extends PureComponent {
 
     return (
       <Modal
-        className={theme.modal}
+        className={cx(theme.modal, 'modal')}
         style={modalStyles}
         isOpen={isOpen}
         onRequestClose={onRequestClose}

--- a/app/javascript/app/components/modal/modal.js
+++ b/app/javascript/app/components/modal/modal.js
@@ -1,6 +1,20 @@
+import { createElement, PureComponent } from 'react';
 import ModalHeader from './modal-header-component';
 import ModalComponent from './modal-component';
 
 export { ModalHeader, ModalComponent };
 
-export default ModalComponent;
+class ModalContainer extends PureComponent {
+  componentDidUpdate() {
+    const modal = document.getElementsByClassName('modal')[0];
+    if (modal && modal.hasAttribute('tabindex')) { modal.removeAttribute('tabindex'); }
+  }
+
+  render() {
+    return createElement(ModalComponent, {
+      ...this.props
+    });
+  }
+}
+
+export default ModalContainer;

--- a/app/javascript/app/components/modal/modal.js
+++ b/app/javascript/app/components/modal/modal.js
@@ -5,9 +5,12 @@ import ModalComponent from './modal-component';
 export { ModalHeader, ModalComponent };
 
 class ModalContainer extends PureComponent {
+  // TODO: This is obviously not the best solution. We have to remove the tabindex from the modal as its preventing the scrollbar from the dropdowns inside it to work
   componentDidUpdate() {
     const modal = document.getElementsByClassName('modal')[0];
-    if (modal && modal.hasAttribute('tabindex')) { modal.removeAttribute('tabindex'); }
+    if (modal && modal.hasAttribute('tabindex')) {
+      modal.removeAttribute('tabindex');
+    }
   }
 
   render() {


### PR DESCRIPTION
Remove tabindex from all the modals to be able to scroll with the scrollbars inside dropdowns.
Please check if you can find something better than this more than hacky solution

![image](https://user-images.githubusercontent.com/9701591/42501204-7fa565b0-8433-11e8-8ea0-9081364780ee.png)
