### PR TITLE
Fix getCustomTicks function to process quantification pair values

### DIFF
--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -3,6 +3,7 @@ import camelCase from 'lodash/camelCase';
 import chroma from 'chroma-js';
 import minBy from 'lodash/minBy';
 import maxBy from 'lodash/maxBy';
+import isArray from 'lodash/isArray';
 import { getNiceTickValues } from 'recharts-scale';
 import map from 'lodash/map';
 import find from 'lodash/find';
@@ -123,17 +124,16 @@ export function getCustomTicks(
 ) {
   const totalValues = [];
   const yValues = columns.y.map(c => data.map(d => d[[c.value]]));
+  const getSign = value => (value > 0 ? 'positive' : 'negative');
   for (let index = 0; index < yValues[0].length; index++) {
     const total = {
       positive: 0,
       negative: 0
     };
     for (let e = 0; e < yValues.length; e++) {
-      if (yValues[e][index] > 0) {
-        total.positive += yValues[e][index] || 0;
-      } else {
-        total.negative += yValues[e][index] || 0;
-      }
+      let value = yValues[e][index];
+      if (isArray(value)) value = value[1]; // Take the biggest value of the quantification pair
+      total[getSign(value)] += value || 0;
     }
     totalValues.push(total);
   }


### PR DESCRIPTION
This PR fixes the ticks on the y axis that were not taking into account the Values of the quantifications. Now the sum is correct so the real max number is displayed. Be aware that there is a buffer that is showing a range below and above the max and min values.

Try: http://localhost:3000/countries/IND

Before:
![image](https://user-images.githubusercontent.com/9701591/44223351-ae327780-a187-11e8-83c7-1fbfa8a13961.png)
After:
![image](https://user-images.githubusercontent.com/9701591/44223331-a1158880-a187-11e8-81b7-3322d62be1c8.png)
