### PR TITLE
NDC-Comparison/Show country values in the correct order and dash if empty

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { deburrUpper } from 'app/utils';
+import isNaN from 'lodash/isNaN';
 import uniq from 'lodash/uniq';
 import sortBy from 'lodash/sortBy';
 import snakeCase from 'lodash/snakeCase';
@@ -85,27 +86,23 @@ export const parsedCategoriesWithSectors = createSelector(
           cat.sectors.map(sec => {
             const definitions = [];
             cat.indicators.forEach(ind => {
-              const descriptions = [];
-              let hasValue = false;
-              countries.forEach(loc => {
-                const value = ind.locations[loc]
+              const descriptions = countries.map(loc => {
+                const valueObject = ind.locations[loc]
                   ? ind.locations[loc].find(v => v.sector_id === sec)
                   : null;
-                if (value && value.value) {
-                  hasValue = true;
-                  descriptions.push({
-                    iso: loc,
-                    value: value.value
-                  });
-                }
+                const value =
+                  (valueObject && valueObject.value) ||
+                  (isNaN(parseInt(loc, 10)) ? '-' : null);
+                return {
+                  iso: loc,
+                  value
+                };
               });
-              if (hasValue) {
-                definitions.push({
-                  title: ind.name,
-                  slug: ind.slug,
-                  descriptions
-                });
-              }
+              definitions.push({
+                title: ind.name,
+                slug: ind.slug,
+                descriptions
+              });
             });
             const parent =
               sectors[sec].parent_id && sectors[sectors[sec].parent_id];

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -23,7 +23,7 @@ export const parseIndicatorsDefs = createSelector(
       const parsedDefinitions = categoryIndicators.map(def => {
         const descriptions = countries.map(country => ({
           iso: country,
-          value: def.locations[country] ? def.locations[country][0].value : null
+          value: def.locations[country] ? def.locations[country][0].value : '-'
         }));
         return {
           title: def.name,


### PR DESCRIPTION
- Show empty values of the country in the accordion with a dash ('-')
- There was a bug showing the order of the values for each country. Before the countries without values were not displayed at all so some country values were misplaced. Now the array has empty values so they can be properly arranged.

Before: 
![image](https://user-images.githubusercontent.com/9701591/43580926-54cd13e8-9657-11e8-87c6-4559951c1282.png)

After:
![image](https://user-images.githubusercontent.com/9701591/43580781-e2c4895c-9656-11e8-9a75-f42efe86ff30.png)
