### PR TITLE
Feature/mycw stacked barcharts alphabetical sort

### DIFF
--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -9,6 +9,9 @@ import cx from 'classnames';
 import styles from './modal-styles.scss';
 
 class CustomModal extends PureComponent {
+  componentWillMount() {
+    Modal.setAppElement('body');
+  }
   // eslint-disable-line react/prefer-stateless-function
   render() {
     const {

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -97,10 +97,8 @@ export const stackBarChart2Data = (
   yAxisLabel,
   small
 ) => {
-  const data = groupBy(
-    timeseries,
-    ['location', 'indicator'],
-    [locations, indicators]
+  const data = orderAlphabetically(
+    groupBy(timeseries, ['location', 'indicator'], [locations, indicators])
   );
   const keys = Object.keys(data[0]).filter(k => k !== 'location');
   const baseConfig = makeConfig(data, keys, indicators, yAxisLabel, small);

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -53,16 +53,19 @@ const makeConfig = (data, keys, indicators, yAxisLabel, small) => {
       : {
         vertical: false
       },
-    theme: keys.reduce(
-      (th, k, i) =>
-        assign(th, {
-          [k]: {
-            fill: chartColors[i],
-            stroke: ''
-          }
-        }),
-      {}
-    ),
+    theme: keys
+      .slice()
+      .sort()
+      .reduce(
+        (th, k, i) =>
+          assign(th, {
+            [k]: {
+              fill: chartColors[i],
+              stroke: ''
+            }
+          }),
+        {}
+      ),
     tooltip: small ? null : { unit, names },
     legend: keys
       .slice()

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -64,10 +64,13 @@ const makeConfig = (data, keys, indicators, yAxisLabel, small) => {
       {}
     ),
     tooltip: small ? null : { unit, names },
-    legend: keys.map((k, i) => ({
-      color: chartColors[i],
-      label: names[0][k]
-    }))
+    legend: keys
+      .slice()
+      .sort()
+      .map((k, i) => ({
+        color: chartColors[i],
+        label: names[0][k]
+      }))
   };
 };
 

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { CHART_COLORS, CHART_COLORS_EXTENDED } from 'data/constants';
 import { assign } from 'app/utils';
 import { setChartColors } from 'app/utils/graphs';
-import { groupByYear, groupBy, pick } from '../utils';
+import { groupByYear, groupBy, pick, orderAlphabetically } from '../utils';
 
 import Tick from '../tick';
 
@@ -14,6 +14,7 @@ const makeConfig = (data, keys, indicators, yAxisLabel, small) => {
     CHART_COLORS,
     CHART_COLORS_EXTENDED
   );
+
   return {
     chart: {
       data: pick('value', data), // only data value key
@@ -76,7 +77,9 @@ export const stackBarChart1Data = (
   yAxisLabel,
   small
 ) => {
-  const data = groupByYear(timeSeries, 'indicator', indicators);
+  const data = orderAlphabetically(
+    groupByYear(timeSeries, 'indicator', indicators)
+  );
   const keys = Object.keys(data[0]).filter(k => k !== 'year');
   return makeConfig(data, keys, indicators, yAxisLabel, small);
 };

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
@@ -84,6 +84,7 @@ export const orderAlphabetically = unorderedObjectsArray => {
   unorderedObjectsArray.forEach(obj => {
     const orderedObject = {};
     Object.keys(obj)
+      .slice()
       .sort(sortStringsReverse)
       .forEach(function (key) {
         orderedObject[key] = obj[key];

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
@@ -68,3 +68,27 @@ export const pick = (key, list) =>
       {}
     )
   );
+
+const sortStringsReverse = (a, b) => {
+  if (a > b) {
+    return -1;
+  }
+  if (a < b) {
+    return 1;
+  }
+  return 0;
+};
+
+export const orderAlphabetically = unorderedObjectsArray => {
+  const orderedObjectsArray = [];
+  unorderedObjectsArray.forEach(obj => {
+    const orderedObject = {};
+    Object.keys(obj)
+      .sort(sortStringsReverse)
+      .forEach(function (key) {
+        orderedObject[key] = obj[key];
+      });
+    orderedObjectsArray.push(orderedObject);
+  });
+  return orderedObjectsArray;
+};


### PR DESCRIPTION
This Pr sorts myCW vertical stacked bar charts alphabetically (now the legendes, the tooltip and the data displayed on the chart are sorted alphabetically)
[Pivotal](https://www.pivotaltracker.com/story/show/158939263)
[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/357603339)   

![kapture 2018-07-11 at 12 23 21](https://user-images.githubusercontent.com/6906348/42565946-3e9d7d8c-8505-11e8-8f8d-143a1cab41c7.gif)
