### PR TITLE
Fix/countries selection clear

### DIFF
--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
@@ -107,6 +107,7 @@ class CompareGhgChart extends PureComponent {
       loading,
       needsWBData
     } = this.props;
+
     const isAbsoluteValue =
       calculationSelected !== CALCULATION_OPTIONS.ABSOLUTE_VALUE;
     return (

--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
@@ -31,7 +31,7 @@ import {
 import { calculatedRatio } from 'utils/ghg-emissions';
 
 // meta data for selectors
-const getSources = state => state.meta.data_source || null;
+const getSources = state => (state.meta && state.meta.data_source) || null;
 
 // values from search
 const getSourceSelection = state => state.search.source || null;

--- a/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
+++ b/app/javascript/app/components/compare/compare-socioeconomics/compare-socioeconomics-component.jsx
@@ -60,6 +60,7 @@ class CompareSocioeconomics extends PureComponent {
       locationNames,
       loading
     } = this.props;
+    const hasLocationNames = locationNames && locationNames.length;
     return (
       <div className={styles.section}>
         <div className={layout.content}>
@@ -73,13 +74,11 @@ class CompareSocioeconomics extends PureComponent {
                     className={styles.compareSocioeconomics}
                   >
                     <TabletPortraitOnly>
-                      {locationNames[i] && (
+                      {hasLocationNames && locationNames[i] && (
                         <div className={cx(styles.countryHeader)}>
                           <div
                             className={styles.dot}
-                            style={{
-                              backgroundColor: CHART_COLORS[i]
-                            }}
+                            style={{ backgroundColor: CHART_COLORS[i] }}
                           />
                           <div className={styles.countryName}>
                             {locationNames[i]}

--- a/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-component.jsx
+++ b/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-component.jsx
@@ -9,6 +9,7 @@ const CountryCompareSelector = ({
   countryOptions,
   handleDropDownChange,
   activeCountryOptions,
+  hideResetButton,
   selectors,
   className
 }) => (
@@ -24,6 +25,7 @@ const CountryCompareSelector = ({
             value={activeCountryOptions[index]}
             transparent
             colorDot={v.country ? v.color : null}
+            hideResetButton={hideResetButton}
           />
         ))}
       </div>
@@ -32,6 +34,7 @@ const CountryCompareSelector = ({
 );
 
 CountryCompareSelector.propTypes = {
+  hideResetButton: PropTypes.bool,
   activeCountryOptions: PropTypes.array,
   selectors: PropTypes.array,
   countryOptions: PropTypes.array,

--- a/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
+++ b/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector-selectors.js
@@ -28,6 +28,11 @@ export const getSelectedCountries = createSelector(
   }
 );
 
+export const getHideResetButton = createSelector(
+  [getSelectedCountries],
+  countries => countries.filter(c => c && !!c.value).length === 1
+);
+
 export const getCountriesOptions = createSelector(
   [getCountries, getSelectedCountries],
   (countries, selectedCountries) => {

--- a/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector.js
+++ b/app/javascript/app/components/country-compare/country-compare-selector/country-compare-selector.js
@@ -9,7 +9,8 @@ import CountryCompareSelectorComponent from './country-compare-selector-componen
 import {
   getCountriesOptions,
   getSelectedCountries,
-  getCountryConfig
+  getCountryConfig,
+  getHideResetButton
 } from './country-compare-selector-selectors';
 
 const mapStateToProps = (state, { location }) => {
@@ -23,6 +24,7 @@ const mapStateToProps = (state, { location }) => {
     locations,
     countryOptions: getCountriesOptions(selectorsState),
     activeCountryOptions: getSelectedCountries(selectorsState),
+    hideResetButton: getHideResetButton(selectorsState),
     selectors: getCountryConfig(selectorsState)
   };
 };

--- a/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider.js
+++ b/app/javascript/app/providers/socioeconomics-provider/socioeconomics-provider.js
@@ -26,9 +26,7 @@ class SocioeconomicsProvider extends PureComponent {
     const nextLocations = nextProps.locations;
     if (
       iso !== nextIso ||
-      (locations &&
-        locations.length &&
-        !isEqual(locations.sort(), nextLocations.sort()))
+      (locations && !isEqual(locations.sort(), nextLocations.sort()))
     ) {
       this.props.fetchSocioeconomics(nextIso ? [nextIso] : nextLocations);
     }

--- a/app/javascript/app/utils/ghg-emissions.js
+++ b/app/javascript/app/utils/ghg-emissions.js
@@ -6,6 +6,8 @@ import {
 
 export const getGhgEmissionDefaults = (source, meta) => {
   const defaults = DEFAULT_EMISSIONS_SELECTIONS[source];
+  if (!defaults) return {};
+
   const sectorDefaults =
     source === 'UNFCCC'
       ? Object.keys(defaults.sector).map(key => defaults.sector[key])


### PR DESCRIPTION
This PR hides the clear selection when only one country is selected to avoid a full empty white page.

![kapture 2018-07-23 at 13 34 01](https://user-images.githubusercontent.com/10500650/43074417-7171064e-8e7d-11e8-9143-000eb1da73ad.gif)

React selectize doesn't have a good documentation so I have to dig into the src to found the [props availables](https://github.com/furqanZafar/react-selectize/blob/master/src/index.d.ts#L20) just in case someone else could need them again.