### PR TITLE
Feature/data explorer add year selectors

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -4,9 +4,6 @@ import DataExplorerProvider from 'providers/data-explorer-provider/data-explorer
 import RegionsProvider from 'providers/regions-provider/regions-provider';
 import CountriesProvider from 'providers/countries-provider/countries-provider';
 import Table from 'components/table';
-import Dropdown from 'components/dropdown';
-import MultiDropdown from 'components/dropdown/multi-dropdown';
-import MultiSelect from 'components/multiselect';
 import MetadataText from 'components/metadata-text';
 import AnchorNav from 'components/anchor-nav';
 import NoContent from 'components/no-content';
@@ -14,14 +11,11 @@ import Loading from 'components/loading';
 import Button from 'components/button';
 import ModalDownload from 'components/modal-download';
 import anchorNavLightTheme from 'styles/themes/anchor-nav/anchor-nav-light.scss';
-import { toStartCase, deburrCapitalize } from 'app/utils';
+import { toStartCase } from 'app/utils';
 import cx from 'classnames';
 import ReactPaginate from 'react-paginate';
-import {
-  MULTIPLE_LEVEL_SECTION_FIELDS,
-  GROUPED_SELECT_FIELDS
-} from 'data/data-explorer-constants';
 import isEmpty from 'lodash/isEmpty';
+import DataExplorerFilters from './data-explorer-filters';
 import ApiDocumentation from './api-documentation/api-documentation';
 import styles from './data-explorer-content-styles.scss';
 
@@ -82,83 +76,6 @@ class DataExplorerContent extends PureComponent {
     );
   }
 
-  renderFilters() {
-    const {
-      handleFilterChange,
-      selectedOptions,
-      filterOptions,
-      filters,
-      section,
-      activeFilterRegion,
-      isDisabled
-    } = this.props;
-
-    const multipleSection = field =>
-      MULTIPLE_LEVEL_SECTION_FIELDS[section] &&
-      MULTIPLE_LEVEL_SECTION_FIELDS[section].find(s => s.key === field);
-    const groupedSelect = field =>
-      GROUPED_SELECT_FIELDS[section] &&
-      GROUPED_SELECT_FIELDS[section].find(s => s.key === field);
-    return filters.map(field => {
-      if (multipleSection(field)) {
-        return (
-          <MultiDropdown
-            key={field}
-            label={deburrCapitalize(field)}
-            placeholder={`Filter by ${deburrCapitalize(field)}`}
-            options={filterOptions ? filterOptions[field] : []}
-            value={
-              selectedOptions ? (
-                selectedOptions[field] && selectedOptions[field][0]
-              ) : null
-            }
-            disabled={isDisabled(field)}
-            clearable
-            onChange={option =>
-              handleFilterChange(field, option && option.value)}
-            noParentSelection={multipleSection(field).noSelectableParent}
-          />
-        );
-      } else if (groupedSelect(field)) {
-        const fieldInfo = GROUPED_SELECT_FIELDS[section].find(
-          f => f.key === field
-        );
-        return (
-          <MultiSelect
-            key={field}
-            label={fieldInfo.label}
-            selectedLabel={activeFilterRegion}
-            placeholder={`Filter by ${fieldInfo.label}`}
-            values={(selectedOptions && selectedOptions[field]) || []}
-            options={filterOptions ? filterOptions[field] : []}
-            groups={fieldInfo.groups}
-            disabled={isDisabled(field)}
-            onMultiValueChange={selected =>
-              handleFilterChange(field, selected, true)}
-          />
-        );
-      }
-      return (
-        <Dropdown
-          key={field}
-          label={deburrCapitalize(field)}
-          placeholder={`Filter by ${deburrCapitalize(field)}`}
-          options={filterOptions ? filterOptions[field] : []}
-          onValueChange={selected =>
-            handleFilterChange(field, selected && selected.value)}
-          value={
-            selectedOptions && selectedOptions[field] ? (
-              selectedOptions[field][0]
-            ) : null
-          }
-          plain
-          disabled={isDisabled(field)}
-          noAutoSort={field === 'goals' || field === 'targets'}
-        />
-      );
-    });
-  }
-
   render() {
     const {
       section,
@@ -191,7 +108,9 @@ class DataExplorerContent extends PureComponent {
         />
         <RegionsProvider />
         <CountriesProvider />
-        <div className={styles.filtersContainer}>{this.renderFilters()}</div>
+        <div className={styles.filtersContainer}>
+          <DataExplorerFilters section={section} />
+        </div>
         <AnchorNav
           links={anchorLinks}
           theme={anchorNavLightTheme}
@@ -239,18 +158,13 @@ class DataExplorerContent extends PureComponent {
 }
 
 DataExplorerContent.propTypes = {
-  activeFilterRegion: PropTypes.string,
   section: PropTypes.string.isRequired,
   sectionLabel: PropTypes.string.isRequired,
-  handleFilterChange: PropTypes.func.isRequired,
   handlePageChange: PropTypes.func.isRequired,
-  isDisabled: PropTypes.func.isRequired,
   handleDownloadModalOpen: PropTypes.func.isRequired,
   handleDataDownload: PropTypes.func.isRequired,
   handleSortChange: PropTypes.func.isRequired,
-  filters: PropTypes.array,
   selectedOptions: PropTypes.object,
-  filterOptions: PropTypes.object,
   metadataSection: PropTypes.bool,
   data: PropTypes.array,
   meta: PropTypes.array,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -157,7 +157,9 @@ export const getLinkFilterQuery = createSelector(
 export const parseFilterQuery = createSelector(
   [getFilterQuery, getNonColumnQuery],
   (filterIds, nonColumnQuery) => {
-    if (!filterIds || (isEmpty(filterIds) && isEmpty(nonColumnQuery))) { return null; }
+    if (!filterIds || (isEmpty(filterIds) && isEmpty(nonColumnQuery))) {
+      return null;
+    }
     const filterQuery = qs.stringify({ ...filterIds, ...nonColumnQuery });
     return filterQuery;
   }
@@ -368,8 +370,9 @@ export const parseExternalParams = createSelector(
       const keyWithoutPrefix = k
         .replace(`${DATA_EXPLORER_EXTERNAL_PREFIX}-`, '')
         .replace(`${section}-`, '');
-      const metaMatchingKey = keyWithoutPrefix.replace('-', '_');
+      let metaMatchingKey = keyWithoutPrefix.replace('-', '_');
       if (metaMatchingKey !== 'undefined') {
+        if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const labelObject = meta[section][metaMatchingKey].find(
           i =>
             i.id === parseInt(externalFields[k], 10) ||
@@ -506,7 +509,9 @@ export const addYearOptions = createSelector(
       !sectionsWithYearsFilter.includes(section) ||
       !options ||
       !data
-    ) { return options; }
+    ) {
+      return options;
+    }
     const yearColumns = Object.keys(data[0]).filter(k => isANumber(k));
     const yearOptions = years => years.map(y => ({ label: y, value: y }));
     const updatedOptions = { ...options };

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -10,21 +10,16 @@ import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import {
   DATA_EXPLORER_SECTIONS,
-  DATA_EXPLORER_FILTERS,
   DATA_EXPLORER_EXTERNAL_PREFIX,
-  DATA_EXPLORER_DEPENDENCIES,
   DATA_EXPLORER_PER_PAGE
 } from 'data/data-explorer-constants';
 import { ESP_HOST } from 'data/constants';
 import DataExplorerContentComponent from './data-explorer-content-component';
 import {
   parseData,
-  getActiveFilterRegion,
   getMethodology,
   getSectionLabel,
   getFirstTableHeaders,
-  getDependentOptions,
-  getSelectedOptions,
   parseFilterQuery,
   parseExternalParams,
   getLink,
@@ -65,62 +60,29 @@ const mapStateToProps = (state, { section, location }) => {
     state.dataExplorer.data &&
     state.dataExplorer.data[section];
   const dataLength = hasFetchedData && state.dataExplorer.data[section].total;
-  const metadataSection = !!location.hash && location.hash === '#meta';
   const loading =
     (state.dataExplorer && state.dataExplorer.loading) || !hasFetchedData;
   const loadingMeta = state.dataExplorer && state.dataExplorer.loadingMeta;
-  const selectedOptions = getSelectedOptions(dataState);
-  const filterDependencyMissing = key =>
-    DATA_EXPLORER_DEPENDENCIES[section] &&
-    DATA_EXPLORER_DEPENDENCIES[section][key] &&
-    selectedOptions &&
-    !DATA_EXPLORER_DEPENDENCIES[section][key].every(k =>
-      Object.keys(selectedOptions).includes(k)
-    );
-  const isDisabled = key =>
-    (!metadataSection && loading) ||
-    (metadataSection && loadingMeta) ||
-    filterDependencyMissing(key);
+
   return {
     data,
     pageCount: dataLength ? dataLength / DATA_EXPLORER_PER_PAGE : 0,
     initialPage: search.page && parseInt(search.page, 10) - 1,
     meta,
     metadataSection: !!location.hash && location.hash === '#meta',
-    isDisabled,
     firstColumnHeaders: getFirstTableHeaders(dataState),
     href: getLink(dataState),
     sectionLabel: getSectionLabel(dataState),
     downloadHref,
-    filters: DATA_EXPLORER_FILTERS[section],
-    filterOptions: getDependentOptions(dataState),
-    selectedOptions,
     anchorLinks,
     query: location.search,
     filterQuery,
     parsedExternalParams: parseExternalParams(dataState),
-    activeFilterRegion: getActiveFilterRegion(dataState),
     titleLinks: getTitleLinks(dataState),
     search,
     loading,
     loadingMeta
   };
-};
-
-const getDependentKeysToDelete = (value, section, filterName) => {
-  const dependentKeysToDelete = [];
-  if (DATA_EXPLORER_DEPENDENCIES[section]) {
-    Object.keys(
-      DATA_EXPLORER_DEPENDENCIES[section]
-    ).forEach(dependentFilterKey => {
-      const parentFilterKeys =
-        DATA_EXPLORER_DEPENDENCIES[section][dependentFilterKey];
-      if (parentFilterKeys.includes(filterName)) {
-        dependentKeysToDelete.push(dependentFilterKey);
-      }
-    });
-  }
-  return dependentKeysToDelete;
 };
 
 const resetPageParam = {
@@ -162,70 +124,6 @@ class DataExplorerContentContainer extends PureComponent {
     }));
     this.updateUrlParam(paramsToUpdate, true);
   }
-
-  sourceAndVersionParam = (value, section) => {
-    const values = value && value.split(' - ');
-    return [
-      {
-        name: `${section}-data-sources`,
-        value: value && values[0]
-      },
-      {
-        name: `${section}-gwps`,
-        value: value && values[1]
-      }
-    ];
-  };
-
-  parsedMultipleValues = (filterName, value) => {
-    const { selectedOptions } = this.props;
-    const oldFilters = selectedOptions[filterName];
-    const removing = oldFilters && value.length < oldFilters.length;
-    const selectedFilter = !oldFilters
-      ? value[0]
-      : value
-        .filter(x => oldFilters.indexOf(x) === -1)
-        .concat(oldFilters.filter(x => value.indexOf(x) === -1))[0];
-    const filtersParam = [];
-    if (!removing && selectedFilter.groupId === 'regions') {
-      filtersParam.push(selectedFilter.value);
-      selectedFilter.members.forEach(m => filtersParam.push(m.iso_code3));
-    } else {
-      value.forEach(filter => {
-        if (filter.groupId !== 'regions') {
-          filtersParam.push(filter.value);
-        }
-      });
-    }
-    return filtersParam.toString();
-  };
-
-  handleFilterChange = (filterName, value, multiple) => {
-    const { section } = this.props;
-    const SOURCE_AND_VERSION_KEY = 'source';
-    let paramsToUpdate = [];
-    const dependentKeysToDeleteParams = getDependentKeysToDelete(
-      value,
-      section,
-      filterName
-    ).map(k => ({ name: `${section}-${k}`, value: undefined }));
-    let parsedValue = value;
-    if (multiple) parsedValue = this.parsedMultipleValues(filterName, value);
-    parsedValue = parsedValue === '' ? undefined : parsedValue;
-    if (filterName === SOURCE_AND_VERSION_KEY) {
-      paramsToUpdate = paramsToUpdate.concat(
-        this.sourceAndVersionParam(value, section)
-      );
-    } else {
-      paramsToUpdate.push({
-        name: `${section}-${filterName}`,
-        value: parsedValue
-      });
-    }
-    this.updateUrlParam(
-      paramsToUpdate.concat(resetPageParam).concat(dependentKeysToDeleteParams)
-    );
-  };
 
   handlePageChange = page => {
     this.updateUrlParam({ name: 'page', value: page.selected + 1 });
@@ -274,8 +172,7 @@ DataExplorerContentContainer.propTypes = {
   location: PropTypes.object,
   downloadHref: PropTypes.string,
   setModalDownloadParams: PropTypes.func,
-  search: PropTypes.object,
-  selectedOptions: PropTypes.object
+  search: PropTypes.object
 };
 
 export default withRouter(

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Dropdown from 'components/dropdown';
 import MultiDropdown from 'components/dropdown/multi-dropdown';
 import MultiSelect from 'components/multiselect';
-import { toStartCase, deburrCapitalize } from 'app/utils';
+import { deburrCapitalize } from 'app/utils';
 import {
   MULTIPLE_LEVEL_SECTION_FIELDS,
   GROUPED_SELECT_FIELDS,
@@ -12,6 +12,33 @@ import {
 
 class DataExplorerFilters extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
+
+  renderDropdown(field, isColumnField) {
+    const {
+      handleFilterChange,
+      selectedOptions,
+      filterOptions,
+      isDisabled
+    } = this.props;
+
+    const value = isColumnField
+      ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
+      : selectedOptions && selectedOptions[field];
+    return (
+      <Dropdown
+        key={field}
+        label={deburrCapitalize(field)}
+        placeholder={`Filter by ${deburrCapitalize(field)}`}
+        options={(filterOptions && filterOptions[field]) || []}
+        onValueChange={selected =>
+          handleFilterChange(field, selected && selected.value)}
+        value={value || null}
+        plain
+        disabled={isDisabled(field)}
+        noAutoSort={field === 'goals' || field === 'targets'}
+      />
+    );
+  }
 
   render() {
     const {
@@ -69,44 +96,16 @@ class DataExplorerFilters extends PureComponent {
           />
         );
       }
-      return (
-        <Dropdown
-          key={field}
-          label={deburrCapitalize(field)}
-          placeholder={`Filter by ${deburrCapitalize(field)}`}
-          options={(filterOptions && filterOptions[field]) || []}
-          onValueChange={selected =>
-            handleFilterChange(field, selected && selected.value)}
-          value={
-            (selectedOptions &&
-              selectedOptions[field] &&
-              selectedOptions[field][0]) ||
-            null
-          }
-          plain
-          disabled={isDisabled(field)}
-          noAutoSort={field === 'goals' || field === 'targets'}
-        />
-      );
+      return this.renderDropdown(field, true);
     });
     const hasYearFilters =
       section === SECTION_NAMES.historicalEmissions ||
       section === SECTION_NAMES.pathways;
     const yearFilters =
       hasYearFilters &&
-      ['start_year', 'end_year'].map(field => (
-        <Dropdown
-          key={field}
-          label={toStartCase(field)}
-          placeholder={`Filter by ${toStartCase(field)}`}
-          options={(filterOptions && filterOptions[field]) || []}
-          onValueChange={selected =>
-            handleFilterChange(field, selected && selected.value)}
-          value={(selectedOptions && selectedOptions[field]) || null}
-          plain
-          disabled={isDisabled(field)}
-        />
-      ));
+      ['start_year', 'end_year'].map(field =>
+        this.renderDropdown(field, false)
+      );
     return yearFilters ? fieldFilters.concat(yearFilters) : fieldFilters;
   }
 }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -1,0 +1,124 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Dropdown from 'components/dropdown';
+import MultiDropdown from 'components/dropdown/multi-dropdown';
+import MultiSelect from 'components/multiselect';
+import { toStartCase, deburrCapitalize } from 'app/utils';
+import {
+  MULTIPLE_LEVEL_SECTION_FIELDS,
+  GROUPED_SELECT_FIELDS,
+  SECTION_NAMES
+} from 'data/data-explorer-constants';
+
+class DataExplorerFilters extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+
+  render() {
+    const {
+      handleFilterChange,
+      selectedOptions,
+      filterOptions,
+      filters,
+      section,
+      activeFilterRegion,
+      isDisabled
+    } = this.props;
+
+    const multipleSection = field =>
+      MULTIPLE_LEVEL_SECTION_FIELDS[section] &&
+      MULTIPLE_LEVEL_SECTION_FIELDS[section].find(s => s.key === field);
+    const groupedSelect = field =>
+      GROUPED_SELECT_FIELDS[section] &&
+      GROUPED_SELECT_FIELDS[section].find(s => s.key === field);
+    const fieldFilters = filters.map(field => {
+      if (multipleSection(field)) {
+        return (
+          <MultiDropdown
+            key={field}
+            label={deburrCapitalize(field)}
+            placeholder={`Filter by ${deburrCapitalize(field)}`}
+            options={filterOptions ? filterOptions[field] : []}
+            value={
+              selectedOptions ? (
+                selectedOptions[field] && selectedOptions[field][0]
+              ) : null
+            }
+            disabled={isDisabled(field)}
+            clearable
+            onChange={option =>
+              handleFilterChange(field, option && option.value)}
+            noParentSelection={multipleSection(field).noSelectableParent}
+          />
+        );
+      } else if (groupedSelect(field)) {
+        const fieldInfo = GROUPED_SELECT_FIELDS[section].find(
+          f => f.key === field
+        );
+        return (
+          <MultiSelect
+            key={field}
+            label={fieldInfo.label}
+            selectedLabel={activeFilterRegion}
+            placeholder={`Filter by ${fieldInfo.label}`}
+            values={(selectedOptions && selectedOptions[field]) || []}
+            options={filterOptions ? filterOptions[field] : []}
+            groups={fieldInfo.groups}
+            disabled={isDisabled(field)}
+            onMultiValueChange={selected =>
+              handleFilterChange(field, selected, true)}
+          />
+        );
+      }
+      return (
+        <Dropdown
+          key={field}
+          label={deburrCapitalize(field)}
+          placeholder={`Filter by ${deburrCapitalize(field)}`}
+          options={(filterOptions && filterOptions[field]) || []}
+          onValueChange={selected =>
+            handleFilterChange(field, selected && selected.value)}
+          value={
+            (selectedOptions &&
+              selectedOptions[field] &&
+              selectedOptions[field][0]) ||
+            null
+          }
+          plain
+          disabled={isDisabled(field)}
+          noAutoSort={field === 'goals' || field === 'targets'}
+        />
+      );
+    });
+    const hasYearFilters =
+      section === SECTION_NAMES.historicalEmissions ||
+      section === SECTION_NAMES.pathways;
+    const yearFilters =
+      hasYearFilters &&
+      ['start_year', 'end_year'].map(field => (
+        <Dropdown
+          key={field}
+          label={toStartCase(field)}
+          placeholder={`Filter by ${toStartCase(field)}`}
+          options={(filterOptions && filterOptions[field]) || []}
+          onValueChange={selected =>
+            handleFilterChange(field, selected && selected.value)}
+          value={(selectedOptions && selectedOptions[field]) || null}
+          plain
+          disabled={isDisabled(field)}
+        />
+      ));
+    return yearFilters ? fieldFilters.concat(yearFilters) : fieldFilters;
+  }
+}
+
+DataExplorerFilters.propTypes = {
+  activeFilterRegion: PropTypes.string,
+  section: PropTypes.string.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.func.isRequired,
+  filters: PropTypes.array,
+  selectedOptions: PropTypes.object,
+  filterOptions: PropTypes.object
+};
+
+export default DataExplorerFilters;

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -1,0 +1,165 @@
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import { PureComponent, createElement } from 'react';
+import { getSearch, getLocationParamUpdated } from 'utils/navigation';
+import { PropTypes } from 'prop-types';
+import { actions } from 'components/modal-download';
+import {
+  DATA_EXPLORER_FILTERS,
+  DATA_EXPLORER_DEPENDENCIES
+} from 'data/data-explorer-constants';
+import DataExplorerFiltersComponent from './data-explorer-filters-component';
+import {
+  getActiveFilterRegion,
+  addYearOptions,
+  getSelectedOptions
+} from '../data-explorer-content-selectors';
+
+const mapStateToProps = (state, { section, location }) => {
+  const search = getSearch(location);
+  const dataState = {
+    data: state.dataExplorer && state.dataExplorer.data,
+    countries: state.countries && state.countries.data,
+    regions: state.regions && state.regions.data,
+    meta: state.dataExplorer && state.dataExplorer.metadata,
+    section,
+    search
+  };
+  const hasFetchedData =
+    state.dataExplorer &&
+    state.dataExplorer.data &&
+    state.dataExplorer.data[section];
+  const metadataSection = !!location.hash && location.hash === '#meta';
+  const loading =
+    (state.dataExplorer && state.dataExplorer.loading) || !hasFetchedData;
+  const loadingMeta = state.dataExplorer && state.dataExplorer.loadingMeta;
+  const selectedOptions = getSelectedOptions(dataState);
+  const filterDependencyMissing = key =>
+    DATA_EXPLORER_DEPENDENCIES[section] &&
+    DATA_EXPLORER_DEPENDENCIES[section][key] &&
+    selectedOptions &&
+    !DATA_EXPLORER_DEPENDENCIES[section][key].every(k =>
+      Object.keys(selectedOptions).includes(k)
+    );
+  const isDisabled = key =>
+    (!metadataSection && loading) ||
+    (metadataSection && loadingMeta) ||
+    filterDependencyMissing(key);
+  return {
+    isDisabled,
+    filters: DATA_EXPLORER_FILTERS[section],
+    filterOptions: addYearOptions(dataState),
+    selectedOptions,
+    activeFilterRegion: getActiveFilterRegion(dataState)
+  };
+};
+
+const getDependentKeysToDelete = (value, section, filterName) => {
+  const dependentKeysToDelete = [];
+  if (DATA_EXPLORER_DEPENDENCIES[section]) {
+    Object.keys(
+      DATA_EXPLORER_DEPENDENCIES[section]
+    ).forEach(dependentFilterKey => {
+      const parentFilterKeys =
+        DATA_EXPLORER_DEPENDENCIES[section][dependentFilterKey];
+      if (parentFilterKeys.includes(filterName)) {
+        dependentKeysToDelete.push(dependentFilterKey);
+      }
+    });
+  }
+  return dependentKeysToDelete;
+};
+
+const resetPageParam = {
+  name: 'page',
+  value: 1
+};
+
+class DataExplorerContentContainer extends PureComponent {
+  sourceAndVersionParam = (value, section) => {
+    const values = value && value.split(' - ');
+    return [
+      {
+        name: `${section}-data-sources`,
+        value: value && values[0]
+      },
+      {
+        name: `${section}-gwps`,
+        value: value && values[1]
+      }
+    ];
+  };
+
+  parsedMultipleValues = (filterName, value) => {
+    const { selectedOptions } = this.props;
+    const oldFilters = selectedOptions[filterName];
+    const removing = oldFilters && value.length < oldFilters.length;
+    const selectedFilter = !oldFilters
+      ? value[0]
+      : value
+        .filter(x => oldFilters.indexOf(x) === -1)
+        .concat(oldFilters.filter(x => value.indexOf(x) === -1))[0];
+    const filtersParam = [];
+    if (!removing && selectedFilter.groupId === 'regions') {
+      filtersParam.push(selectedFilter.value);
+      selectedFilter.members.forEach(m => filtersParam.push(m.iso_code3));
+    } else {
+      value.forEach(filter => {
+        if (filter.groupId !== 'regions') {
+          filtersParam.push(filter.value);
+        }
+      });
+    }
+    return filtersParam.toString();
+  };
+
+  handleFilterChange = (filterName, value, multiple) => {
+    const { section } = this.props;
+    const SOURCE_AND_VERSION_KEY = 'source';
+    let paramsToUpdate = [];
+    const dependentKeysToDeleteParams = getDependentKeysToDelete(
+      value,
+      section,
+      filterName
+    ).map(k => ({ name: `${section}-${k}`, value: undefined }));
+    let parsedValue = value;
+    if (multiple) parsedValue = this.parsedMultipleValues(filterName, value);
+    parsedValue = parsedValue === '' ? undefined : parsedValue;
+    if (filterName === SOURCE_AND_VERSION_KEY) {
+      paramsToUpdate = paramsToUpdate.concat(
+        this.sourceAndVersionParam(value, section)
+      );
+    } else {
+      paramsToUpdate.push({
+        name: `${section}-${filterName}`,
+        value: parsedValue
+      });
+    }
+    this.updateUrlParam(
+      paramsToUpdate.concat(resetPageParam).concat(dependentKeysToDeleteParams)
+    );
+  };
+
+  updateUrlParam(params, clear) {
+    const { history, location } = this.props;
+    history.replace(getLocationParamUpdated(location, params, clear));
+  }
+
+  render() {
+    return createElement(DataExplorerFiltersComponent, {
+      ...this.props,
+      handleFilterChange: this.handleFilterChange
+    });
+  }
+}
+
+DataExplorerContentContainer.propTypes = {
+  section: PropTypes.string,
+  history: PropTypes.object,
+  location: PropTypes.object,
+  selectedOptions: PropTypes.object
+};
+
+export default withRouter(
+  connect(mapStateToProps, actions)(DataExplorerContentContainer)
+);

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -58,7 +58,13 @@ const mapStateToProps = (state, { location }) => {
   ];
   const filtersSelected = getFiltersSelected(espData);
   const downloadFilters = {};
-  ['model', 'category', 'indicator', 'currentLocation'].forEach(f => {
+  [
+    'model',
+    'category',
+    'subcategory',
+    'indicator',
+    'currentLocation'
+  ].forEach(f => {
     if (search[f] && search[f] !== '') downloadFilters[f] = search[f];
   });
   return {
@@ -100,7 +106,13 @@ class EmissionPathwayGraphContainer extends PureComponent {
     }
 
     const { search, filtersSelected } = this.props;
-    ['model', 'category', 'indicator', 'currentLocation'].forEach(f => {
+    [
+      'model',
+      'category',
+      'subcategory',
+      'indicator',
+      'currentLocation'
+    ].forEach(f => {
       if (!search[f] && filtersSelected[f]) {
         this.updateUrlParam({ name: f, value: filtersSelected[f].value });
       }

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -7,17 +7,17 @@ export const DATA_EXPLORER_BLACKLIST = [
 export const DATA_EXPLORER_FIRST_TABLE_HEADERS = [
   'region',
   'data_source',
-  'gwp',
   'sector',
+  'gwp',
   'gas',
+  'unit',
   'location',
   'model',
   'scenario',
   'category',
   'subcategory',
   'indicator',
-  'definition',
-  'unit'
+  'definition'
 ];
 
 export const DATA_EXPLORER_SECTIONS = {
@@ -51,8 +51,8 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
 };
 
 export const DATA_EXPLORER_FILTERS = {
-  'historical-emissions': ['source', 'gases', 'regions', 'sectors'],
-  'ndc-sdg-linkages': ['goals', 'targets', 'sectors', 'countries'],
+  'historical-emissions': ['regions', 'source', 'sectors', 'gases'],
+  'ndc-sdg-linkages': ['countries', 'goals', 'targets', 'sectors'],
   'emission-pathways': [
     'locations',
     'models',
@@ -61,7 +61,7 @@ export const DATA_EXPLORER_FILTERS = {
     'subcategories',
     'indicators'
   ],
-  'ndc-content': ['categories', 'indicators', 'sectors', 'countries']
+  'ndc-content': ['countries', 'categories', 'indicators', 'sectors']
 };
 
 export const DATA_EXPLORER_DEPENDENCIES = {

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -125,7 +125,7 @@ export const GROUPED_SELECT_FIELDS = {
   ]
 };
 
-export const DATA_EXPLORER_PER_PAGE = 20;
+export const DATA_EXPLORER_PER_PAGE = 200;
 
 export const SECTION_NAMES = {
   pathways: 'emission-pathways',
@@ -189,6 +189,7 @@ export const FILTERED_FIELDS = {
     ]
   }
 };
+export const NON_COLUMN_KEYS = ['start_year', 'end_year'];
 
 export const POSSIBLE_LABEL_FIELDS = [
   'name',

--- a/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
+++ b/app/javascript/app/providers/data-explorer-provider/data-explorer-provider-actions.js
@@ -55,7 +55,8 @@ export const fetchDataExplorer = createThunkAction(
             if (response.ok) {
               return {
                 total: response.headers.get('Total'),
-                data: json.data
+                data: json.data,
+                meta: json.meta
               };
             }
             throw Error(response.statusText);

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -11,7 +11,8 @@ import capitalize from 'lodash/capitalize';
 export const assign = (o, ...rest) => Object.assign({}, o, ...rest);
 
 export const deburrUpper = string => toUpper(deburr(string));
-export const deburrCapitalize = string => capitalize(deburr(string));
+export const deburrCapitalize = string =>
+  capitalize(deburr(string)).replace('_', ' ');
 export const toStartCase = string => {
   const parsedString = startCase(string);
   const replacements = {


### PR DESCRIPTION
This PR branches from fix/data-explorer-historical-regions-to-countries
The first commit is 0bee144 Change per page to 200

- Add the start_year and end year filters
- Changes the order of the displayed columns: https://www.pivotaltracker.com/story/show/159760423
- Changes the per page to 200: https://www.pivotaltracker.com/story/show/159760381

![image](https://user-images.githubusercontent.com/9701591/44106451-029f9940-9ff5-11e8-898a-3f6d5e207eb9.png)

Extra: 
  - Extract filters part to component and refactor (Next step could be to extract the selectors to a different file)
- In the Pathways module get the subcategories to the URL and parse them to the data explorer through the download button
![image](https://user-images.githubusercontent.com/9701591/44204142-d1dacb00-a151-11e8-9e72-8f0ccc50f04b.png)

Note: There is a bug right now. If we select a start or end year and we try to select again, the options will be limited to the ones the selected data has unless we clear the dropdown. I'm waiting for the backend team to give a fast solution for this. Other option will be to do an extra fetch with the current filters except the year-related ones.