### PR TITLE
Feature/data explorer split categories subcategories dropdown pathways

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -164,13 +164,14 @@ function getOptions(section, filter, filtersMeta) {
 
 function parseOptions(section, filter, options) {
   if (section !== 'emission-pathways') return options;
-  if (filter === 'categories') {
-    return options.filter(option => option.parent_id === null);
+  switch (filter) {
+    case 'categories':
+      return options.filter(option => option.parent_id === null);
+    case 'subcategories':
+      return options.filter(option => option.parent_id !== null);
+    default:
+      return options;
   }
-  if (filter === 'subcategories') {
-    return options.filter(option => option.parent_id !== null);
-  }
-  return options;
 }
 
 export const getFilterOptions = createSelector(

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -78,7 +78,11 @@ export const getFilterQuery = createSelector(
     const parsedFilters = removeFiltersPrefix(search, section);
     const filterIds = {};
     Object.keys(parsedFilters).forEach(key => {
-      const parsedKey = key.replace('-', '_');
+      let correctedKey = key;
+      if (key === 'subcategories') {
+        correctedKey = 'categories';
+      }
+      const parsedKey = correctedKey.replace('-', '_');
       const filter =
         metadata[parsedKey] &&
         metadata[parsedKey].find(option =>
@@ -140,14 +144,20 @@ export const getLink = createSelector(
 
 function getOptions(section, filter, filtersMeta) {
   if (section !== 'emission-pathways') return filtersMeta[filter];
-  if (filter === 'categories' || filter === 'subcategories') { return filtersMeta.categories; }
+  if (filter === 'categories' || filter === 'subcategories') {
+    return filtersMeta.categories;
+  }
   return filtersMeta[filter];
 }
 
 function parseOptions(section, filter, options) {
   if (section !== 'emission-pathways') return options;
-  if (filter === 'categories') { return options.filter(option => option.parent_id === null); }
-  if (filter === 'subcategories') { return options.filter(option => option.parent_id !== null); }
+  if (filter === 'categories') {
+    return options.filter(option => option.parent_id === null);
+  }
+  if (filter === 'subcategories') {
+    return options.filter(option => option.parent_id !== null);
+  }
   return options;
 }
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -138,6 +138,19 @@ export const getLink = createSelector(
   }
 );
 
+function getOptions(section, filter, filtersMeta) {
+  if (section !== 'emission-pathways') return filtersMeta[filter];
+  if (filter === 'categories' || filter === 'subcategories') { return filtersMeta.categories; }
+  return filtersMeta[filter];
+}
+
+function parseOptions(section, filter, options) {
+  if (section !== 'emission-pathways') return options;
+  if (filter === 'categories') { return options.filter(option => option.parent_id === null); }
+  if (filter === 'subcategories') { return options.filter(option => option.parent_id !== null); }
+  return options;
+}
+
 export const getFilterOptions = createSelector(
   [getMeta, getSection, getCountries, getRegions, getSourceOptions],
   (meta, section, countries, regions, sourceVersions) => {
@@ -153,9 +166,10 @@ export const getFilterOptions = createSelector(
     }
     const filterOptions = {};
     filterKeys.forEach(f => {
-      const options = filtersMeta[f];
+      const options = getOptions(section, f, filtersMeta);
       if (options) {
-        const parsedOptions = options.map(option => {
+        const parsedOptions = parseOptions(section, f, options);
+        const optionsArray = parsedOptions.map(option => {
           const slug =
             option.slug ||
             option.name ||
@@ -178,14 +192,14 @@ export const getFilterOptions = createSelector(
             ...option
           };
         });
-        filterOptions[f] = parsedOptions;
+        filterOptions[f] = optionsArray;
       }
     });
     return filterOptions;
   }
 );
 
-const parseOptions = options => {
+const parseMultipleLevelOptions = options => {
   const groupParents = [];
   const finalOptions = options
     .map(option => {
@@ -223,7 +237,7 @@ const parseGroupsInOptions = createSelector(
       if (
         DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS[section].find(s => s.key === key)
       ) {
-        updatedOptions[key] = parseOptions(updatedOptions[key]);
+        updatedOptions[key] = parseMultipleLevelOptions(updatedOptions[key]);
       }
     });
     return updatedOptions;

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-styles.scss
@@ -40,22 +40,13 @@
 
 .filtersContainer {
   @include columns(6);
-  @include xy-gutters($gutter-position: 'bottom');
 
-  > :nth-child(n+3) {
-    @include xy-gutters($gutter-position: 'top');
+  > * {
+    @include xy-gutters($gutter-position: 'bottom');
   }
 
   @media #{$tablet-landscape} {
     @include columns(3);
-
-    > :nth-child(n+3) {
-      @include xy-gutters($gutter-position: 'top', $gutters: 0);
-    }
-
-    > :nth-child(5) {
-      @include xy-gutters($gutter-position: 'top');
-    }
   }
 }
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -2,9 +2,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { PureComponent, createElement } from 'react';
 import { openDownloadModal } from 'utils/data-explorer';
-import { getLocationParamUpdated } from 'utils/navigation';
+import { getSearch, getLocationParamUpdated } from 'utils/navigation';
 import { PropTypes } from 'prop-types';
-import qs from 'query-string';
 import { actions } from 'components/modal-download';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
@@ -30,7 +29,7 @@ import {
 } from './data-explorer-content-selectors';
 
 const mapStateToProps = (state, { section, location }) => {
-  const search = qs.parse(location.search);
+  const search = getSearch(location);
   const dataState = {
     data: state.dataExplorer && state.dataExplorer.data,
     countries: state.countries && state.countries.data,

--- a/app/javascript/app/components/navbar/navbar-component.jsx
+++ b/app/javascript/app/components/navbar/navbar-component.jsx
@@ -1,15 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Nav from 'components/nav';
 import ToolsNav from 'components/tools-nav';
 
 import styles from './navbar-styles.scss';
 
+const FEATURE_DATA_EXPLORER = process.env.FEATURE_DATA_EXPLORER === 'true';
+
 class NavBar extends PureComponent {
   render() {
     const { routes } = this.props;
     return (
-      <div className={styles.row}>
+      <div
+        className={cx(styles.row, {
+          [styles.withDataExplorerLayout]: FEATURE_DATA_EXPLORER
+        })}
+      >
         <div className={styles.navigationWrapper}>
           <Nav routes={routes} className={styles.navigation} isRendered />
         </div>

--- a/app/javascript/app/components/navbar/navbar-styles.scss
+++ b/app/javascript/app/components/navbar/navbar-styles.scss
@@ -6,6 +6,12 @@
   height: $navbar-height;
 }
 
+.withDataExplorerLayout {
+  @include row((9, 3));
+
+  height: $navbar-height;
+}
+
 .navigationWrapper {
   display: flex;
   align-items: center;

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -329,6 +329,7 @@ export const DATA_EXPLORER_FILTERS = {
     'models',
     'scenarios',
     'categories',
+    'subcategories',
     'indicators'
   ],
   'ndc-content': ['categories', 'indicators', 'sectors', 'countries']
@@ -374,6 +375,9 @@ export const DATA_EXPLORER_TO_MODULES_PARAMS = {
     },
     categories: {
       key: 'category'
+    },
+    subcategories: {
+      key: 'subcategories'
     }
   }
 };
@@ -386,8 +390,7 @@ export const SOURCE_VERSIONS = [
 ];
 
 export const DATA_EXPLORER_MULTIPLE_LEVEL_SECTIONS = {
-  'ndc-content': [{ key: 'sectors' }, { key: 'categories' }],
-  'emission-pathways': [{ key: 'categories', noSelectableParent: true }]
+  'ndc-content': [{ key: 'sectors' }, { key: 'categories' }]
 };
 
 export const DATA_EXPLORER_PER_PAGE = 20;

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -336,7 +336,7 @@ export const DATA_EXPLORER_FILTERS = {
 };
 
 export const DATA_EXPLORER_DEPENDENCIES = {
-  'emission-pathways': { indicators: ['categories'] }
+  'emission-pathways': { indicators: ['subcategories'] }
 };
 
 export const DATA_EXPLORER_SECTION_BASE_URIS = {

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -377,7 +377,7 @@ export const DATA_EXPLORER_TO_MODULES_PARAMS = {
       key: 'category'
     },
     subcategories: {
-      key: 'subcategories'
+      key: 'subcategory'
     }
   }
 };

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -2,8 +2,10 @@ import qs from 'query-string';
 import isArray from 'lodash/isArray';
 import { CONTAINED_PATHNAME } from 'data/constants';
 
+export const getSearch = location => qs.parse(location.search);
+
 export function getLocationParamUpdated(location, params = [], clear = false) {
-  const search = qs.parse(location.search);
+  const search = getSearch(location);
   const newFilters = {};
   const paramsArray = isArray(params) ? params : [params];
   paramsArray.forEach(param => {
@@ -34,6 +36,7 @@ export const isEmbededComponent = location =>
   location.pathname.includes('/embed');
 
 export default {
+  getSearch,
   getLocationParamUpdated,
   isPageContained,
   isPageNdcp,


### PR DESCRIPTION
This PR splits `categories` two level dropdown into two different dropdowns: `categories` and `subcategories`
[Pivotal](https://www.pivotaltracker.com/story/show/159405453)

BEFORE . 

![image](https://user-images.githubusercontent.com/6906348/43591441-a55e8802-9673-11e8-9f23-6132d0109aab.png)

AFTER .   
![image](https://user-images.githubusercontent.com/6906348/43591351-70d572ee-9673-11e8-9343-5e6807f6c72f.png)


Further improvements should be done to allow the display of the proper selections when changing from data explorer to module view and vice versa. Those improvements will be addressed in another PR regarding dropdowns dependencies ([Pivotal](https://www.pivotaltracker.com/story/show/159405550))

It also fixes an small issue with navigation layout triggering horizontal scroll when `FEATURE_DATA_EXPLORER=true`

before .  
![image](https://user-images.githubusercontent.com/6906348/43591663-17e1a72e-9674-11e8-9c6e-60bdd338c3ec.png)


after .  

![image](https://user-images.githubusercontent.com/6906348/43591697-28051a82-9674-11e8-9334-71e7bce93eee.png)
