### PR TITLE
Fixed logo width

### DIFF
--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-component.jsx
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-component.jsx
@@ -20,14 +20,14 @@ const LegendComponent = ({ className, data = [], theme }) => (
         ))}
     </ul>
     {data &&
-    data.logo && (
-      <div className={theme.legendLogo}>
-        <div className={theme.legendLogoTitle}>Data provided by:</div>
-        <a href={data.modelUrl} target="_blank">
-          <img src={`https:${data.logo}`} />
-        </a>
-      </div>
-    )}
+      data.logo && (
+        <div className={theme.legendLogoContainer}>
+          <div className={theme.legendLogoTitle}>Data provided by:</div>
+          <a href={data.modelUrl} target="_blank" className={theme.legendLogo}>
+            <img id="logoImage" src={`https:${data.logo}`} />
+          </a>
+        </div>
+      )}
   </div>
 );
 

--- a/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-styles.scss
+++ b/app/javascript/app/components/my-climate-watch/viz-creator/components/charts/legend/legend-styles.scss
@@ -19,14 +19,19 @@
   box-shadow: none;
 }
 
-.legendLogo {
+.legendLogoContainer {
   display: flex;
   flex-direction: column;
+  align-items: center;
   color: $dark-gray;
-  max-width: 150px;
+  min-width: 110px;
   font-size: $font-size-sm;
 }
 
 .legendLogoTitle {
   padding-bottom: 10px;
+}
+
+.legendLogo {
+  width: 100px;
 }


### PR DESCRIPTION
This PR fixes logos `width` on MyCW visualisations (it can be tested on the visualisation edit modal or on the embedded page).
[Pivotal](https://www.pivotaltracker.com/story/show/159006498)

Due to the huge differences on logos formats some of them seem bigger than others. Maybe we could suggest some min and max measures?
@faustoperez what do you think?

![image](https://user-images.githubusercontent.com/6906348/42689251-c66f3bce-869f-11e8-9124-6fc550d7aabb.png)
![image](https://user-images.githubusercontent.com/6906348/42689259-cf83f1dc-869f-11e8-8378-46c5cdd260ac.png)
![image](https://user-images.githubusercontent.com/6906348/42689267-d7c037c0-869f-11e8-8218-8e3c57a0702d.png)
