### PR TITLE
Feature/data explorer change wording

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -13,7 +13,7 @@ import Loading from 'components/loading';
 import Button from 'components/button';
 import ModalDownload from 'components/modal-download';
 import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
-import { toStartCase } from 'app/utils';
+import { toStartCase, deburrCapitalize } from 'app/utils';
 import cx from 'classnames';
 import ReactPaginate from 'react-paginate';
 import { DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS } from 'data/constants';
@@ -84,8 +84,8 @@ class DataExplorerContent extends PureComponent {
         (multipleSector(field) ? (
           <MultiDropdown
             key={field}
-            label={toStartCase(field)}
-            placeholder={`Filter by ${toStartCase(field)}`}
+            label={deburrCapitalize(field)}
+            placeholder={`Filter by ${deburrCapitalize(field)}`}
             options={filterOptions ? filterOptions[field] : []}
             value={selectedOptions ? selectedOptions[field] : null}
             disabled={isDisabled(field)}
@@ -100,8 +100,8 @@ class DataExplorerContent extends PureComponent {
         ) : (
           <Dropdown
             key={field}
-            label={toStartCase(field)}
-            placeholder={`Filter by ${toStartCase(field)}`}
+            label={deburrCapitalize(field)}
+            placeholder={`Filter by ${deburrCapitalize(field)}`}
             options={filterOptions ? filterOptions[field] : []}
             onValueChange={selected =>
               handleFilterChange(field, selected && selected.slug)}
@@ -117,6 +117,7 @@ class DataExplorerContent extends PureComponent {
   render() {
     const {
       section,
+      sectionLabel,
       href,
       metadataSection,
       anchorLinks,
@@ -134,7 +135,7 @@ class DataExplorerContent extends PureComponent {
     } = this.props;
 
     const downloadButtonText = isEmpty(selectedOptions)
-      ? `Download ${toStartCase(section)} data`
+      ? `Download ${toStartCase(sectionLabel)} data`
       : 'Download selected data';
 
     return (
@@ -157,7 +158,7 @@ class DataExplorerContent extends PureComponent {
         </div>
         <div className={styles.buttons}>
           <Button className={styles.button} href={href} color="plain">
-            {`View in ${toStartCase(section)}`}
+            {`View in ${toStartCase(sectionLabel)}`}
           </Button>
           {!loading && data && !metadataSection ? (
             <ReactPaginate
@@ -195,6 +196,7 @@ class DataExplorerContent extends PureComponent {
 
 DataExplorerContent.propTypes = {
   section: PropTypes.string.isRequired,
+  sectionLabel: PropTypes.string.isRequired,
   handleFilterChange: PropTypes.func.isRequired,
   handlePageChange: PropTypes.func.isRequired,
   isDisabled: PropTypes.func.isRequired,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -17,7 +17,7 @@ import {
   DATA_EXPLORER_EXTERNAL_PREFIX,
   DATA_EXPLORER_TO_MODULES_PARAMS,
   DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS,
-  DATA_EXPLORER_SECTION_LABELS
+  DATA_EXPLORER_SECTIONS
 } from 'data/constants';
 
 const getMeta = state => state.meta || null;
@@ -36,7 +36,7 @@ export const getData = createSelector(
 
 export const getSectionLabel = createSelector(
   getSection,
-  section => DATA_EXPLORER_SECTION_LABELS[section]
+  section => DATA_EXPLORER_SECTIONS[section].label
 );
 
 export const getSourceOptions = createSelector(

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -16,7 +16,8 @@ import {
   DATA_EXPLORER_SECTION_BASE_URIS,
   DATA_EXPLORER_EXTERNAL_PREFIX,
   DATA_EXPLORER_TO_MODULES_PARAMS,
-  DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS
+  DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS,
+  DATA_EXPLORER_SECTION_LABELS
 } from 'data/constants';
 
 const getMeta = state => state.meta || null;
@@ -31,6 +32,11 @@ export const getData = createSelector(
     if (!data || !section) return null;
     return (data && data[section] && data[section].data) || null;
   }
+);
+
+export const getSectionLabel = createSelector(
+  getSection,
+  section => DATA_EXPLORER_SECTION_LABELS[section]
 );
 
 export const getSourceOptions = createSelector(

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -21,6 +21,7 @@ import DataExplorerContentComponent from './data-explorer-content-component';
 import {
   parseData,
   getMethodology,
+  getSectionLabel,
   getFilteredOptions,
   getSelectedOptions,
   getPathwaysMetodology,
@@ -91,6 +92,7 @@ const mapStateToProps = (state, { section, location }) => {
     isDisabled,
     firstColumnHeaders: DATA_EXPLORER_FIRST_COLUMN_HEADERS,
     href: getLink(dataState),
+    sectionLabel: getSectionLabel(dataState),
     downloadHref,
     filters: DATA_EXPLORER_FILTERS[section],
     filterOptions: getFilteredOptions(dataState),

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -10,7 +10,7 @@ import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import {
   DATA_EXPLORER_FIRST_COLUMN_HEADERS,
-  DATA_EXPLORER_SECTION_NAMES,
+  DATA_EXPLORER_SECTIONS,
   DATA_EXPLORER_FILTERS,
   DATA_EXPLORER_EXTERNAL_PREFIX,
   DATA_EXPLORER_DEPENDENCIES,
@@ -50,9 +50,9 @@ const mapStateToProps = (state, { section, location }) => {
   ];
   const filterQuery = parseFilterQuery(dataState);
   const devESPURL = section === 'emission-pathways' ? ESP_HOST : '';
-  const downloadHref = `${devESPURL}/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[
+  const downloadHref = `${devESPURL}/api/v1/data/${DATA_EXPLORER_SECTIONS[
     section
-  ]}/download.csv${filterQuery ? `?${filterQuery}` : ''}`;
+  ].requestPath}/download.csv${filterQuery ? `?${filterQuery}` : ''}`;
   const meta =
     section === 'emission-pathways'
       ? getPathwaysMetodology(dataState)

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -303,18 +303,21 @@ export const USERS_PROFESIONAL_SECTORS = [
   'Other'
 ];
 
-export const DATA_EXPLORER_SECTION_NAMES = {
-  'historical-emissions': 'historical_emissions',
-  'ndc-sdg-linkages': 'ndc_sdg',
-  'emission-pathways': 'emission_pathways',
-  'ndc-content': 'ndc_content'
+export const DATA_EXPLORER_SECTIONS = {
+  'historical-emissions': {
+    requestPath: 'historical_emissions',
+    label: 'historical-emissions'
+  },
+  'ndc-sdg-linkages': { requestPath: 'ndc_sdg', label: 'ndc-sdg-linkages' },
+  'emission-pathways': { requestPath: 'emission_pathways', label: 'pathways' },
+  'ndc-content': { requestPath: 'ndc_content', label: 'ndc-content' }
 };
 
-export const DATA_EXPLORER_SECTION_LABELS = {
-  'historical-emissions': 'historical-emissions',
-  'ndc-sdg-linkages': 'ndc-sdg-linkages',
-  'emission-pathways': 'pathways',
-  'ndc-content': 'ndc-content'
+export const DATA_EXPLORER_SECTION_BASE_URIS = {
+  'historical-emissions': 'ghg-emissions',
+  'ndc-sdg-linkages': 'ndcs-sdg',
+  'ndc-content': 'ndcs-content',
+  'emission-pathways': 'pathways'
 };
 
 export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
@@ -329,12 +332,7 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
 };
 
 export const DATA_EXPLORER_FILTERS = {
-  'historical-emissions': [
-    'source',
-    'gases',
-    'countries and regions',
-    'sectors'
-  ],
+  'historical-emissions': ['source', 'gases', 'regions', 'sectors'],
   'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
   'emission-pathways': [
     'locations',
@@ -350,12 +348,6 @@ export const DATA_EXPLORER_DEPENDENCIES = {
   'emission-pathways': { indicators: ['categories'] }
 };
 
-export const DATA_EXPLORER_SECTION_BASE_URIS = {
-  'historical-emissions': 'ghg-emissions',
-  'ndc-sdg-linkages': 'ndcs-sdg',
-  'ndc-content': 'ndcs-content',
-  'emission-pathways': 'pathways'
-};
 export const DATA_EXPLORER_EXTERNAL_PREFIX = 'external';
 export const DATA_EXPLORER_TO_MODULES_PARAMS = {
   'historical-emissions': {
@@ -431,7 +423,6 @@ export default {
   LENSES_SELECTOR_INFO,
   DATA_EXPLORER_BLACKLIST,
   DATA_EXPLORER_FIRST_COLUMN_HEADERS,
-  DATA_EXPLORER_SECTION_NAMES,
   DATA_EXPLORER_METHODOLOGY_SOURCE,
   SOURCE_VERSIONS,
   USERS_PROFESIONAL_SECTORS,
@@ -440,7 +431,7 @@ export default {
   DATA_EXPLORER_EXTERNAL_PREFIX,
   DATA_EXPLORER_TO_MODULES_PARAMS,
   DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS,
-  DATA_EXPLORER_SECTION_LABELS,
+  DATA_EXPLORER_SECTIONS,
   DATA_EXPLORER_PER_PAGE,
   ESP_HOST
 };

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -310,6 +310,13 @@ export const DATA_EXPLORER_SECTION_NAMES = {
   'ndc-content': 'ndc_content'
 };
 
+export const DATA_EXPLORER_SECTION_LABELS = {
+  'historical-emissions': 'historical-emissions',
+  'ndc-sdg-linkages': 'ndc-sdg-linkages',
+  'emission-pathways': 'pathways',
+  'ndc-content': 'ndc-content'
+};
+
 export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
   'historical-emissions': {
     PIK: ['historical_emissions_pik'],
@@ -322,7 +329,12 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
 };
 
 export const DATA_EXPLORER_FILTERS = {
-  'historical-emissions': ['source', 'gases', 'regions', 'sectors'],
+  'historical-emissions': [
+    'source',
+    'gases',
+    'countries and regions',
+    'sectors'
+  ],
   'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
   'emission-pathways': [
     'locations',
@@ -428,6 +440,7 @@ export default {
   DATA_EXPLORER_EXTERNAL_PREFIX,
   DATA_EXPLORER_TO_MODULES_PARAMS,
   DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS,
+  DATA_EXPLORER_SECTION_LABELS,
   DATA_EXPLORER_PER_PAGE,
   ESP_HOST
 };

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import {
-  DATA_EXPLORER_SECTION_NAMES,
+  DATA_EXPLORER_SECTIONS,
   ESP_HOST,
   DATA_EXPLORER_PER_PAGE
 } from 'data/constants';
@@ -50,9 +50,8 @@ export const fetchDataExplorer = createThunkAction(
       const parsedQuery = parseQuery(qs.stringify(updatedQuery));
 
       fetch(
-        `${devESPURL(section)}/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[
-          section
-        ]}?${parsedQuery}`
+        `${devESPURL(section)}/api/v1/data/${DATA_EXPLORER_SECTIONS[section]
+          .requestPath}?${parsedQuery}`
       )
         .then(response =>
           response.json().then(json => {
@@ -121,9 +120,8 @@ export const fetchMetadata = createThunkAction(
         !dataExplorer.metadata[section])
     ) {
       fetch(
-        `${devESPURL(section)}/api/v1/data/${DATA_EXPLORER_SECTION_NAMES[
-          section
-        ]}/meta`
+        `${devESPURL(section)}/api/v1/data/${DATA_EXPLORER_SECTIONS[section]
+          .requestPath}/meta`
       )
         .then(response => {
           if (response.ok) {

--- a/app/javascript/app/routes/app-routes/data-explorer-routes/data-explorer-routes.js
+++ b/app/javascript/app/routes/app-routes/data-explorer-routes/data-explorer-routes.js
@@ -21,7 +21,7 @@ export default [
     exact: true
   },
   {
-    label: 'Emission Pathways',
+    label: 'Pathways',
     path: '/data-explorer/emission-pathways',
     component: () =>
       createElement(DataExplorerContent, {

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -6,10 +6,12 @@ import isArray from 'lodash/isArray';
 import isString from 'lodash/isString';
 import isFinite from 'lodash/isFinite';
 import startCase from 'lodash/startCase';
+import capitalize from 'lodash/capitalize';
 
 export const assign = (o, ...rest) => Object.assign({}, o, ...rest);
 
 export const deburrUpper = string => toUpper(deburr(string));
+export const deburrCapitalize = string => capitalize(deburr(string));
 export const toStartCase = string => {
   const parsedString = startCase(string);
   const replacements = {


### PR DESCRIPTION
Changed `Emission Pathways` labels to `Pathways` on Data Explorer component.
Also reworded `Regions` dropdown label to `Countries and regions` 
[Pivotal (pathways)](https://www.pivotaltracker.com/story/show/159405777)
[Pivotal (Countries and regions)](https://www.pivotaltracker.com/story/show/159404553)
test here:
http://localhost:3000/data-explorer/historical-emissions?page=1

![image](https://user-images.githubusercontent.com/6906348/43463402-c8036504-94d8-11e8-854a-52c3fc2bc1ce.png)
![image](https://user-images.githubusercontent.com/6906348/43463442-db20b010-94d8-11e8-92ca-0d19cd4de2e8.png)
