### PR TITLE
Feature/configurable sorting for data explorer endpoints

### DIFF
--- a/app/controllers/api/v1/data/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/data/historical_emissions_controller.rb
@@ -13,7 +13,7 @@ module Api
                  each_serializer: Api::V1::Data::HistoricalEmissions::RecordSerializer,
                  params: params,
                  root: :data,
-                 meta: {years: @filter.years}
+                 meta: {years: @filter.years, columns: @filter.column_manifest}
         end
 
         def meta

--- a/app/controllers/api/v1/data/historical_emissions_controller.rb
+++ b/app/controllers/api/v1/data/historical_emissions_controller.rb
@@ -13,7 +13,7 @@ module Api
                  each_serializer: Api::V1::Data::HistoricalEmissions::RecordSerializer,
                  params: params,
                  root: :data,
-                 meta: {years: @filter.years, columns: @filter.column_manifest}
+                 meta: @filter.meta
         end
 
         def meta

--- a/app/controllers/api/v1/data/ndc_content_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content_controller.rb
@@ -12,7 +12,7 @@ module Api
                  each_serializer: Api::V1::Data::NdcContent::NdcContentSerializer,
                  params: params,
                  root: :data,
-                 meta: {columns: @filter.column_manifest}
+                 meta: @filter.meta
         end
 
         def meta

--- a/app/controllers/api/v1/data/ndc_content_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content_controller.rb
@@ -11,7 +11,8 @@ module Api
                  adapter: :json,
                  each_serializer: Api::V1::Data::NdcContent::NdcContentSerializer,
                  params: params,
-                 root: :data
+                 root: :data,
+                 meta: {columns: @filter.column_manifest}
         end
 
         def meta

--- a/app/controllers/api/v1/data/ndc_sdg_controller.rb
+++ b/app/controllers/api/v1/data/ndc_sdg_controller.rb
@@ -11,7 +11,8 @@ module Api
                  adapter: :json,
                  each_serializer: Api::V1::Data::NdcSdg::NdcSdgSerializer,
                  params: params,
-                 root: :data
+                 root: :data,
+                 meta: {columns: @filter.column_manifest}
         end
 
         def meta

--- a/app/controllers/api/v1/data/ndc_sdg_controller.rb
+++ b/app/controllers/api/v1/data/ndc_sdg_controller.rb
@@ -12,7 +12,7 @@ module Api
                  each_serializer: Api::V1::Data::NdcSdg::NdcSdgSerializer,
                  params: params,
                  root: :data,
-                 meta: {columns: @filter.column_manifest}
+                 meta: @filter.meta
         end
 
         def meta

--- a/app/models/historical_emissions/searchable_record.rb
+++ b/app/models/historical_emissions/searchable_record.rb
@@ -1,0 +1,22 @@
+module HistoricalEmissions
+  class SearchableRecord < ApplicationRecord
+    self.table_name = 'historical_emissions_searchable_records'
+
+    belongs_to :record,
+               class_name: 'HistoricalEmissions::Record',
+               foreign_key: :id
+    belongs_to :location
+    belongs_to :data_source, class_name: 'HistoricalEmissions::DataSource'
+    belongs_to :sector, class_name: 'HistoricalEmissions::Sector'
+    belongs_to :gas, class_name: 'HistoricalEmissions::Gas'
+    belongs_to :gwp, class_name: 'HistoricalEmissions::Gwp'
+
+    def readonly?
+      true
+    end
+
+    def self.refresh
+      Scenic.database.refresh_materialized_view(table_name, concurrently: false)
+    end
+  end
+end

--- a/app/services/api/v1/data/column_helpers.rb
+++ b/app/services/api/v1/data/column_helpers.rb
@@ -11,24 +11,14 @@ module Api
         end
 
         def column_manifest
-          select_columns_map.map do |column_properties|
-            sortable =
-              if column_properties[:order].nil?
-                true
-              else
-                column_properties[:order]
-              end
-            tmp = {
-              name: column_properties[:alias],
-              sortable: sortable
-            }
-            # rubocop:disable Style/IfUnlessModifier
-            if @sorting_column == column_properties[:column]
-              tmp[:current] = @sorting_direction
+          sortable_columns = select_columns_map.select do |column_properties|
+            if column_properties[:order].nil? || column_properties[:order]
+              true
+            else
+              column_properties[:order]
             end
-            # rubocop:enable Style/IfUnlessModifier
-            tmp
           end
+          {columns: sortable_columns.map { |cp| cp[:alias] }}
         end
 
         private

--- a/app/services/api/v1/data/column_helpers.rb
+++ b/app/services/api/v1/data/column_helpers.rb
@@ -1,0 +1,66 @@
+module Api
+  module V1
+    module Data
+      module ColumnHelpers
+        extend ActiveSupport::Concern
+
+        def column_aliases
+          select_columns_map.map do |column_properties|
+            column_properties[:alias]
+          end
+        end
+
+        def column_manifest
+          select_columns_map.map do |column_properties|
+            sortable =
+              if column_properties[:order].nil?
+                true
+              else
+                column_properties[:order]
+              end
+            tmp = {
+              name: column_properties[:alias],
+              sortable: sortable
+            }
+            # rubocop:disable Style/IfUnlessModifier
+            if @sorting_column == column_properties[:column]
+              tmp[:current] = @sorting_direction
+            end
+            # rubocop:enable Style/IfUnlessModifier
+            tmp
+          end
+        end
+
+        private
+
+        def alias_to_name(column_alias)
+          tmp = select_columns_map.find do |column_properties|
+            column_properties[:alias] == column_alias
+          end
+          tmp && tmp[:column]
+        end
+
+        def select_columns
+          select_columns_map.map do |column_properties|
+            column = column_properties[:column]
+            column_alias = column_properties[:alias]
+            if column != column_alias
+              [column, 'AS', column_alias].join(' ')
+            else
+              column
+            end
+          end
+        end
+
+        def group_columns
+          groupable_columns = select_columns_map.select do |column_properties|
+            column_properties[:group].nil? || column_properties[:group] == true
+          end
+          groupable_columns.map do |column_properties|
+            column_properties[:column]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v1/data/historical_emissions_filter.rb
+++ b/app/services/api/v1/data/historical_emissions_filter.rb
@@ -49,6 +49,12 @@ module Api
           "emissions_dict->'#{year}'"
         end
 
+        def meta
+          {
+            years: @years
+          }.merge(sorting_manifest).merge(column_manifest)
+        end
+
         private
 
         # rubocop:disable Metrics/MethodLength

--- a/app/services/api/v1/data/ndc_content_csv_content.rb
+++ b/app/services/api/v1/data/ndc_content_csv_content.rb
@@ -6,7 +6,7 @@ module Api
       class NdcContentCsvContent
         def initialize(filter, output)
           @query = filter.call
-          @headers = filter.class.column_aliases
+          @headers = filter.column_aliases
           @output = output
         end
 

--- a/app/services/api/v1/data/ndc_content_filter.rb
+++ b/app/services/api/v1/data/ndc_content_filter.rb
@@ -31,6 +31,10 @@ module Api
             order(sanitised_order)
         end
 
+        def meta
+          sorting_manifest.merge(column_manifest)
+        end
+
         private
 
         # rubocop:disable Metrics/MethodLength

--- a/app/services/api/v1/data/ndc_sdg_csv_content.rb
+++ b/app/services/api/v1/data/ndc_sdg_csv_content.rb
@@ -6,7 +6,7 @@ module Api
       class NdcSdgCsvContent
         def initialize(filter, output)
           @query = filter.call
-          @headers = filter.class.column_aliases
+          @headers = filter.column_aliases
           @output = output
         end
 

--- a/app/services/api/v1/data/ndc_sdg_filter.rb
+++ b/app/services/api/v1/data/ndc_sdg_filter.rb
@@ -26,6 +26,10 @@ module Api
             order(sanitised_order)
         end
 
+        def meta
+          sorting_manifest.merge(column_manifest)
+        end
+
         private
 
         # rubocop:disable Metrics/MethodLength

--- a/app/services/api/v1/data/sanitised_sorting.rb
+++ b/app/services/api/v1/data/sanitised_sorting.rb
@@ -6,6 +6,10 @@ module Api
         SORTING_DIRECTIONS = %w(ASC DESC).freeze
         DEFAULT_SORTING_DIRECTION = 'ASC'.freeze
 
+        def sorting_manifest
+          {sorting: {sort_col: @sorting_alias, sort_dir: @sorting_direction}}
+        end
+
         private
 
         def sanitised_order
@@ -15,32 +19,45 @@ module Api
           )
         end
 
+        # @param column [String] name of column; can be a year
+        # @param direction [String] ASC / DESC
         def initialise_sorting(column, direction)
-          @sorting_column = sanitise_sorting_column(column)
+          @sorting_alias = sanitise_sorting_column(column)
+          if @sorting_alias.nil? && column =~ /^\d{4}$/ &&
+              respond_to?(:year_value_column)
+            @sorting_alias = column
+            @sorting_column = year_value_column(column)
+          else
+            @sorting_alias = default_sorting_column if @sorting_alias.nil?
+            @sorting_column = alias_to_name(@sorting_alias)
+          end
           @sorting_direction = sanitise_sorting_direction(direction)
+          # rubocop:disable Naming/MemoizedInstanceVariableName
+          @sorting_direction ||= DEFAULT_SORTING_DIRECTION
+          # rubocop:enable Naming/MemoizedInstanceVariableName
         end
 
         def sanitise_sorting_column(column)
-          return default_sorting_column unless column.present?
+          return nil unless column.present?
           column = column.downcase
           # rubocop:disable Style/IfUnlessModifier
           if available_sorting_columns.include?(column)
-            return alias_to_name(column)
+            return column
           end
           # rubocop:enable Style/IfUnlessModifier
-          default_sorting_column
+          nil
         end
 
         def sanitise_sorting_direction(direction)
-          return DEFAULT_SORTING_DIRECTION unless direction
+          return nil unless direction
           direction = direction.upcase
           return direction if SORTING_DIRECTIONS.include?(direction)
-          DEFAULT_SORTING_DIRECTION
+          nil
         end
 
         def default_sorting_column
           if available_sorting_columns.include? 'iso_code3'
-            alias_to_name('iso_code3')
+            'iso_code3'
           else
             available_sorting_columns.first
           end

--- a/app/services/api/v1/data/sanitised_sorting.rb
+++ b/app/services/api/v1/data/sanitised_sorting.rb
@@ -1,0 +1,55 @@
+module Api
+  module V1
+    module Data
+      module SanitisedSorting
+        extend ActiveSupport::Concern
+        SORTING_DIRECTIONS = %w(ASC DESC).freeze
+        DEFAULT_SORTING_DIRECTION = 'ASC'.freeze
+
+        private
+
+        def sanitised_order
+          @query.klass.send(
+            :sanitize_sql_for_order,
+            "#{@sorting_column} #{@sorting_direction}"
+          )
+        end
+
+        def initialise_sorting(column, direction)
+          @sorting_column = sanitise_sorting_column(column)
+          @sorting_direction = sanitise_sorting_direction(direction)
+        end
+
+        def sanitise_sorting_column(column)
+          return default_sorting_column unless column.present?
+          column = column.downcase
+          # rubocop:disable Style/IfUnlessModifier
+          if available_sorting_columns.include?(column)
+            return alias_to_name(column)
+          end
+          # rubocop:enable Style/IfUnlessModifier
+          default_sorting_column
+        end
+
+        def sanitise_sorting_direction(direction)
+          return DEFAULT_SORTING_DIRECTION unless direction
+          direction = direction.upcase
+          return direction if SORTING_DIRECTIONS.include?(direction)
+          DEFAULT_SORTING_DIRECTION
+        end
+
+        def default_sorting_column
+          if available_sorting_columns.include? 'iso_code3'
+            alias_to_name('iso_code3')
+          else
+            available_sorting_columns.first
+          end
+        end
+
+        def available_sorting_columns
+          column_aliases
+        end
+      end
+    end
+  end
+end

--- a/app/services/import_historical_emissions.rb
+++ b/app/services/import_historical_emissions.rb
@@ -12,6 +12,8 @@ class ImportHistoricalEmissions
     import_records(S3CSVReader.read(DATA_CAIT_FILEPATH))
     import_records(S3CSVReader.read(DATA_PIK_FILEPATH))
     import_records(S3CSVReader.read(DATA_UNFCCC_FILEPATH))
+    HistoricalEmissions::NormalisedRecord.refresh
+    HistoricalEmissions::SearchableRecord.refresh
   end
 
   private

--- a/db/migrate/20180803123629_create_historical_emissions_searchable_records.rb
+++ b/db/migrate/20180803123629_create_historical_emissions_searchable_records.rb
@@ -1,0 +1,17 @@
+class CreateHistoricalEmissionsSearchableRecords < ActiveRecord::Migration[5.1]
+  def up
+    execute 'REFRESH MATERIALIZED VIEW historical_emissions_normalised_records'
+    create_view :historical_emissions_searchable_records, materialized: true
+    add_index :historical_emissions_searchable_records, [:data_source_id]
+    add_index :historical_emissions_searchable_records, [:gwp_id]
+    add_index :historical_emissions_searchable_records, [:location_id]
+    add_index :historical_emissions_searchable_records, [:sector_id]
+    add_index :historical_emissions_searchable_records, [:gas_id]
+    add_index :historical_emissions_searchable_records, [:id], unique: true
+    execute 'CREATE INDEX index_searchable_emissions_path_ops ON historical_emissions_searchable_records USING GIN (emissions_dict jsonb_path_ops)'
+  end
+
+  def down
+    drop_view :historical_emissions_searchable_records, materialized: true
+  end
+end

--- a/db/views/historical_emissions_searchable_records_v01.sql
+++ b/db/views/historical_emissions_searchable_records_v01.sql
@@ -1,0 +1,36 @@
+SELECT
+  records.id,
+  records.data_source_id,
+  data_sources.name AS data_source,
+  gwp_id,
+  gwps.name AS gwp,
+  location_id,
+  locations.iso_code3 AS iso_code3,
+  locations.wri_standard_name AS region,
+  sector_id,
+  sectors.name AS sector,
+  gas_id,
+  gases.name AS gas,
+  records_with_emissions_dict.emissions,
+  emissions_dict
+FROM historical_emissions_records records
+JOIN historical_emissions_data_sources data_sources ON data_sources.id = records.data_source_id
+JOIN historical_emissions_gwps gwps ON gwps.id = records.gwp_id
+JOIN locations ON locations.id = records.location_id
+JOIN historical_emissions_sectors sectors ON sectors.id = records.sector_id
+JOIN historical_emissions_gases gases ON gases.id = records.gas_id
+LEFT JOIN (
+  SELECT
+    id,
+    JSONB_AGG(
+        JSONB_BUILD_OBJECT(
+            'year', year,
+            'value', ROUND(value::NUMERIC, 2)
+        )
+    ) AS emissions,
+    JSONB_OBJECT_AGG(
+        year, ROUND(value::NUMERIC, 2)
+    ) AS emissions_dict
+  FROM historical_emissions_normalised_records
+  GROUP BY id
+) records_with_emissions_dict ON records.id = records_with_emissions_dict.id;

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -11,7 +11,7 @@
 - start_year
 - end_year
 - sort_dir (ASC / DESC)
-- sort_col (column name for sortable columns - see meta)
+- sort_col (column name or year - see meta)
 
 ### CSV download endpoint
 
@@ -54,13 +54,16 @@ Iso code 3 | Region | Data source | Gwp | Sector | Gas | Unit | year 1 | year 2 
          integer
       ],
       "columns":[
-         {"name":"string", "sortable":boolean, "current":"string"}
-      ]
+         "string"
+      ],
+      "sorting":{
+         "sort_col":"string","sort_dir":"string"
+      }
    }
 }
 ```
 
-Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns. Current sorting column and direction are also returned.
 
 ```
 Link: <http://localhost:3000/api/v1/data/historical_emissions?page=622&start_year=2000>; rel="last", <http://localhost:3000/api/v1/data/historical_emissions?page=2&start_year=2000>; rel="next"
@@ -222,13 +225,16 @@ Id | Iso code3 | Country | Indc text | Status | Climate response | Type of infor
    ],
    "meta":{
       "columns":[
-         {"name":"string", "sortable":boolean, "current":"string"}
-      ]
+         "string"
+      ],
+      "sorting":{
+         "sort_col":"string","sort_dir":"string"
+      }
    }
 }
 ```
 
-Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available data columns. Current sorting column and direction are also returned.
 
 ```
 Link: <http://localhost:3000/api/v1/data/ndc_sdg?page=170>; rel="last", <http://localhost:3000/api/v1/data/ndc_sdg?page=2>; rel="next"
@@ -384,13 +390,16 @@ Id | Iso code3 | Country | Indicator | Source | Label | Sector | Value | Categor
    ],
    "meta":{
       "columns":[
-         {"name":"string", "sortable":boolean, "current":"string"}
-      ]
+         "string"
+      ],
+      "sorting":{
+         "sort_col":"string","sort_dir":"string"
+      }
    }
 }
 ```
 
-Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available data columns. Current sorting column and direction are also returned.
 
 ```
 Link: <http://localhost:3000/api/v1/data/ndc_content?page=1933>; rel="last", <http://localhost:3000/api/v1/data/ndc_content?page=2>; rel="next"

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -10,6 +10,8 @@
 - sector_ids[]
 - start_year
 - end_year
+- sort_dir (ASC / DESC)
+- sort_col (column name for sortable columns - see meta)
 
 ### CSV download endpoint
 
@@ -50,12 +52,15 @@ Iso code 3 | Region | Data source | Gwp | Sector | Gas | Unit | year 1 | year 2 
    "meta":{
       "years":[
          integer
+      ],
+      "columns":[
+         {"name":"string", "sortable":boolean, "current":"string"}
       ]
    }
 }
 ```
 
-Response is paginated. Pagination headers are in place.
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
 
 ```
 Link: <http://localhost:3000/api/v1/data/historical_emissions?page=622&start_year=2000>; rel="last", <http://localhost:3000/api/v1/data/historical_emissions?page=2&start_year=2000>; rel="next"

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -341,6 +341,8 @@ Link: </api/v1/data/ndc_sdg/goals>; rel="meta goals", </api/v1/data/ndc_sdg/targ
 - category_ids[]
 - label_ids[]
 - sector_ids[]
+- sort_dir (ASC / DESC)
+- sort_col (column name for sortable columns - see meta)
 
 ### CSV download endpoint
 
@@ -372,11 +374,16 @@ Id | Iso code3 | Country | Indicator | Source | Label | Sector | Value | Categor
          "label":"string or null",
          "sector":"string or null"
       }
-   ]
+   ],
+   "meta":{
+      "columns":[
+         {"name":"string", "sortable":boolean, "current":"string"}
+      ]
+   }
 }
 ```
 
-Response is paginated. Pagination headers are in place.
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
 
 ```
 Link: <http://localhost:3000/api/v1/data/ndc_content?page=1933>; rel="last", <http://localhost:3000/api/v1/data/ndc_content?page=2>; rel="next"

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -183,6 +183,8 @@ Link: </api/v1/data/historical_emissions/data_sources>; rel="meta data_sources",
 - goal_ids[]
 - target_ids[]
 - sector_ids[]
+- sort_dir (ASC / DESC)
+- sort_col (column name for sortable columns - see meta)
 
 ### CSV download endpoint
 
@@ -217,11 +219,16 @@ Id | Iso code3 | Country | Indc text | Status | Climate response | Type of infor
          "goal_number":"17",
          "goal":"Strengthen the means of implementation and revitalize the global partnership for sustainable development"
       }
-   ]
+   ],
+   "meta":{
+      "columns":[
+         {"name":"string", "sortable":boolean, "current":"string"}
+      ]
+   }
 }
 ```
 
-Response is paginated. Pagination headers are in place.
+Response is paginated. Pagination headers are in place. Meta section is to inform the rendering of data in a tabular form: it lists available years of data (useful when used as headers) and all available data columns together with information on whether they are sortable or not. Column which is currently used for sorting will additionaly have the "current" property set to either "ASC" or "DESC".
 
 ```
 Link: <http://localhost:3000/api/v1/data/ndc_sdg?page=170>; rel="last", <http://localhost:3000/api/v1/data/ndc_sdg?page=2>; rel="next"

--- a/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::Data::HistoricalEmissionsController, type: :controller d
 
   before(:each) do
     HistoricalEmissions::NormalisedRecord.refresh
+    HistoricalEmissions::SearchableRecord.refresh
   end
 
   describe 'GET index' do

--- a/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/data/historical_emissions_controller_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe Api::V1::Data::HistoricalEmissionsController, type: :controller d
       expect(@response).to match_response_schema('historical_emissions')
     end
 
+    it 'sorts by gas ascending' do
+      get :index, params: {
+        sort_col: 'gas', sort_dir: 'ASC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['gas']).to eq(gas_CO2.name)
+    end
+
+    it 'sorts by gas descending' do
+      get :index, params: {
+        sort_col: 'gas', sort_dir: 'DESC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['gas']).to eq(gas_N2O.name)
+    end
+
     it 'sets pagination headers' do
       get :index
       expect(@response.headers).to include('Total')

--- a/spec/controllers/api/v1/data/ndc_content_controller_spec.rb
+++ b/spec/controllers/api/v1/data/ndc_content_controller_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe Api::V1::Data::NdcContentController, type: :controller do
       expect(@response).to match_response_schema('ndc_content')
     end
 
+    it 'sorts by indicator ascending' do
+      get :index, params: {
+        sort_col: 'indicator', sort_dir: 'ASC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['indicator']).to eq(ghg_target_type.name)
+    end
+
+    it 'sorts by indicator descending' do
+      get :index, params: {
+        sort_col: 'indicator', sort_dir: 'DESC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['indicator']).to eq(sectoral_targets_on.name)
+    end
+
     it 'sets pagination headers' do
       get :index
       expect(@response.headers).to include('Total')

--- a/spec/controllers/api/v1/data/ndc_sdg_controller_spec.rb
+++ b/spec/controllers/api/v1/data/ndc_sdg_controller_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe Api::V1::Data::NdcSdgController, type: :controller do
       expect(@response).to match_response_schema('ndc_sdgs')
     end
 
+    it 'sorts by iso_code3 ascending' do
+      get :index, params: {
+        sort_col: 'iso_code3', sort_dir: 'ASC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['iso_code3']).to eq(spain.iso_code3)
+    end
+
+    it 'sorts by iso_code3 descending' do
+      get :index, params: {
+        sort_col: 'iso_code3', sort_dir: 'DESC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['iso_code3']).to eq(uk.iso_code3)
+    end
+
     it 'sets pagination headers' do
       get :index
       expect(@response.headers).to include('Total')

--- a/spec/services/api/v1/data/historical_emissions_filter_spec.rb
+++ b/spec/services/api/v1/data/historical_emissions_filter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::Data::HistoricalEmissionsFilter do
 
   before(:each) do
     HistoricalEmissions::NormalisedRecord.refresh
+    HistoricalEmissions::SearchableRecord.refresh
   end
 
   describe :call do

--- a/spec/support/schemas/api/v1/data/historical_emissions.json
+++ b/spec/support/schemas/api/v1/data/historical_emissions.json
@@ -156,41 +156,47 @@
             ]
           }
         },
+        "sorting": {
+          "$id": "/properties/meta/properties/sorting",
+          "type": "object",
+          "properties": {
+            "sort_col": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_col",
+              "type": "string",
+              "title": "The Sort_col Schema ",
+              "default": "",
+              "examples": [
+                "iso_code3"
+              ]
+            },
+            "sort_dir": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_dir",
+              "type": "string",
+              "title": "The Sort_dir Schema ",
+              "default": "",
+              "examples": [
+                "ASC"
+              ]
+            }
+          }
+        },
         "columns": {
           "$id": "/properties/meta/properties/columns",
           "type": "array",
           "items": {
             "$id": "/properties/meta/properties/columns/items",
-            "type": "object",
-            "properties": {
-              "name": {
-                "$id": "/properties/meta/properties/columns/items/properties/name",
-                "type": "string",
-                "title": "The Name Schema ",
-                "default": "",
-                "examples": [
-                  "gas"
-                ]
-              },
-              "sortable": {
-                "$id": "/properties/meta/properties/columns/items/properties/sortable",
-                "type": "boolean",
-                "title": "The Sortable Schema ",
-                "default": false,
-                "examples": [
-                  true
-                ]
-              },
-              "current": {
-                "$id": "/properties/meta/properties/columns/items/properties/current",
-                "type": ["string", "null"],
-                "title": "The Current Schema ",
-                "default": "",
-                "examples": [
-                  "ASC"
-                ]
-              }
-            }
+            "type": "string",
+            "title": "The 0th Schema ",
+            "default": "",
+            "examples": [
+              "id",
+              "iso_code3",
+              "region",
+              "data_source",
+              "gwp",
+              "sector",
+              "gas"
+            ]
           }
         }
       }

--- a/spec/support/schemas/api/v1/data/historical_emissions.json
+++ b/spec/support/schemas/api/v1/data/historical_emissions.json
@@ -151,8 +151,46 @@
               2011,
               2012,
               2013,
-              2014
+              2014,
+              2015
             ]
+          }
+        },
+        "columns": {
+          "$id": "/properties/meta/properties/columns",
+          "type": "array",
+          "items": {
+            "$id": "/properties/meta/properties/columns/items",
+            "type": "object",
+            "properties": {
+              "name": {
+                "$id": "/properties/meta/properties/columns/items/properties/name",
+                "type": "string",
+                "title": "The Name Schema ",
+                "default": "",
+                "examples": [
+                  "gas"
+                ]
+              },
+              "sortable": {
+                "$id": "/properties/meta/properties/columns/items/properties/sortable",
+                "type": "boolean",
+                "title": "The Sortable Schema ",
+                "default": false,
+                "examples": [
+                  true
+                ]
+              },
+              "current": {
+                "$id": "/properties/meta/properties/columns/items/properties/current",
+                "type": ["string", "null"],
+                "title": "The Current Schema ",
+                "default": "",
+                "examples": [
+                  "ASC"
+                ]
+              }
+            }
           }
         }
       }

--- a/spec/support/schemas/api/v1/data/ndc_content.json
+++ b/spec/support/schemas/api/v1/data/ndc_content.json
@@ -94,6 +94,49 @@
           }
         }
       }
+    },
+    "meta": {
+      "$id": "/properties/meta",
+      "type": "object",
+      "properties": {
+        "columns": {
+          "$id": "/properties/meta/properties/columns",
+          "type": "array",
+          "items": {
+            "$id": "/properties/meta/properties/columns/items",
+            "type": "object",
+            "properties": {
+              "name": {
+                "$id": "/properties/meta/properties/columns/items/properties/name",
+                "type": "string",
+                "title": "The Name Schema ",
+                "default": "",
+                "examples": [
+                  "indicator"
+                ]
+              },
+              "sortable": {
+                "$id": "/properties/meta/properties/columns/items/properties/sortable",
+                "type": "boolean",
+                "title": "The Sortable Schema ",
+                "default": false,
+                "examples": [
+                  true
+                ]
+              },
+              "current": {
+                "$id": "/properties/meta/properties/columns/items/properties/current",
+                "type": "string",
+                "title": "The Current Schema ",
+                "default": "",
+                "examples": [
+                  "ASC"
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/spec/support/schemas/api/v1/data/ndc_content.json
+++ b/spec/support/schemas/api/v1/data/ndc_content.json
@@ -99,41 +99,48 @@
       "$id": "/properties/meta",
       "type": "object",
       "properties": {
+        "sorting": {
+          "$id": "/properties/meta/properties/sorting",
+          "type": "object",
+          "properties": {
+            "sort_col": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_col",
+              "type": "string",
+              "title": "The Sort_col Schema ",
+              "default": "",
+              "examples": [
+                "indicator"
+              ]
+            },
+            "sort_dir": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_dir",
+              "type": "string",
+              "title": "The Sort_dir Schema ",
+              "default": "",
+              "examples": [
+                "ASC"
+              ]
+            }
+          }
+        },
         "columns": {
           "$id": "/properties/meta/properties/columns",
           "type": "array",
           "items": {
             "$id": "/properties/meta/properties/columns/items",
-            "type": "object",
-            "properties": {
-              "name": {
-                "$id": "/properties/meta/properties/columns/items/properties/name",
-                "type": "string",
-                "title": "The Name Schema ",
-                "default": "",
-                "examples": [
-                  "indicator"
-                ]
-              },
-              "sortable": {
-                "$id": "/properties/meta/properties/columns/items/properties/sortable",
-                "type": "boolean",
-                "title": "The Sortable Schema ",
-                "default": false,
-                "examples": [
-                  true
-                ]
-              },
-              "current": {
-                "$id": "/properties/meta/properties/columns/items/properties/current",
-                "type": "string",
-                "title": "The Current Schema ",
-                "default": "",
-                "examples": [
-                  "ASC"
-                ]
-              }
-            }
+            "type": "string",
+            "title": "The 0th Schema ",
+            "default": "",
+            "examples": [
+              "id",
+              "iso_code3",
+              "country",
+              "indicator",
+              "source",
+              "label",
+              "sector",
+              "value"
+            ]
           }
         }
       }

--- a/spec/support/schemas/api/v1/data/ndc_sdgs.json
+++ b/spec/support/schemas/api/v1/data/ndc_sdgs.json
@@ -116,8 +116,42 @@
             "title": "The Goal Schema ",
             "default": "",
             "examples": [
-              "Protect, restore and promote sustainable use of terrestrial ecosystems, sustainably manage forests, combat desertification, and halt and reverse land degradation and halt biodiversity loss"
+              "Strengthen the means of implementation and revitalize the global partnership for sustainable development"
             ]
+          }
+        }
+      }
+    },
+    "meta": {
+      "$id": "/properties/meta",
+      "type": "object",
+      "properties": {
+        "columns": {
+          "$id": "/properties/meta/properties/columns",
+          "type": "array",
+          "items": {
+            "$id": "/properties/meta/properties/columns/items",
+            "type": "object",
+            "properties": {
+              "name": {
+                "$id": "/properties/meta/properties/columns/items/properties/name",
+                "type": "string",
+                "title": "The Name Schema ",
+                "default": "",
+                "examples": [
+                  "id"
+                ]
+              },
+              "sortable": {
+                "$id": "/properties/meta/properties/columns/items/properties/sortable",
+                "type": "boolean",
+                "title": "The Sortable Schema ",
+                "default": false,
+                "examples": [
+                  true
+                ]
+              }
+            }
           }
         }
       }

--- a/spec/support/schemas/api/v1/data/ndc_sdgs.json
+++ b/spec/support/schemas/api/v1/data/ndc_sdgs.json
@@ -126,32 +126,54 @@
       "$id": "/properties/meta",
       "type": "object",
       "properties": {
+        "sorting": {
+          "$id": "/properties/meta/properties/sorting",
+          "type": "object",
+          "properties": {
+            "sort_col": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_col",
+              "type": "string",
+              "title": "The Sort_col Schema ",
+              "default": "",
+              "examples": [
+                "iso_code3"
+              ]
+            },
+            "sort_dir": {
+              "$id": "/properties/meta/properties/sorting/properties/sort_dir",
+              "type": "string",
+              "title": "The Sort_dir Schema ",
+              "default": "",
+              "examples": [
+                "ASC"
+              ]
+            }
+          }
+        },
         "columns": {
           "$id": "/properties/meta/properties/columns",
           "type": "array",
           "items": {
             "$id": "/properties/meta/properties/columns/items",
-            "type": "object",
-            "properties": {
-              "name": {
-                "$id": "/properties/meta/properties/columns/items/properties/name",
-                "type": "string",
-                "title": "The Name Schema ",
-                "default": "",
-                "examples": [
-                  "id"
-                ]
-              },
-              "sortable": {
-                "$id": "/properties/meta/properties/columns/items/properties/sortable",
-                "type": "boolean",
-                "title": "The Sortable Schema ",
-                "default": false,
-                "examples": [
-                  true
-                ]
-              }
-            }
+            "type": "string",
+            "title": "The 0th Schema ",
+            "default": "",
+            "examples": [
+              "id",
+              "iso_code3",
+              "country",
+              "indc_text",
+              "status",
+              "climate_response",
+              "type_of_information",
+              "sector",
+              "target_number",
+              "target",
+              "goal_number",
+              "goal",
+              "document_type",
+              "language"
+            ]
           }
         }
       }


### PR DESCRIPTION
Enables `sort_col` and `sort_dir` params for historical emissions, NDC content, NDC-SDG linkages data explorer endpoints.

In case of historical emissions `sort_col` can be a year.

Related: https://github.com/Vizzuality/emissions-scenario-portal/pull/271