### PR TITLE
Ensure all default selection in ndc map and table

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -81,27 +81,14 @@ export const getCategoryIndicators = createSelector(
 );
 
 export const getSelectedIndicator = createSelector(
-  [
-    state => state.indicatorSelected,
-    getCategoryIndicators,
-    getSelectedCategory
-  ],
-  (selected, indicators = [], categorySelected) => {
+  [state => state.indicatorSelected, getCategoryIndicators],
+  (selected, indicators = []) => {
     if (!indicators || !indicators.length) return {};
-    if (!selected) {
-      const defaultSelection =
-        {
-          mitigation: 'coverage_gas',
-          sectoral_mitigation_actions: 'm_agriculture'
-        }[categorySelected.value] || 'pa_status';
-      return (
-        indicators.find(ind => ind.value === defaultSelection) || indicators[0]
-      );
-    }
-    return (
-      indicators.find(indicator => indicator.value === selected) ||
-      indicators[0]
-    );
+    const defaultSelection = indicators[0];
+    return selected
+      ? indicators.find(indicator => indicator.value === selected) ||
+        defaultSelection
+      : defaultSelection;
   }
 );
 


### PR DESCRIPTION
Duplicating code for now, but would be nice to put this in practice once: https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances

Not the best moment for now so here we have the same default indicator selected independently of the map or the table, also was an issue with the sort as was done after the indicator selector it could have diferences across them

![kapture 2018-07-26 at 16 16 27](https://user-images.githubusercontent.com/10500650/43268162-34852006-90f0-11e8-8462-e8f832800df5.gif)
