### PR TITLE
Fix/data explorer regions dropdown

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -3,7 +3,6 @@ import remove from 'lodash/remove';
 import isEmpty from 'lodash/isEmpty';
 import isArray from 'lodash/isArray';
 import pick from 'lodash/pick';
-import snakeCase from 'lodash/snakeCase';
 import qs from 'query-string';
 import { findEqual, isANumber } from 'utils/utils';
 import sortBy from 'lodash/sortBy';
@@ -249,26 +248,6 @@ const addGroupId = (object, groupId) =>
     return updatedRegion;
   });
 
-const getExtraOptionFields = option => {
-  const extraOptionKeys = [
-    'slug',
-    'groupId',
-    'dataSourceId',
-    'dataSourceSlug',
-    'versionId',
-    'versionSlug',
-    'goal_id'
-  ];
-  const extraOptions = {};
-  extraOptionKeys.forEach(k => {
-    const existingValue = option[snakeCase(k)] || option[k];
-    if (existingValue) {
-      extraOptions[k] = existingValue;
-    }
-  });
-  return extraOptions;
-};
-
 const getLabel = (option, filterKey) => {
   const labelField = POSSIBLE_LABEL_FIELDS.find(field => option[field]);
   let label = option[labelField];
@@ -316,7 +295,7 @@ export const getFilterOptions = createSelector(
             (option.id && String(option.id)) ||
             (option.dataSourceId &&
               `${option.dataSourceId}-${option.versionId}`);
-          return { value, label, ...getExtraOptionFields(option) };
+          return { ...option, value, label };
         });
         filterOptions[f] = optionsArray;
       }
@@ -524,11 +503,11 @@ export const getDependentOptions = createSelector(
               : i[idLabelToFilterBy];
 
             if (isArray(id)) return id.includes(selectedId);
-            id = String(id);
+            id = parseInt(id, 10);
 
             return isArray(selectedId)
               ? selectedId.includes(id)
-              : id === selectedId;
+              : id === parseInt(selectedId, 10);
           });
         });
       }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -614,12 +614,13 @@ export const getSelectedOptions = createSelector(
         };
       } else {
         selectedOptions[key] = selectedFields[key].map(f => ({
-          value: f.label || f.slug,
+          value: f.value || f.slug,
           label: f.label,
           id: f.iso_code3 || f.id || [f.data_source_id, f.version_id]
         }));
       }
     });
+
     return selectedOptions;
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -81,8 +81,17 @@ class DataExplorerContentContainer extends PureComponent {
     ];
   };
 
-  parsedMultipleValues = (filterName, value) =>
-    value.map(filter => filter.value).toString();
+  parsedMultipleValues = (filterName, value) => {
+    const selectedValue = value[value.length - 1];
+    if (
+      selectedValue &&
+      selectedValue.groupId &&
+      selectedValue.groupId === 'regions'
+    ) {
+      return [selectedValue.value];
+    }
+    return value.map(filter => filter.value).toString();
+  };
 
   handleFilterChange = (filterName, value, multiple) => {
     const { section } = this.props;

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -10,7 +10,7 @@ import {
 } from 'data/data-explorer-constants';
 import DataExplorerFiltersComponent from './data-explorer-filters-component';
 import {
-  getActiveFilterRegion,
+  getActiveFilterLabel,
   addYearOptions,
   getSelectedOptions
 } from '../data-explorer-content-selectors';
@@ -50,7 +50,7 @@ const mapStateToProps = (state, { section, location }) => {
     filters: DATA_EXPLORER_FILTERS[section],
     filterOptions: addYearOptions(dataState),
     selectedOptions,
-    activeFilterRegion: getActiveFilterRegion(dataState)
+    activeFilterRegion: getActiveFilterLabel(dataState)
   };
 };
 
@@ -96,20 +96,12 @@ class DataExplorerContentContainer extends PureComponent {
     const removing = oldFilters && value.length < oldFilters.length;
     const selectedFilter = !oldFilters
       ? value[0]
-      : value
-        .filter(x => oldFilters.indexOf(x) === -1)
-        .concat(oldFilters.filter(x => value.indexOf(x) === -1))[0];
+      : value.filter(f => Object.keys(oldFilters).includes(!f.label));
     const filtersParam = [];
-    if (!removing && selectedFilter.groupId === 'regions') {
-      filtersParam.push(selectedFilter.value);
-      selectedFilter.members.forEach(m => filtersParam.push(m.iso_code3));
-    } else {
-      value.forEach(filter => {
-        if (filter.groupId !== 'regions') {
-          filtersParam.push(filter.value);
-        }
-      });
-    }
+    if (!removing) filtersParam.push(selectedFilter.value);
+    value.forEach(filter => {
+      filtersParam.push(filter.value);
+    });
     return filtersParam.toString();
   };
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -81,19 +81,8 @@ class DataExplorerContentContainer extends PureComponent {
     ];
   };
 
-  parsedMultipleValues = (filterName, value) => {
-    const { selectedOptions } = this.props;
-    const oldFilters = selectedOptions[filterName];
-    const removing = oldFilters && value.length < oldFilters.length;
-    const selectedFilter = !oldFilters
-      ? value[0]
-      : value.filter(f => !oldFilters.map(o => o.label).includes(f.label));
-    const filtersParam = [];
-    value.forEach(filter => {
-      if (!(removing && selectedFilter.value !== filter)) { filtersParam.push(filter.value); }
-    });
-    return filtersParam.toString();
-  };
+  parsedMultipleValues = (filterName, value) =>
+    value.map(filter => filter.value).toString();
 
   handleFilterChange = (filterName, value, multiple) => {
     const { section } = this.props;
@@ -140,8 +129,7 @@ class DataExplorerContentContainer extends PureComponent {
 DataExplorerContentContainer.propTypes = {
   section: PropTypes.string,
   history: PropTypes.object,
-  location: PropTypes.object,
-  selectedOptions: PropTypes.object
+  location: PropTypes.object
 };
 
 export default withRouter(

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -87,11 +87,10 @@ class DataExplorerContentContainer extends PureComponent {
     const removing = oldFilters && value.length < oldFilters.length;
     const selectedFilter = !oldFilters
       ? value[0]
-      : value.filter(f => Object.keys(oldFilters).includes(!f.label));
+      : value.filter(f => !oldFilters.map(o => o.label).includes(f.label));
     const filtersParam = [];
-    if (!removing) filtersParam.push(selectedFilter.value);
     value.forEach(filter => {
-      filtersParam.push(filter.value);
+      if (!(removing && selectedFilter.value !== filter)) { filtersParam.push(filter.value); }
     });
     return filtersParam.toString();
   };
@@ -110,7 +109,6 @@ class DataExplorerContentContainer extends PureComponent {
     const parsedValue = multiple
       ? this.parsedMultipleValues(filterName, value)
       : value;
-
     if (filterName === SOURCE_AND_VERSION_KEY) {
       paramsToUpdate = paramsToUpdate.concat(
         this.sourceAndVersionParam(value, section)

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -282,11 +282,11 @@ export const USERS_PROFESIONAL_SECTORS = [
 ];
 
 export const SOURCE_VERSIONS = [
-  { name: 'PIK - AR2', data_source_slug: 'PIK', version_slug: 'AR2' },
-  { name: 'PIK - AR4', data_source_slug: 'PIK', version_slug: 'AR4' },
-  { name: 'CAIT - AR2', data_source_slug: 'CAIT', version_slug: 'AR2' },
-  { name: 'UNFCCC - AR2', data_source_slug: 'UNFCCC', version_slug: 'AR2' },
-  { name: 'UNFCCC - AR4', data_source_slug: 'UNFCCC', version_slug: 'AR4' }
+  { name: 'PIK - AR2', dataSourceSlug: 'PIK', versionSlug: 'AR2' },
+  { name: 'PIK - AR4', dataSourceSlug: 'PIK', versionSlug: 'AR4' },
+  { name: 'CAIT - AR2', dataSourceSlug: 'CAIT', versionSlug: 'AR2' },
+  { name: 'UNFCCC - AR2', dataSourceSlug: 'UNFCCC', versionSlug: 'AR2' },
+  { name: 'UNFCCC - AR4', dataSourceSlug: 'UNFCCC', versionSlug: 'AR4' }
 ];
 
 export default {

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -154,7 +154,7 @@ export const FILTERED_FIELDS = {
     sectors: [
       {
         parent: 'source',
-        id: 'data_source_id'
+        id: 'dataSourceId'
       }
     ]
   },


### PR DESCRIPTION
The data explorer/ GHG emissions/ Regions and countries dropdown was not working as expected:
- Dots were not appearing in the selected options
- Some strings in the URL were showing the label instead of the value

This was fixed and:
- Now only when we have one region or country selected we show the name as the dropdown label

Important:
- The selection is now cleared when we select a new region to match the GHG dropdown behavior. 
- The link to GHG won't automatically transfer the regions and countries, this will be done in a new PR.

![image](https://user-images.githubusercontent.com/9701591/44351215-a59cb280-a4a1-11e8-9bba-37acbe94d26e.png)
