### PR TITLE
Add subtitle to climate risk card

### DIFF
--- a/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability-selectors.js
+++ b/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability-selectors.js
@@ -156,6 +156,7 @@ export const getSectionData = createSelector(
       {
         sectionType: 'LINE',
         title: lowerUpperFirst(getSection(sections, 'climate_risks').name),
+        subtitle: 'Lower score indicates high levels of climate risk',
         slug: 'climate_risks',
         data: getData(sections, iso, queryIsos, countries, 'climate_risks'),
         maximum: getSection(sections, 'climate_risks').maximum


### PR DESCRIPTION
Add a subtitle on `climate-risk` vulnerability card.  
`"Lower score indicates high levels of climate risk"`
[Pivotal](https://www.pivotaltracker.com/story/show/158939757)

![image](https://user-images.githubusercontent.com/6906348/42585813-e68bb76c-8536-11e8-82f3-7d76c5eae731.png)
