### PR TITLE
Data Explorer - Enable sort via backend

### DIFF
--- a/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation.js
+++ b/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation.js
@@ -35,6 +35,16 @@ const indicatorsParam = {
   parameter: 'indicator_ids[]',
   description: 'indicator id'
 };
+const sortColumnParam = {
+  name: 'sort_col',
+  parameter: 'sort_col',
+  description: 'column to sort the table by'
+};
+const sortDirectionParam = {
+  name: 'sort_dir',
+  parameter: 'sort_dir',
+  description: 'sort direction (ASC or DESC)'
+};
 const linkHeaderDescription =
   'Returns a Link header with meta endpoint urls for discovery (can be used with a HEAD request)';
 const linkHeaderExtra = 'This response only has headers not body';
@@ -76,7 +86,9 @@ const API_CALLS = {
           description: 'region ISO code 3'
         },
         startYearParam,
-        endYearParam
+        endYearParam,
+        sortColumnParam,
+        sortDirectionParam
       ],
       extra: multipleValuesExtra
     }
@@ -111,7 +123,12 @@ const API_CALLS = {
           description: 'locations ISO code 3'
         },
         startYearParam,
-        endYearParam
+        endYearParam,
+        sortColumnParam,
+        {
+          ...sortDirectionParam,
+          description: `${sortDirectionParam.description}. Years are not sortable`
+        }
       ],
       extra: multipleValuesExtra
     }
@@ -139,7 +156,9 @@ const API_CALLS = {
           description: 'target id'
         },
         sectorsParam,
-        countriesParam
+        countriesParam,
+        sortColumnParam,
+        sortDirectionParam
       ],
       extra: multipleValuesExtra
     }
@@ -169,7 +188,9 @@ const API_CALLS = {
           parameter: 'label_ids[]',
           description: 'label id'
         },
-        sectorsParam
+        sectorsParam,
+        sortColumnParam,
+        sortDirectionParam
       ],
       extra: multipleValuesExtra
     }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -26,19 +26,29 @@ const FEATURE_DATA_SURVEY = process.env.FEATURE_DATA_SURVEY === 'true';
 class DataExplorerContent extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   renderTable() {
-    const { data, firstColumnHeaders, loading } = this.props;
+    const {
+      data,
+      firstColumnHeaders,
+      loading,
+      handleSortChange,
+      search
+    } = this.props;
     if (loading) return <Loading light className={styles.loader} />;
     if (data && data.length) {
       const columns = data && Object.keys(data[0]);
       const sortBy =
-        columns.find(c => firstColumnHeaders.includes(c)) || columns[0];
+        search.sort_col ||
+        columns.find(c => firstColumnHeaders.includes(c)) ||
+        columns[0];
       return (
         <Table
           data={data}
           rowHeight={60}
           sortBy={sortBy}
+          sortDirection={search.sort_dir}
           firstColumnHeaders={firstColumnHeaders}
           horizontalScroll
+          handleSortChange={handleSortChange}
         />
       );
     }
@@ -137,7 +147,6 @@ class DataExplorerContent extends PureComponent {
     const downloadButtonText = isEmpty(selectedOptions)
       ? `Download ${toStartCase(sectionLabel)} data`
       : 'Download selected data';
-
     return (
       <div>
         <DataExplorerProvider
@@ -202,6 +211,7 @@ DataExplorerContent.propTypes = {
   isDisabled: PropTypes.func.isRequired,
   handleDownloadModalOpen: PropTypes.func.isRequired,
   handleDataDownload: PropTypes.func.isRequired,
+  handleSortChange: PropTypes.func.isRequired,
   filters: PropTypes.array,
   selectedOptions: PropTypes.object,
   filterOptions: PropTypes.object,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -179,16 +179,24 @@ export const getFilterQuery = createSelector(
   (meta, search, section) => filterQueryIds(meta, search, section, false)
 );
 
+export const getSortQuery = createSelector([getSearch], search =>
+  qs.stringify(pick(search, ['sort_col', 'sort_dir']))
+);
+
 export const getLinkFilterQuery = createSelector(
   [getMeta, getSearch, getSection],
   (meta, search, section) => filterQueryIds(meta, search, section, true)
 );
 
-export const parseFilterQuery = createSelector([getFilterQuery], filterIds => {
-  if (!filterIds || isEmpty(filterIds)) return null;
-  const filterQuery = qs.stringify(filterIds);
-  return filterQuery && parseQuery(filterQuery);
-});
+export const parseFilterQuery = createSelector(
+  [getFilterQuery, getSortQuery],
+  (filterIds, sortQuery) => {
+    if (!filterIds || isEmpty(filterIds)) return null;
+    const sortParam = sortQuery ? `?${sortQuery}` : '';
+    const filterQuery = `${qs.stringify(filterIds)}${sortParam}`;
+    return filterQuery && parseQuery(filterQuery);
+  }
+);
 
 export const getLink = createSelector(
   [getLinkFilterQuery, getSection, state => state.meta],

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { PureComponent, createElement } from 'react';
 import { openDownloadModal } from 'utils/data-explorer';
+import { isANumber } from 'utils/utils';
 import { getSearch, getLocationParamUpdated } from 'utils/navigation';
 import { PropTypes } from 'prop-types';
 import { actions } from 'components/modal-download';
@@ -200,10 +201,12 @@ class DataExplorerContentContainer extends PureComponent {
   };
 
   handleSortChange = ({ sortBy, sortDirection }) => {
-    this.updateUrlParam([
-      { name: 'sort_col', value: sortBy },
-      { name: 'sort_dir', value: sortDirection }
-    ]);
+    if (!(this.props.section === 'emission-pathways' && isANumber(sortBy))) {
+      this.updateUrlParam([
+        { name: 'sort_col', value: sortBy },
+        { name: 'sort_dir', value: sortDirection }
+      ]);
+    }
   };
 
   handleDownloadModalOpen = () => {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -199,6 +199,13 @@ class DataExplorerContentContainer extends PureComponent {
     return window.location.assign(downloadHref);
   };
 
+  handleSortChange = ({ sortBy, sortDirection }) => {
+    this.updateUrlParam([
+      { name: 'sort_col', value: sortBy },
+      { name: 'sort_dir', value: sortDirection }
+    ]);
+  };
+
   handleDownloadModalOpen = () => {
     const { setModalDownloadParams, downloadHref } = this.props;
     openDownloadModal(downloadHref, setModalDownloadParams);
@@ -215,6 +222,7 @@ class DataExplorerContentContainer extends PureComponent {
       handleFilterChange: this.handleFilterChange,
       handlePageChange: this.handlePageChange,
       handleDataDownload: this.handleDataDownload,
+      handleSortChange: this.handleSortChange,
       handleDownloadModalOpen: this.handleDownloadModalOpen
     });
   }

--- a/app/javascript/app/components/table/table.js
+++ b/app/javascript/app/components/table/table.js
@@ -16,13 +16,13 @@ import Component from './table-component';
 class TableContainer extends PureComponent {
   constructor(props) {
     super(props);
-    const { data, defaultColumns, sortBy } = props;
+    const { data, defaultColumns, sortBy, sortDirection } = props;
     const columns = defaultColumns || Object.keys(data[0]);
     this.state = {
       data,
       optionsOpen: false,
       sortBy: sortBy || Object.keys(data[0])[0],
-      sortDirection: SortDirection.ASC,
+      sortDirection,
       activeColumns: columns.map(d => ({
         label: toStartCase(d),
         value: d
@@ -97,6 +97,7 @@ class TableContainer extends PureComponent {
       columnsOptions,
       optionsOpen
     } = this.state;
+    const { handleSortChange } = this.props;
     return createElement(Component, {
       ...this.props,
       data,
@@ -105,7 +106,7 @@ class TableContainer extends PureComponent {
       sortDirection,
       activeColumns,
       columnsOptions,
-      handleSortChange: this.handleSortChange,
+      handleSortChange: handleSortChange || this.handleSortChange,
       handleColumnChange: this.handleColumnChange,
       setRowsHeight: this.setRowsHeight,
       setColumnWidth: this.setColumnWidth,
@@ -119,12 +120,15 @@ class TableContainer extends PureComponent {
 TableContainer.propTypes = {
   data: PropTypes.array.isRequired,
   defaultColumns: PropTypes.array,
-  sortBy: PropTypes.string.isRequired
+  handleSortChange: PropTypes.func,
+  sortBy: PropTypes.string.isRequired,
+  sortDirection: PropTypes.string.isRequired
 };
 
 TableContainer.defaultProps = {
   data: [],
-  sortBy: 'value'
+  sortBy: 'value',
+  sortDirection: SortDirection.ASC
 };
 
 export default TableContainer;

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider.js
@@ -1,7 +1,6 @@
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash/isEqual';
 import reducers, { initialState } from './data-explorer-provider-reducers';
 import * as actions from './data-explorer-provider-actions';
 
@@ -19,11 +18,7 @@ class DataExplorerProvider extends PureComponent {
       query: prevQuery,
       page: prevPage
     } = prevProps;
-    if (
-      page !== prevPage ||
-      section !== prevSection ||
-      !isEqual(query, prevQuery)
-    ) {
+    if (page !== prevPage || section !== prevSection || query !== prevQuery) {
       fetchDataExplorer({ section, query, page });
     }
   }

--- a/app/javascript/app/utils/data-explorer.js
+++ b/app/javascript/app/utils/data-explorer.js
@@ -17,7 +17,9 @@ const REPLACEMENTS = {
   targets: 'target_ids[]',
   models: 'model_ids[]',
   scenarios: 'scenario_ids[]',
-  locations: 'location_ids[]'
+  locations: 'location_ids[]',
+  sort_col: 'sort_col',
+  sort_dir: 'sort_dir'
 };
 
 export const parseQuery = query => query && replaceAll(query, REPLACEMENTS);

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -23,6 +23,8 @@ export const toStartCase = string => {
   return replaceAll(parsedString, replacements);
 };
 
+export const isANumber = i => !isNaN(parseInt(i, 10));
+
 export const lowerUpperFirst = string => upperFirst(toLower(string));
 
 export const isCountryIncluded = (countriesIncluded = [], iso) => {
@@ -199,5 +201,6 @@ export default {
   wordWrap,
   parseLinkHeader,
   replaceAll,
-  findEqual
+  findEqual,
+  isANumber
 };


### PR DESCRIPTION
This PR enables the sort via Backend. Before the sorting of the table was done only in the page that we were in. Now we send a request to the backend to sort the table

- Add and fetch by sort params in the url
- Dont sort years in Pathways
- Documentation in the frontend updated

Note: The Pathways years are not sorted in the backend

![image](https://user-images.githubusercontent.com/9701591/43786273-8c98e940-9a68-11e8-93cc-630a21a9db8a.png)
