### PR TITLE
Speed up years query using a materialised view

### DIFF
--- a/app/models/historical_emissions/normalised_record.rb
+++ b/app/models/historical_emissions/normalised_record.rb
@@ -1,0 +1,22 @@
+module HistoricalEmissions
+  class NormalisedRecord < ApplicationRecord
+    self.table_name = 'historical_emissions_normalised_records'
+
+    belongs_to :record,
+               class_name: 'HistoricalEmissions::Record',
+               foreign_key: :id
+    belongs_to :location
+    belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
+    belongs_to :sector, class_name: 'HistoricalEmissions::Sector'
+    belongs_to :gas, class_name: 'HistoricalEmissions::Gas'
+    belongs_to :gwp, class_name: 'HistoricalEmissions::Gwp'
+
+    def readonly?
+      true
+    end
+
+    def self.refresh
+      Scenic.database.refresh_materialized_view(table_name, concurrently: false)
+    end
+  end
+end

--- a/app/models/historical_emissions/record.rb
+++ b/app/models/historical_emissions/record.rb
@@ -1,5 +1,8 @@
 module HistoricalEmissions
   class Record < ApplicationRecord
+    has_many :normalised_records,
+             class_name: 'HistoricalEmissions::NormalisedRecord',
+             foreign_key: :id
     belongs_to :location
     belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
     belongs_to :sector, class_name: 'HistoricalEmissions::Sector'

--- a/db/migrate/20180720105038_create_historical_emissions_normalised_records_mview.rb
+++ b/db/migrate/20180720105038_create_historical_emissions_normalised_records_mview.rb
@@ -1,0 +1,12 @@
+class CreateHistoricalEmissionsNormalisedRecordsMview < ActiveRecord::Migration[5.1]
+  def change
+    create_view :historical_emissions_normalised_records, materialized: true
+    add_index :historical_emissions_normalised_records, [:data_source_id]
+    add_index :historical_emissions_normalised_records, [:gwp_id]
+    add_index :historical_emissions_normalised_records, [:location_id]
+    add_index :historical_emissions_normalised_records, [:sector_id]
+    add_index :historical_emissions_normalised_records, [:gas_id]
+    add_index :historical_emissions_normalised_records, [:year]
+    add_index :historical_emissions_normalised_records, [:id, :year], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -236,6 +236,23 @@ CREATE TABLE public.historical_emissions_records (
 
 
 --
+-- Name: historical_emissions_normalised_records; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.historical_emissions_normalised_records AS
+ SELECT historical_emissions_records.id,
+    historical_emissions_records.data_source_id,
+    historical_emissions_records.gwp_id,
+    historical_emissions_records.location_id,
+    historical_emissions_records.sector_id,
+    historical_emissions_records.gas_id,
+    ((jsonb_array_elements(historical_emissions_records.emissions) ->> 'year'::text))::integer AS year,
+    (jsonb_array_elements(historical_emissions_records.emissions) ->> 'value'::text) AS value
+   FROM public.historical_emissions_records
+  WITH NO DATA;
+
+
+--
 -- Name: historical_emissions_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -2010,6 +2027,55 @@ CREATE UNIQUE INDEX index_adaptation_variables_on_slug ON public.adaptation_vari
 
 
 --
+-- Name: index_historical_emissions_normalised_records_on_data_source_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_data_source_id ON public.historical_emissions_normalised_records USING btree (data_source_id);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_gas_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_gas_id ON public.historical_emissions_normalised_records USING btree (gas_id);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_gwp_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_gwp_id ON public.historical_emissions_normalised_records USING btree (gwp_id);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_id_and_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_historical_emissions_normalised_records_on_id_and_year ON public.historical_emissions_normalised_records USING btree (id, year);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_location_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_location_id ON public.historical_emissions_normalised_records USING btree (location_id);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_sector_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_sector_id ON public.historical_emissions_normalised_records USING btree (sector_id);
+
+
+--
+-- Name: index_historical_emissions_normalised_records_on_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_historical_emissions_normalised_records_on_year ON public.historical_emissions_normalised_records USING btree (year);
+
+
+--
 -- Name: index_historical_emissions_records_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2799,6 +2865,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180613114503'),
 ('20180613114709'),
 ('20180613124118'),
-('20180615113815');
+('20180615113815'),
+('20180720105038');
 
 

--- a/db/views/historical_emissions_normalised_records_v01.sql
+++ b/db/views/historical_emissions_normalised_records_v01.sql
@@ -1,0 +1,10 @@
+SELECT
+  id,
+  data_source_id,
+  gwp_id,
+  location_id,
+  sector_id,
+  gas_id,
+  (JSONB_ARRAY_ELEMENTS(emissions)->>'year')::INT AS year,
+  JSONB_ARRAY_ELEMENTS(emissions)->>'value' AS value
+FROM historical_emissions_records

--- a/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V1::Data::HistoricalEmissionsController, type: :controller do
   include_context 'historical emissions records'
 
+  before(:each) do
+    HistoricalEmissions::NormalisedRecord.refresh
+  end
+
   describe 'GET index' do
     it 'renders emissions records' do
       get :index, params: {

--- a/spec/services/api/v1/data/historical_emissions_filter_spec.rb
+++ b/spec/services/api/v1/data/historical_emissions_filter_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V1::Data::HistoricalEmissionsFilter do
   include_context 'historical emissions records'
 
+  before(:each) do
+    HistoricalEmissions::NormalisedRecord.refresh
+  end
+
   describe :call do
     it 'filters by subsector' do
       filter = Api::V1::Data::HistoricalEmissionsFilter.new(


### PR DESCRIPTION
Some speed improvements here, mostly to do with the "years" query, which now runs on top of a normalised representation of the historical emissions records table.

`bundle exec rake db:migrate`