### PR TITLE
Fix/ndcs categories fetch

### DIFF
--- a/app/javascript/app/components/dropdown/dropdown.js
+++ b/app/javascript/app/components/dropdown/dropdown.js
@@ -2,6 +2,7 @@ import { mapProps } from 'recompose';
 import sortBy from 'lodash/sortBy';
 import Component from './dropdown-component';
 
+const { NODE_ENV } = process.env;
 const optionsSanitizer = mapProps(props => {
   let updatedProps = props;
   if (updatedProps.options && updatedProps.options.length) {
@@ -9,7 +10,9 @@ const optionsSanitizer = mapProps(props => {
       let sanitizedOption = option;
       if (!option.label || !option.value) {
         sanitizedOption = { label: '', value: '' };
-        console.warn(`Option from ${props.label} is empty`);
+        if (NODE_ENV === 'development') {
+          console.warn(`Option from ${props.label} is empty`);
+        }
       }
       return sanitizedOption;
     });

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
@@ -127,9 +127,9 @@ const NDCMap = ({
 
 NDCMap.propTypes = {
   loading: PropTypes.bool,
-  categories: PropTypes.array.isRequired,
+  categories: PropTypes.array,
+  indicators: PropTypes.array,
   selectedCategory: PropTypes.object,
-  indicators: PropTypes.array.isRequired,
   selectedIndicator: PropTypes.object,
   paths: PropTypes.array.isRequired,
   tooltipTxt: PropTypes.string,

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -7,28 +7,30 @@ import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import { PATH_LAYERS } from 'app/data/constants';
 
 const getCountries = state => state.countries || null;
-const getCategoriesData = state => state.mapCategories || {};
-const getIndicatorsData = state => state.mapIndicators || [];
+const getCategoriesData = state => state.categories || null;
+const getIndicatorsData = state => state.indicators || null;
 
 export const getISOCountries = createSelector([getCountries], countries =>
   countries.map(country => country.iso_code3)
 );
 
-export const getCategories = createSelector(getCategoriesData, categories =>
-  sortBy(
+export const getCategories = createSelector(getCategoriesData, categories => {
+  if (!categories) return null;
+  return sortBy(
     Object.keys(categories).map(category => ({
       label: categories[category].name,
       value: categories[category].slug,
       id: category
     })),
     'label'
-  )
-);
+  );
+});
 
 export const getIndicatorsParsed = createSelector(
   [getIndicatorsData, getISOCountries],
-  (indicators, isos) =>
-    sortBy(
+  (indicators, isos) => {
+    if (!indicators || !indicators.length) return null;
+    return sortBy(
       uniqBy(
         indicators.map(i => {
           const legendBuckets = createLegendBuckets(
@@ -47,7 +49,8 @@ export const getIndicatorsParsed = createSelector(
         'value'
       ),
       'label'
-    )
+    );
+  }
 );
 
 export const getSelectedCategory = createSelector(
@@ -69,6 +72,7 @@ export const getSelectedCategory = createSelector(
 export const getCategoryIndicators = createSelector(
   [getIndicatorsParsed, getSelectedCategory],
   (indicatorsParsed, category) => {
+    if (!indicatorsParsed) return null;
     const categoryIndicators = indicatorsParsed.filter(
       indicator => indicator.categoryIds.indexOf(parseInt(category.id, 10)) > -1
     );

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
@@ -55,7 +55,7 @@ class NDCMapContainer extends PureComponent {
   }
 
   componentWillMount() {
-    this.props.fetchNDCSMapIndicators();
+    this.props.fetchNDCS();
   }
 
   getTooltipText() {
@@ -152,7 +152,7 @@ NDCMapContainer.propTypes = {
   isoCountries: PropTypes.array.isRequired,
   selectedIndicator: PropTypes.object.isRequired,
   setModalMetadata: PropTypes.func.isRequired,
-  fetchNDCSMapIndicators: PropTypes.func.isRequired
+  fetchNDCS: PropTypes.func.isRequired
 };
 
 export default withRouter(connect(mapStateToProps, actions)(NDCMapContainer));

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -7,7 +7,6 @@ import indcTransform from 'utils/indctransform';
 
 const fetchNDCSInit = createAction('fetchNDCSInit');
 const fetchNDCSReady = createAction('fetchNDCSReady');
-const fetchNDCSMapIndicatorsReady = createAction('fetchNDCSMapIndicatorsReady');
 const fetchNDCSFail = createAction('fetchNDCSFail');
 
 const fetchNDCS = createThunkAction('fetchNDCS', () => (dispatch, state) => {
@@ -18,7 +17,7 @@ const fetchNDCS = createThunkAction('fetchNDCS', () => (dispatch, state) => {
     !ndcs.loading
   ) {
     dispatch(fetchNDCSInit());
-    fetch('/api/v1/ndcs?filter=global')
+    fetch('/api/v1/ndcs?filter=map')
       .then(response => {
         if (response.ok) return response.json();
         throw Error(response.statusText);
@@ -34,38 +33,9 @@ const fetchNDCS = createThunkAction('fetchNDCS', () => (dispatch, state) => {
   }
 });
 
-const fetchNDCSMapIndicators = createThunkAction(
-  'fetchNDCSMapIndicators',
-  () => (dispatch, state) => {
-    const { ndcs } = state();
-    if (
-      ndcs &&
-      (isEmpty(ndcs.data) || isEmpty(ndcs.data.mapIndicators)) &&
-      !ndcs.loading
-    ) {
-      dispatch(fetchNDCSInit());
-      fetch('/api/v1/ndcs?filter=map')
-        .then(response => {
-          if (response.ok) return response.json();
-          throw Error(response.statusText);
-        })
-        .then(data => indcTransform(data))
-        .then(data => {
-          dispatch(fetchNDCSMapIndicatorsReady(data));
-        })
-        .catch(error => {
-          console.warn(error);
-          dispatch(fetchNDCSFail());
-        });
-    }
-  }
-);
-
 export default {
   fetchNDCS,
   fetchNDCSInit,
   fetchNDCSReady,
-  fetchNDCSFail,
-  fetchNDCSMapIndicators,
-  fetchNDCSMapIndicatorsReady
+  fetchNDCSFail
 };

--- a/app/javascript/app/pages/ndcs/ndcs-reducers.js
+++ b/app/javascript/app/pages/ndcs/ndcs-reducers.js
@@ -18,25 +18,7 @@ export default {
           ...state,
           data: {
             ...state.data,
-            sectors: payload.sectors,
-            categories: payload.categories,
-            indicators: payload.indicators
-          }
-        },
-        false
-      ),
-      true
-    ),
-  fetchNDCSMapIndicatorsReady: (state, { payload }) =>
-    setLoaded(
-      setLoading(
-        {
-          ...state,
-          data: {
-            ...state.data,
-            sectors: payload.sectors,
-            mapCategories: payload.categories,
-            mapIndicators: payload.indicators
+            ...payload
           }
         },
         false

--- a/app/javascript/app/pages/ndcs/ndcs.js
+++ b/app/javascript/app/pages/ndcs/ndcs.js
@@ -1,5 +1,6 @@
 import { PureComponent, createElement } from 'react';
 import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import actions from './ndcs-actions';
@@ -14,10 +15,18 @@ const mapStateToProps = (state, { route, location }) => ({
 });
 
 class NDCContainer extends PureComponent {
+  componentWillMount() {
+    this.props.fetchNDCS();
+  }
+
   render() {
     return createElement(Component, this.props);
   }
 }
+
+NDCContainer.propTypes = {
+  fetchNDCS: PropTypes.func.isRequired
+};
 
 export { actions, reducers, initialState };
 export default withRouter(connect(mapStateToProps, actions)(NDCContainer));

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -49,7 +49,8 @@ module.exports = {
       writeToFileEmit: true
     }),
     new webpack.DefinePlugin({
-      'process.env.JSCOV': JSON.stringify(false)
+      'process.env.JSCOV': JSON.stringify(false),
+      'process.env.NODE_ENV': env.NODE_ENV
     })
   ],
 


### PR DESCRIPTION
The ndcs data finally should shows only the map categories so this PR clear the old logic and unify both in map and table.

Bonus: don't show warning on production