### PR TITLE
Feature/mycw add model logos

### DIFF
--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-component.jsx
@@ -9,21 +9,31 @@ import styles from './legend-styles';
 const LegendComponent = ({ className, data = [], theme }) => (
   <div className={cx(className, theme.legend)}>
     <ul className={theme.tags}>
-      {data.map(l => (
-        <Tag
-          key={l.label}
-          className={theme.tagItem}
-          label={l.label}
-          color={l.color}
-        />
-      ))}
+      {data &&
+        data.theme.map(l => (
+          <Tag
+            key={l.label}
+            className={theme.tagItem}
+            label={l.label}
+            color={l.color}
+          />
+        ))}
     </ul>
+    {data &&
+    data.logo && (
+      <div className={theme.legendLogo}>
+        <div className={theme.legendLogoTitle}>Data provided by:</div>
+        <a href={data.modelUrl} target="_blank">
+          <img src={`https:${data.logo}`} />
+        </a>
+      </div>
+    )}
   </div>
 );
 
 LegendComponent.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.array,
+  data: PropTypes.object,
   theme: PropTypes.object
 };
 

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-styles.scss
@@ -1,14 +1,32 @@
-.legend {
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-  }
+@import '~styles/layout.scss';
 
-  .tagItem {
-    margin-right: 10px;
-    margin-bottom: 1rem;
-    padding: 0;
-    border: none;
-    box-shadow: none;
-  }
+.legend {
+  display: flex;
+  justify-content: space-between;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.tagItem {
+  margin-right: 10px;
+  margin-bottom: 1rem;
+  height: fit-content;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+}
+
+.legendLogo {
+  display: flex;
+  flex-direction: column;
+  color: $dark-gray;
+  max-width: 150px;
+  font-size: $font-size-sm;
+}
+
+.legendLogoTitle {
+  padding-bottom: 10px;
 }

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/line/line-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/line/line-config.js
@@ -8,7 +8,7 @@ import {
 } from 'app/utils/graphs';
 import { groupByYear, pick } from '../utils';
 
-const makeConfig = (data, indicators, small) => {
+const makeConfig = (data, indicators, small, models) => {
   const keys = Object.keys(data[0]).filter(k => k !== 'year');
   const chartColors = setChartColors(
     keys.length,
@@ -68,15 +68,42 @@ const makeConfig = (data, indicators, small) => {
       {}
     ),
     tooltip: small ? null : { unit, names },
-    legend: keys.map((k, i) => ({
-      color: chartColors[i],
-      label: names[0][k]
-    }))
+    legend: {
+      theme: keys.map((k, i) => ({
+        color: chartColors[i],
+        label: names[0][k]
+      })),
+      logo: models.data.find(model => model.id === models.selected.value).logo,
+      modelUrl: models.data.find(model => model.id === models.selected.value)
+        .url
+    }
   };
 };
 
-export const lineChart1Data = (timeSeries, scenarios, indicators, small) =>
-  makeConfig(groupByYear(timeSeries, 'scenario', scenarios), indicators, small);
+export const lineChart1Data = (
+  timeSeries,
+  scenarios,
+  indicators,
+  small,
+  models
+) =>
+  makeConfig(
+    groupByYear(timeSeries, 'scenario', scenarios),
+    indicators,
+    small,
+    models
+  );
 
-export const lineChart2Data = (timeSeries, locations, indicators, small) =>
-  makeConfig(groupByYear(timeSeries, 'location', locations), indicators, small);
+export const lineChart2Data = (
+  timeSeries,
+  locations,
+  indicators,
+  small,
+  models
+) =>
+  makeConfig(
+    groupByYear(timeSeries, 'location', locations),
+    indicators,
+    small,
+    models
+  );

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/pie/pie-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/pie/pie-config.js
@@ -5,7 +5,13 @@ import { assign } from 'app/utils';
 import { setChartColors } from 'app/utils/graphs';
 import { pick } from '../utils';
 
-export const pieChart1Data = (timeSeries, indicators, yAxisLabel, small) => {
+export const pieChart1Data = (
+  timeSeries,
+  indicators,
+  yAxisLabel,
+  small,
+  models
+) => {
   const data = timeSeries.map(ts => {
     const found = find(indicators, { id: ts.indicator_id });
     return found
@@ -46,10 +52,15 @@ export const pieChart1Data = (timeSeries, indicators, yAxisLabel, small) => {
       {}
     ),
     tooltip: small ? null : { unit, names, pie: true },
-    legend: data.map((k, i) => ({
-      color: chartColors[i],
-      label: k.name
-    }))
+    legend: {
+      theme: data.map((k, i) => ({
+        color: chartColors[i],
+        label: k.name
+      })),
+      logo: models.data.find(model => model.id === models.selected.value).logo,
+      modelUrl: models.data.find(model => model.id === models.selected.value)
+        .url
+    }
   };
 };
 
@@ -58,7 +69,8 @@ export const pieChart2Data = (
   indicators,
   locations,
   yAxisLabel,
-  small
+  small,
+  models
 ) => {
   const data = timeSeries.map(ts => {
     const indicator = find(indicators, { id: ts.indicator_id });
@@ -104,10 +116,15 @@ export const pieChart2Data = (
       {}
     ),
     tooltip: small ? null : { unit, names, pie: true },
-    legend: data.map((k, i) => ({
-      color: chartColors[i],
-      label: k.name
-    }))
+    legend: {
+      theme: data.map((k, i) => ({
+        color: chartColors[i],
+        label: k.name
+      })),
+      logo: models.data.find(model => model.id === models.selected.value).logo,
+      modelUrl: models.data.find(model => model.id === models.selected.value)
+        .url
+    }
   };
 };
 

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -6,7 +6,7 @@ import { groupByYear, groupBy, pick } from '../utils';
 
 import Tick from '../tick';
 
-const makeConfig = (data, keys, indicators, yAxisLabel, small) => {
+const makeConfig = (data, keys, indicators, yAxisLabel, small, models) => {
   const names = pick('name', data); // only data name key
   const unit = indicators[0] && indicators[0].unit;
   const chartColors = setChartColors(
@@ -63,10 +63,15 @@ const makeConfig = (data, keys, indicators, yAxisLabel, small) => {
       {}
     ),
     tooltip: small ? null : { unit, names },
-    legend: keys.map((k, i) => ({
-      color: chartColors[i],
-      label: names[0][k]
-    }))
+    legend: {
+      theme: keys.map((k, i) => ({
+        color: chartColors[i],
+        label: names[0][k]
+      })),
+      logo: models.data.find(model => model.id === models.selected.value).logo,
+      modelUrl: models.data.find(model => model.id === models.selected.value)
+        .url
+    }
   };
 };
 
@@ -74,11 +79,12 @@ export const stackBarChart1Data = (
   timeSeries,
   indicators,
   yAxisLabel,
-  small
+  small,
+  models
 ) => {
   const data = groupByYear(timeSeries, 'indicator', indicators);
   const keys = Object.keys(data[0]).filter(k => k !== 'year');
-  return makeConfig(data, keys, indicators, yAxisLabel, small);
+  return makeConfig(data, keys, indicators, yAxisLabel, small, models);
 };
 
 export const stackBarChart2Data = (
@@ -86,7 +92,8 @@ export const stackBarChart2Data = (
   locations,
   indicators,
   yAxisLabel,
-  small
+  small,
+  models
 ) => {
   const data = groupBy(
     timeseries,
@@ -94,7 +101,14 @@ export const stackBarChart2Data = (
     [locations, indicators]
   );
   const keys = Object.keys(data[0]).filter(k => k !== 'location');
-  const baseConfig = makeConfig(data, keys, indicators, yAxisLabel, small);
+  const baseConfig = makeConfig(
+    data,
+    keys,
+    indicators,
+    yAxisLabel,
+    small,
+    models
+  );
   return assign(baseConfig, {
     chart: {
       ...baseConfig.chart,

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-selectors.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-selectors.js
@@ -108,7 +108,8 @@ export const chartDataSelector = createSelector(
     indicatorsSelector,
     locationsSelector,
     subcategoriesSelector,
-    smallSelector
+    smallSelector,
+    modelsSelector
   ],
   (
     hasData,
@@ -118,7 +119,8 @@ export const chartDataSelector = createSelector(
     indicators,
     locations,
     subcategories,
-    small
+    small,
+    models
   ) => {
     if (!hasData) return {};
     const indicatorLabel =
@@ -136,7 +138,8 @@ export const chartDataSelector = createSelector(
           timeseries.data,
           scenarios.data,
           indicators.data,
-          small
+          small,
+          models
         );
 
       case 'StackBarChart-1':
@@ -144,7 +147,8 @@ export const chartDataSelector = createSelector(
           timeseries.data,
           indicators.data,
           yAxisLabel,
-          small
+          small,
+          models
         );
 
       case 'PieChart-1':
@@ -152,7 +156,8 @@ export const chartDataSelector = createSelector(
           timeseries.data,
           indicators.data,
           yAxisLabel,
-          small
+          small,
+          models
         );
 
       case 'LineChart-2':
@@ -160,7 +165,8 @@ export const chartDataSelector = createSelector(
           timeseries.data,
           locations.data,
           indicators.data,
-          small
+          small,
+          models
         );
 
       case 'PieChart-2':
@@ -169,7 +175,8 @@ export const chartDataSelector = createSelector(
           indicators.data,
           locations.data,
           yAxisLabel,
-          small
+          small,
+          models
         );
 
       case 'StackBarChart-2':
@@ -178,7 +185,8 @@ export const chartDataSelector = createSelector(
           locations.data,
           indicators.data,
           yAxisLabel,
-          small
+          small,
+          models
         );
 
       default:


### PR DESCRIPTION
This PR adds model logo to MyCW visualizations (both on the visCreator and on the embedded modules). 
To see it in action it is mandatory to create a new visualization, because old ones have been already stored in the data base without the logo data.  
[Pivotal](https://www.pivotaltracker.com/story/show/158939295)
[Basecap](https://basecamp.com/1756858/projects/13795275/todos/357603432)  

![kapture 2018-07-11 at 17 23 44](https://user-images.githubusercontent.com/6906348/42582374-372e7c0c-852f-11e8-83fa-da489b4884ad.gif)
