### PR TITLE
Fix/mycw viscreator title update

### DIFF
--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
@@ -24,7 +24,6 @@ class MyVisCard extends PureComponent {
       ? chartDataSelector({ datasets, small: false })
       : null;
     const id = data.id;
-
     return (
       <div className={styles.cardContainer}>
         <div className={cx(styles.card, className)}>
@@ -38,6 +37,17 @@ class MyVisCard extends PureComponent {
             <Dotdotdot className={styles.cardDescription} clamp={2}>
               {data.description}
             </Dotdotdot>
+          </div>
+          <div className={styles.providerNote}>
+            {chartData.legend.dataProvider && (
+              <a
+                href={chartData.legend.modelUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Data provided by: {chartData.legend.dataProvider}
+              </a>
+            )}
           </div>
         </div>
         <ButtonGroup

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
@@ -27,7 +27,11 @@ class MyVisCard extends PureComponent {
     return (
       <div className={styles.cardContainer}>
         <div className={cx(styles.card, className)}>
-          <div className={styles.chart}>
+          <div
+            className={cx(styles.chart, {
+              [styles.pieChart]: chart === 'PieChart'
+            })}
+          >
             {datasets && (
               <RenderChart chart={chart} config={chartData} height={200} />
             )}

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-// import Dotdotdot from 'react-dotdotdot';
+import Dotdotdot from 'react-dotdotdot';
 import ButtonGroup from 'components/button-group';
 import RenderChart from 'components/my-climate-watch/viz-creator/components/render-chart';
 import {
@@ -35,9 +35,9 @@ class MyVisCard extends PureComponent {
           </div>
           <div className={styles.cardTexts}>
             <h2 className={styles.cardTitle}>{data.title}</h2>
-            {/* <Dotdotdot className={styles.cardDescription} clamp={3}>
+            <Dotdotdot className={styles.cardDescription} clamp={2}>
               {data.description}
-            </Dotdotdot> */}
+            </Dotdotdot>
           </div>
         </div>
         <ButtonGroup

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
@@ -39,10 +39,11 @@
 
 .cardActions {
   position: absolute;
-  right: 0;
+  right: 8px;
   top: 0;
   width: 120px;
   box-shadow: none;
+  border: none;
 
   &:hover {
     box-shadow: none;
@@ -58,7 +59,7 @@
   font-size: $font-size-xs;
   position: absolute;
   bottom: 10px;
-  right: 10px;
+  right: 20px;
 
   a {
     color: $gray;

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
@@ -4,8 +4,8 @@
   position: relative;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
   border: solid 1px rgba(26, 28, 34, 0.1);
-  min-height: 270px;
-  background-color: $light-gray;
+  height: 390px;
+  background-color: $white;
 }
 
 .card {
@@ -17,8 +17,6 @@
 
 .cardTexts {
   padding: 20px;
-  padding-bottom: 40px;
-  min-height: 126px;
   color: $theme-color;
   background-color: $white;
 
@@ -35,6 +33,11 @@
 
 .chart {
   padding: 20px 50px 20px 10px;
+  background-color: $light-gray;
+}
+
+.pieChart {
+  padding: 20px 10px;
 }
 
 .cardActions {
@@ -63,5 +66,9 @@
 
   a {
     color: $gray;
+  }
+
+  a:hover {
+    color: $dark-gray;
   }
 }

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
@@ -16,7 +16,7 @@
 }
 
 .cardTexts {
-  padding: 20px 20px 69px 20px;
+  padding: 20px;
   min-height: 126px;
   color: $theme-color;
   background-color: $white;
@@ -38,7 +38,16 @@
 
 .cardActions {
   position: absolute;
-  right: 10px;
-  bottom: 10px;
+  right: 0;
+  top: 0;
   width: 120px;
+  box-shadow: none;
+
+  &:hover {
+    box-shadow: none;
+  }
+
+  button {
+    border: none;
+  }
 }

--- a/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/my-visualisations/my-cw-vis-card/my-cw-vis-card-styles.scss
@@ -17,6 +17,7 @@
 
 .cardTexts {
   padding: 20px;
+  padding-bottom: 40px;
   min-height: 126px;
   color: $theme-color;
   background-color: $white;
@@ -49,5 +50,17 @@
 
   button {
     border: none;
+  }
+}
+
+.providerNote {
+  text-decoration: none;
+  font-size: $font-size-xs;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+
+  a {
+    color: $gray;
   }
 }

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/line/line-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/line/line-config.js
@@ -6,7 +6,7 @@ import {
   setXAxisDomain,
   setYAxisDomain
 } from 'app/utils/graphs';
-import { groupByYear, pick } from '../utils';
+import { groupByYear, pick, getSelectedModel } from '../utils';
 
 const makeConfig = (data, indicators, small, models) => {
   const keys = Object.keys(data[0]).filter(k => k !== 'year');
@@ -73,9 +73,9 @@ const makeConfig = (data, indicators, small, models) => {
         color: chartColors[i],
         label: names[0][k]
       })),
-      logo: models.data.find(model => model.id === models.selected.value).logo,
-      modelUrl: models.data.find(model => model.id === models.selected.value)
-        .url
+      dataProvider: getSelectedModel(models).maintainer_institute,
+      logo: getSelectedModel(models).logo,
+      modelUrl: getSelectedModel(models).url
     }
   };
 };

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/pie/pie-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/pie/pie-config.js
@@ -3,7 +3,7 @@ import camelCase from 'lodash/camelCase';
 import { CHART_COLORS, CHART_COLORS_EXTENDED } from 'data/constants';
 import { assign } from 'app/utils';
 import { setChartColors } from 'app/utils/graphs';
-import { pick } from '../utils';
+import { pick, getSelectedModel } from '../utils';
 
 export const pieChart1Data = (
   timeSeries,
@@ -121,9 +121,9 @@ export const pieChart2Data = (
         color: chartColors[i],
         label: k.name
       })),
-      logo: models.data.find(model => model.id === models.selected.value).logo,
-      modelUrl: models.data.find(model => model.id === models.selected.value)
-        .url
+      dataProvider: getSelectedModel(models).maintainer_institute,
+      logo: getSelectedModel(models).logo,
+      modelUrl: getSelectedModel(models).url
     }
   };
 };

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/stack-bar/stack-bar-config.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { CHART_COLORS, CHART_COLORS_EXTENDED } from 'data/constants';
 import { assign } from 'app/utils';
 import { setChartColors } from 'app/utils/graphs';
-import { groupByYear, groupBy, pick, orderAlphabetically } from '../utils';
+import {
+  groupByYear,
+  groupBy,
+  pick,
+  orderAlphabetically,
+  getSelectedModel
+} from '../utils';
 
 import Tick from '../tick';
 
@@ -75,9 +81,9 @@ const makeConfig = (data, keys, indicators, yAxisLabel, small, models) => {
           color: chartColors[i],
           label: names[0][k]
         })),
-      logo: models.data.find(model => model.id === models.selected.value).logo,
-      modelUrl: models.data.find(model => model.id === models.selected.value)
-        .url
+      dataProvider: getSelectedModel(models).maintainer_institute,
+      logo: getSelectedModel(models).logo,
+      modelUrl: getSelectedModel(models).url
     }
   };
 };

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/utils.js
@@ -93,3 +93,6 @@ export const orderAlphabetically = unorderedObjectsArray => {
   });
   return orderedObjectsArray;
 };
+
+export const getSelectedModel = models =>
+  models.data.find(model => model.id === models.selected.value);

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-four.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-four.jsx
@@ -5,7 +5,6 @@ import cx from 'classnames';
 
 import Fieldset from 'components/fieldset';
 import TextInput from 'components/text-input';
-import TextArea from 'components/text-area';
 import Loading from 'components/loading';
 import Button from 'components/button';
 
@@ -21,24 +20,26 @@ const findDescription = (field, coll) =>
   findField(field, coll) && findField(field, coll).message;
 
 class Step4 extends Component {
-  updateTitleValue() {
-    return this.props.title === undefined
-      ? this.props.placeholder
-      : this.props.title;
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: props.title === undefined ? props.placeholder : props.title || '',
+      description: props.description || '',
+      placeholder: props.placeholder || ''
+    };
   }
+
+  onInputChange = (e, input) => this.setState({ [input]: e.target.value });
 
   render() {
     const {
-      title,
-      placeholder,
       chartData,
-      onNameChange,
-      onDescriptionChange,
+      saveTitle,
+      saveDescription,
       timeseries,
       saveVisualisation,
       deleteVisualisation,
       id,
-      description,
       creationStatus,
       visualisationType
     } = this.props;
@@ -58,9 +59,8 @@ class Step4 extends Component {
               }}
             >
               <TextInput
-                value={this.updateTitleValue()}
-                onChange={onNameChange}
-                onFocus={onNameChange}
+                value={this.state.title}
+                onChange={e => this.onInputChange(e, 'title')}
                 className={styles.inputText}
                 theme={styles}
               />
@@ -93,12 +93,12 @@ class Step4 extends Component {
                 )
               }}
             >
-              <TextArea
+              <TextInput
+                inputType="textarea"
+                value={this.state.description}
+                onChange={e => this.onInputChange(e, 'description')}
                 className={styles.textArea}
                 theme={styles}
-                onDescriptionChange={onDescriptionChange}
-                onFocus={onDescriptionChange}
-                value={description}
               />
             </Fieldset>
           </div>
@@ -117,9 +117,8 @@ class Step4 extends Component {
           <Button
             color="yellow"
             onClick={() => {
-              if (title === undefined) {
-                onNameChange(placeholder);
-              }
+              saveTitle(this.state.title);
+              saveDescription(this.state.description);
               saveVisualisation({ id });
             }}
             className={styles.saveBtn}
@@ -139,13 +138,13 @@ Step4.propTypes = {
   timeseries: PropTypes.object,
   chartData: PropTypes.object.isRequired,
   visualisationOptions: PropTypes.object,
-  onNameChange: PropTypes.func.isRequired,
+  saveTitle: PropTypes.func.isRequired,
   saveVisualisation: PropTypes.func.isRequired,
   creationStatus: PropTypes.object,
   visualisationType: PropTypes.string,
   description: PropTypes.string,
   deleteVisualisation: PropTypes.func.isRequired,
-  onDescriptionChange: PropTypes.func.isRequired
+  saveDescription: PropTypes.func.isRequired
 };
 
 export default Step4;

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-four.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/step-four.jsx
@@ -9,15 +9,11 @@ import Loading from 'components/loading';
 import Button from 'components/button';
 
 import btnThemes from 'styles/themes/button/buttons';
+import textInputTheme from 'styles/themes/input/text-input-theme';
 import Legend from '../charts/legend';
 import RenderChart from '../render-chart';
 
 import styles from './steps-styles';
-
-const findField = (field, coll) => _find(coll, { field });
-const includesField = (field, coll) => Boolean(findField(field, coll));
-const findDescription = (field, coll) =>
-  findField(field, coll) && findField(field, coll).message;
 
 class Step4 extends Component {
   constructor(props) {
@@ -48,21 +44,13 @@ class Step4 extends Component {
         <div className={styles.stepContainer}>
           <h2 className={styles.stepTitle}>4/4 - Annotate the visualisation</h2>
           <div className={styles.step4Container}>
-            <Fieldset
-              className={styles.fieldset}
-              theme={styles}
-              {...{
-                failed:
-                  creationStatus.failed &&
-                  includesField('title', creationStatus.fields),
-                failMessage: findDescription('title', creationStatus.fields)
-              }}
-            >
+            <Fieldset className={styles.fieldset} theme={styles}>
               <TextInput
                 value={this.state.title}
                 onChange={e => this.onInputChange(e, 'title')}
-                className={styles.inputText}
-                theme={styles}
+                theme={textInputTheme}
+                required={creationStatus.failed}
+                label="Title"
               />
             </Fieldset>
             {timeseries.loading ? (
@@ -80,25 +68,14 @@ class Step4 extends Component {
                 <Legend key="legend" theme={styles} data={chartData.legend} />
               ]
             )}
-            <Fieldset
-              className={styles.fieldset}
-              theme={styles}
-              {...{
-                failed:
-                  creationStatus.failed &&
-                  includesField('description', creationStatus.fields),
-                failMessage: findDescription(
-                  'description',
-                  creationStatus.fields
-                )
-              }}
-            >
+            <Fieldset className={styles.fieldset} theme={styles}>
               <TextInput
                 inputType="textarea"
                 value={this.state.description}
                 onChange={e => this.onInputChange(e, 'description')}
-                className={styles.textArea}
-                theme={styles}
+                theme={textInputTheme}
+                required={creationStatus.failed}
+                label="Description"
               />
             </Fieldset>
           </div>
@@ -137,7 +114,6 @@ Step4.propTypes = {
   placeholder: PropTypes.string,
   timeseries: PropTypes.object,
   chartData: PropTypes.object.isRequired,
-  visualisationOptions: PropTypes.object,
   saveTitle: PropTypes.func.isRequired,
   saveVisualisation: PropTypes.func.isRequired,
   creationStatus: PropTypes.object,

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
@@ -133,40 +133,7 @@
   &.fieldsetContainer {
     border: 1px solid transparent;
     width: 60%;
-
-    &Failed {
-      border-bottom-color: red;
-    }
   }
-}
-
-.input,
-.textArea {
-  width: 100%;
-  border: solid 1px rgba(0, 0, 0, 0.09);
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.09);
-  color: $theme-color;
-  border-radius: 4px;
-  padding: 1em;
-
-  &Failed {
-    width: 100%;
-    // border-color: red;
-  }
-
-  &::placeholder {
-    color: $theme-color;
-    font-style: initial;
-    opacity: 0.5;
-  }
-
-  &:focus {
-    border: solid 1px $theme-color;
-  }
-}
-
-.textArea {
-  min-height: 120px;
 }
 
 .openDropdownPadding {

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/steps/steps-styles.scss
@@ -165,6 +165,10 @@
   }
 }
 
+.textArea {
+  min-height: 120px;
+}
+
 .openDropdownPadding {
   padding-bottom: 110px;
 }

--- a/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/viz-creator-component.jsx
@@ -59,8 +59,8 @@ const VizCreator = props => {
             description={description}
             timeseries={timeseries}
             chartData={chartData}
-            onNameChange={updateVisualisationName}
-            onDescriptionChange={updateVisualisationDescription}
+            saveTitle={updateVisualisationName}
+            saveDescription={updateVisualisationDescription}
             saveVisualisation={saveVisualisation}
             deleteVisualisation={deleteVisualisation}
             creationStatus={creationStatus}

--- a/app/javascript/app/components/text-input/text-input-component.jsx
+++ b/app/javascript/app/components/text-input/text-input-component.jsx
@@ -26,7 +26,8 @@ class InputComponent extends Component {
       },
       className: cx(styles.input, className, theme.input, {
         [theme.disabled]: disabled,
-        [theme.inputFailed]: required && !value
+        [theme.inputFailed]: required && !value,
+        [theme.textArea]: inputType === 'textarea'
       }),
       onChange,
       disabled,
@@ -52,7 +53,7 @@ class InputComponent extends Component {
         )}
         {!value &&
         required && (
-        <span className={theme.requiredError}>This field is required</span>
+         <span className={theme.requiredError}>This field is required</span>
           )}
         {optional && <span className={theme.optional}>(optional)</span>}
         {input}


### PR DESCRIPTION
This PR fixes: 
Allow user to update visualization name on MyCW viscreator.
[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/358315622) . 

Adds description to visualization cards on MyCW.  
[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/358316096) . 

Due to the addition of the description to the visualization card a small redesign has been made (approved by the design team)

Extra: 
-  Added data provider name and link on the card. It is not exactly the requested solution but is the best approach design wise (in our opinion :-)
[Pivotal](https://www.pivotaltracker.com/story/show/159006547)


![image 1](https://user-images.githubusercontent.com/6906348/42646851-6497753a-8602-11e8-9f37-b0b158d0753c.png)



