### PR TITLE
Fix home page scrolling

### DIFF
--- a/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-component.jsx
+++ b/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-component.jsx
@@ -40,8 +40,7 @@ class NavNestedMenuComponent extends PureComponent {
         className={cx(
           styles.navNestedMenuContainer,
           { [styles.isHidden]: isHidden },
-          { [styles.reverse]: reverse },
-          { [styles.regular]: !reverse }
+          { [styles.reverse]: reverse }
         )}
       >
         <ClickOutside onClickOutside={this.closeMenu}>

--- a/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-styles.scss
+++ b/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-styles.scss
@@ -46,15 +46,6 @@
     transition: opacity 0.2s ease;
   }
 
-  &.regular {
-    .navNestedMenu {
-      position: absolute;
-      top: 0;
-      left: -25px;
-      right: -25px;
-    }
-  }
-
   &.isHidden {
     .navNestedMenuWrapper {
       opacity: 0;


### PR DESCRIPTION
This PR fixes a problem with the home page having some unwanted horizontal scrolling due to a negative margin. 
The style of the regular navNestedMenuComponent only used in the country menu was removed. I haven't noticed any problems after deleting this style. If you find something please let me know.

Before:
![image](https://user-images.githubusercontent.com/9701591/42993681-437f5100-8c0c-11e8-952d-cfa2a4f166eb.png)
