### PR TITLE
Speed up migration which creates a materialised view for historical emissions

### DIFF
--- a/app/models/historical_emissions/searchable_record.rb
+++ b/app/models/historical_emissions/searchable_record.rb
@@ -16,6 +16,9 @@ module HistoricalEmissions
     end
 
     def self.refresh
+      Scenic.database.refresh_materialized_view(
+        :historical_emissions_records_emissions, concurrently: false
+      )
       Scenic.database.refresh_materialized_view(table_name, concurrently: false)
     end
   end

--- a/db/migrate/20180803123629_create_historical_emissions_searchable_records.rb
+++ b/db/migrate/20180803123629_create_historical_emissions_searchable_records.rb
@@ -1,17 +1,6 @@
 class CreateHistoricalEmissionsSearchableRecords < ActiveRecord::Migration[5.1]
-  def up
-    execute 'REFRESH MATERIALIZED VIEW historical_emissions_normalised_records'
-    create_view :historical_emissions_searchable_records, materialized: true
-    add_index :historical_emissions_searchable_records, [:data_source_id]
-    add_index :historical_emissions_searchable_records, [:gwp_id]
-    add_index :historical_emissions_searchable_records, [:location_id]
-    add_index :historical_emissions_searchable_records, [:sector_id]
-    add_index :historical_emissions_searchable_records, [:gas_id]
-    add_index :historical_emissions_searchable_records, [:id], unique: true
-    execute 'CREATE INDEX index_searchable_emissions_path_ops ON historical_emissions_searchable_records USING GIN (emissions_dict jsonb_path_ops)'
-  end
-
-  def down
-    drop_view :historical_emissions_searchable_records, materialized: true
+  def change
+    # this was taking too long, so it's now a noop
+    # file kept in order not to affect rails migrations tracking
   end
 end

--- a/db/migrate/20180807150412_create_historical_emissions_searchable_records_more_quickly.rb
+++ b/db/migrate/20180807150412_create_historical_emissions_searchable_records_more_quickly.rb
@@ -1,0 +1,22 @@
+class CreateHistoricalEmissionsSearchableRecordsMoreQuickly < ActiveRecord::Migration[5.1]
+  def up
+    execute 'REFRESH MATERIALIZED VIEW historical_emissions_normalised_records'
+    create_view :historical_emissions_records_emissions, materialized: true
+    add_index :historical_emissions_records_emissions, [:id], unique: true
+
+    drop_view :historical_emissions_searchable_records, materialized: true if view_exists?(:historical_emissions_searchable_records)
+    create_view :historical_emissions_searchable_records, materialized: true
+    add_index :historical_emissions_searchable_records, [:data_source_id]
+    add_index :historical_emissions_searchable_records, [:gwp_id]
+    add_index :historical_emissions_searchable_records, [:location_id]
+    add_index :historical_emissions_searchable_records, [:sector_id]
+    add_index :historical_emissions_searchable_records, [:gas_id]
+    add_index :historical_emissions_searchable_records, [:id], unique: true
+    execute 'CREATE INDEX index_searchable_emissions_path_ops ON historical_emissions_searchable_records USING GIN (emissions_dict jsonb_path_ops)'
+  end
+
+  def down
+    drop_view :historical_emissions_searchable_records, materialized: true
+    drop_view :historical_emissions_records_emissions, materialized: true
+  end
+end

--- a/db/views/historical_emissions_records_emissions_v01.sql
+++ b/db/views/historical_emissions_records_emissions_v01.sql
@@ -1,0 +1,14 @@
+  SELECT
+    id,
+    JSONB_AGG(
+        JSONB_BUILD_OBJECT(
+            'year', year,
+            'value', ROUND(value::NUMERIC, 2)
+        )
+    ) AS emissions,
+    JSONB_OBJECT_AGG(
+        year, ROUND(value::NUMERIC, 2)
+    ) AS emissions_dict
+  FROM historical_emissions_normalised_records
+  GROUP BY id;
+  

--- a/db/views/historical_emissions_searchable_records_v01.sql
+++ b/db/views/historical_emissions_searchable_records_v01.sql
@@ -11,7 +11,7 @@ SELECT
   sectors.name AS sector,
   gas_id,
   gases.name AS gas,
-  records_with_emissions_dict.emissions,
+  records_emissions.emissions,
   emissions_dict
 FROM historical_emissions_records records
 JOIN historical_emissions_data_sources data_sources ON data_sources.id = records.data_source_id
@@ -19,18 +19,4 @@ JOIN historical_emissions_gwps gwps ON gwps.id = records.gwp_id
 JOIN locations ON locations.id = records.location_id
 JOIN historical_emissions_sectors sectors ON sectors.id = records.sector_id
 JOIN historical_emissions_gases gases ON gases.id = records.gas_id
-LEFT JOIN (
-  SELECT
-    id,
-    JSONB_AGG(
-        JSONB_BUILD_OBJECT(
-            'year', year,
-            'value', ROUND(value::NUMERIC, 2)
-        )
-    ) AS emissions,
-    JSONB_OBJECT_AGG(
-        year, ROUND(value::NUMERIC, 2)
-    ) AS emissions_dict
-  FROM historical_emissions_normalised_records
-  GROUP BY id
-) records_with_emissions_dict ON records.id = records_with_emissions_dict.id;
+LEFT JOIN historical_emissions_records_emissions records_emissions ON records.id = records_emissions.id;


### PR DESCRIPTION
This should be faster, because it creates an intermediate materialised view with an index on it where we previously had a subquery. This intermediate view is not used for anything on its own, so it doesn't have its own model and refreshing it is coupled with the main view refresh method.

The old migration is commented out, but left in the migrations directory in order not to confuse migration tracking for people who have run it.
