### PR TITLE
Fix/link to module data explorer

### DIFF
--- a/app/javascript/app/components/button-group/button-group-component.jsx
+++ b/app/javascript/app/components/button-group/button-group-component.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import cx from 'classnames';
-import qs from 'querystring';
 import iconInfo from 'assets/icons/info.svg';
 import iconDownload from 'assets/icons/download.svg';
 import iconAddToUser from 'assets/icons/add-to-user.svg';
@@ -10,16 +9,8 @@ import iconEdit from 'assets/icons/edit.svg';
 import iconDelete from 'assets/icons/delete.svg';
 import PropTypes from 'prop-types';
 import ShareMenu from 'components/share-menu';
-import { Link } from 'react-router-dom';
-import invertBy from 'lodash/invertBy';
-import {
-  DATA_EXPLORER_SECTIONS,
-  DATA_EXPLORER_TO_MODULES_PARAMS
-} from 'data/data-explorer-constants';
 
 import styles from './button-group-styles.scss';
-
-const FEATURE_DATA_EXPLORER = process.env.FEATURE_DATA_EXPLORER === 'true';
 
 const iconsMap = {
   info: iconInfo,
@@ -29,40 +20,6 @@ const iconsMap = {
   delete: iconDelete
 };
 const renderButton = buttonConfig => {
-  const section = Object.keys(DATA_EXPLORER_SECTIONS).find(
-    k => DATA_EXPLORER_SECTIONS[k].moduleName === buttonConfig.section
-  );
-
-  const parseFilters = filters => {
-    const modulesToDataExplorerParamsSchema = invertBy(
-      DATA_EXPLORER_TO_MODULES_PARAMS[section],
-      value => value.key
-    );
-    const parsedFilters = {};
-    Object.keys(filters).forEach(key => {
-      const parsedKey = `external-${section}-${modulesToDataExplorerParamsSchema[
-        key
-      ]}`.replace('_', '-');
-      parsedFilters[parsedKey] = filters[key];
-    });
-    return parsedFilters;
-  };
-
-  const sectionUrl = buttonConfig.section ? `/${section}` : '';
-  const params = buttonConfig.filters
-    ? `?${qs.stringify(parseFilters(buttonConfig.filters))}`
-    : '';
-  const defaultButton = (
-    <Button
-      key={buttonConfig.type}
-      className={styles.button}
-      onClick={buttonConfig.onClick}
-      disabled={buttonConfig.disabled || !buttonConfig.onClick}
-    >
-      <Icon icon={iconsMap[buttonConfig.type]} />
-    </Button>
-  );
-  const downloadLink = `/data-explorer${sectionUrl}${params}`;
   switch (buttonConfig.type) {
     case 'share':
       return (
@@ -76,21 +33,19 @@ const renderButton = buttonConfig => {
           positionRight={buttonConfig.positionRight}
         />
       );
-    case 'download':
-      return FEATURE_DATA_EXPLORER ? (
-        <Link
+    default:
+      return (
+        <Button
           key={buttonConfig.type}
-          className={cx(styles.button, styles.download)}
+          className={styles.button}
+          onClick={buttonConfig.onClick}
+          link={buttonConfig.link}
+          href={buttonConfig.href}
           disabled={buttonConfig.disabled}
-          to={downloadLink}
         >
           <Icon icon={iconsMap[buttonConfig.type]} />
-        </Link>
-      ) : (
-        defaultButton
+        </Button>
       );
-    default:
-      return defaultButton;
   }
 };
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -106,6 +106,12 @@ const findSelectedValueObject = (meta, selectedId) =>
 
 function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
   const filterIds = {};
+  const subcategories =
+    metadata.categories && metadata.categories.filter(cat => cat.parent_id);
+  // Subcategories are needed on Pathways
+  const metadataWithSubcategories = subcategories
+    ? { ...metadata, subcategories }
+    : metadata;
   Object.keys(parsedFilters).forEach(key => {
     let correctedKey = key;
     if (key === FILTER_NAMES.subcategories && !isLinkQuery) {
@@ -114,10 +120,10 @@ function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
     const parsedKey = correctedKey.replace('-', '_');
     const selectedIds = parsedFilters[key].split(',');
     const filters = [];
-    if (metadata[parsedKey]) {
+    if (metadataWithSubcategories[parsedKey]) {
       selectedIds.forEach(selectedId => {
         const foundSelectedOption = findSelectedValueObject(
-          metadata[parsedKey],
+          metadataWithSubcategories[parsedKey],
           selectedId
         );
         if (foundSelectedOption) filters.push(foundSelectedOption);
@@ -146,6 +152,11 @@ export const getFilterQuery = createSelector(
   (meta, search, section) => filterQueryIds(meta, search, section, false)
 );
 
+export const getLinkFilterQuery = createSelector(
+  [getMeta, getSearch, getSection],
+  (meta, search, section) => filterQueryIds(meta, search, section, true)
+);
+
 export const getNonColumnQuery = createSelector(
   [getSearch, getSection],
   (search, section) => {
@@ -156,11 +167,6 @@ export const getNonColumnQuery = createSelector(
     );
     return removeFiltersPrefix(nonColumnQuery, section);
   }
-);
-
-export const getLinkFilterQuery = createSelector(
-  [getMeta, getSearch, getSection],
-  (meta, search, section) => filterQueryIds(meta, search, section, true)
 );
 
 export const parseFilterQuery = createSelector(

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -54,7 +54,7 @@ class EmissionPathwayGraph extends PureComponent {
       modalData,
       model,
       handleModelChange,
-      link
+      downloadLink
     } = this.props;
     const needsTimeSeries =
       filtersSelected && filtersSelected.location && filtersSelected.model;
@@ -96,7 +96,7 @@ class EmissionPathwayGraph extends PureComponent {
                     {
                       type: 'download',
                       section: 'pathways',
-                      link
+                      link: downloadLink
                     },
                     {
                       type: 'addToUser'
@@ -191,7 +191,7 @@ class EmissionPathwayGraph extends PureComponent {
                 {
                   type: 'download',
                   section: 'pathways',
-                  link
+                  link: downloadLink
                 },
                 {
                   type: 'addToUser'
@@ -220,7 +220,7 @@ EmissionPathwayGraph.propTypes = {
   modalData: PropTypes.array,
   model: PropTypes.object,
   config: PropTypes.object,
-  link: PropTypes.string,
+  downloadLink: PropTypes.string,
   loading: PropTypes.bool,
   error: PropTypes.bool,
   filtersLoading: PropTypes.object,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -54,7 +54,7 @@ class EmissionPathwayGraph extends PureComponent {
       modalData,
       model,
       handleModelChange,
-      downloadFilters
+      link
     } = this.props;
     const needsTimeSeries =
       filtersSelected && filtersSelected.location && filtersSelected.model;
@@ -96,7 +96,7 @@ class EmissionPathwayGraph extends PureComponent {
                     {
                       type: 'download',
                       section: 'pathways',
-                      filters: downloadFilters
+                      link
                     },
                     {
                       type: 'addToUser'
@@ -191,7 +191,7 @@ class EmissionPathwayGraph extends PureComponent {
                 {
                   type: 'download',
                   section: 'pathways',
-                  filters: downloadFilters
+                  link
                 },
                 {
                   type: 'addToUser'
@@ -220,7 +220,7 @@ EmissionPathwayGraph.propTypes = {
   modalData: PropTypes.array,
   model: PropTypes.object,
   config: PropTypes.object,
-  downloadFilters: PropTypes.object,
+  link: PropTypes.string,
   loading: PropTypes.bool,
   error: PropTypes.bool,
   filtersLoading: PropTypes.object,

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -579,29 +579,26 @@ export const getLinkToDataExplorer = createSelector(
   [getSearch, getScenarios],
   (search, scenarios) => {
     const section = 'emission-pathways';
-    const dataExplorerFilters = {};
-    [
-      'model',
-      'category',
-      'subcategory',
-      'indicator',
-      'currentLocation'
-    ].forEach(f => {
-      if (search[f] && search[f] !== '') dataExplorerFilters[f] = search[f];
-    });
-    if (search.model && scenarios.length) {
+    if (!scenarios.length) return null;
+    if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
-      // Data Downloader dropdown and table
+      // Data Downloader dropdown and table in case there's no scenario selected
       const scenarioId = scenarios.find(
-        s => s.model.id === parseInt(dataExplorerFilters.model, 10)
+        s => s.model.id === parseInt(search.model, 10)
       ).id;
       const filtersWithScenario = {
-        ...dataExplorerFilters,
+        ...search,
         scenario: scenarioId
       };
       return generateLinkToDataExplorer(filtersWithScenario, section);
     }
-    return generateLinkToDataExplorer(dataExplorerFilters, section);
+    // Selects the first scenario to allow a valid selection on the data explorer
+    // Once Data Explorer scenario dropdown is multiselect this logic could be changed
+    const filtersWithFirstScenario = {
+      ...search,
+      scenario: search.scenario.split(',')[0]
+    };
+    return generateLinkToDataExplorer(filtersWithFirstScenario, section);
   }
 );
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -582,7 +582,7 @@ export const getLinkToDataExplorer = createSelector(
     if (!scenarios.length) return null;
     if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
-      // Data Downloader dropdown and table in case there's no scenario selected
+      // Data Explorer dropdown and table in case there's no scenario selected
       const scenarioId = scenarios.find(
         s => s.model.id === parseInt(search.model, 10)
       ).id;

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -591,6 +591,8 @@ export const getLinkToDataExplorer = createSelector(
         scenario: scenarioId
       };
       return generateLinkToDataExplorer(filtersWithScenario, section);
+    } else if (!search.scenario) {
+      return generateLinkToDataExplorer(search, section);
     }
     // Selects the first scenario to allow a valid selection on the data explorer
     // Once Data Explorer scenario dropdown is multiselect this logic could be changed

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -15,6 +15,8 @@ import {
   setChartColors
 } from 'utils/graphs';
 
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
+
 import {
   ESP_BLACKLIST,
   CHART_COLORS,
@@ -43,6 +45,8 @@ const DEFAULT_SELECTIONS = {
   },
   indicator: 'CO2'
 };
+
+const getSearch = state => state.search || null;
 
 // meta data for selectors
 const getLocations = state => state.locations || null;
@@ -569,6 +573,36 @@ export const getModalData = createSelector(
     parseObjectsInIndicators
   ],
   (model, scenarios, indicator) => [model, scenarios, indicator]
+);
+
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getScenarios],
+  (search, scenarios) => {
+    const section = 'emission-pathways';
+    const dataExplorerFilters = {};
+    [
+      'model',
+      'category',
+      'subcategory',
+      'indicator',
+      'currentLocation'
+    ].forEach(f => {
+      if (search[f] && search[f] !== '') dataExplorerFilters[f] = search[f];
+    });
+    if (search.model && scenarios.length) {
+      // Adds the first scenario belonging to the selected model to populate
+      // Data Downloader dropdown and table
+      const scenarioId = scenarios.find(
+        s => s.model.id === parseInt(dataExplorerFilters.model, 10)
+      ).id;
+      const filtersWithScenario = {
+        ...dataExplorerFilters,
+        scenario: scenarioId
+      };
+      return generateLinkToDataExplorer(filtersWithScenario, section);
+    }
+    return generateLinkToDataExplorer(dataExplorerFilters, section);
+  }
 );
 
 export default {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -98,27 +98,34 @@ class EmissionPathwayGraphContainer extends PureComponent {
     }
 
     const { search, filtersSelected } = this.props;
-    [
+    this.updateUrlWithNewParams(search, filtersSelected);
+  }
+
+  updateUrlWithNewParams = (search, filtersSelected) => {
+    const possibleParams = [
       'model',
       'category',
       'subcategory',
       'indicator',
       'currentLocation'
-    ].forEach(f => {
+    ];
+    const paramsToUpdate = [];
+    possibleParams.forEach(f => {
       if (!search[f]) {
         if (f === 'currentLocation' && filtersSelected.location) {
-          this.updateUrlParam({
+          paramsToUpdate.push({
             name: f,
             value:
               (filtersSelected[f] && filtersSelected[f].value) ||
               filtersSelected.location.value
           });
         } else if (f !== 'currentLocation' && filtersSelected[f]) {
-          this.updateUrlParam({ name: f, value: filtersSelected[f].value });
+          paramsToUpdate.push({ name: f, value: filtersSelected[f].value });
         }
       }
     });
-  }
+    if (paramsToUpdate.length) this.updateUrlParam(paramsToUpdate);
+  };
 
   handleModelChange = model => {
     const { location } = this.props.filtersSelected;

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -18,7 +18,8 @@ import {
   getFiltersOptions,
   getFiltersSelected,
   getModalData,
-  getModelSelected
+  getModelSelected,
+  getLinkToDataExplorer
 } from './emission-pathways-graph-selectors';
 
 const actions = { ...ownActions, ...modalActions };
@@ -46,7 +47,8 @@ const mapStateToProps = (state, { location }) => {
     indicator,
     scenario,
     category,
-    subcategory
+    subcategory,
+    search
   };
   const providers = [
     'espTimeSeries',
@@ -57,16 +59,6 @@ const mapStateToProps = (state, { location }) => {
     'espGraph'
   ];
   const filtersSelected = getFiltersSelected(espData);
-  const downloadFilters = {};
-  [
-    'model',
-    'category',
-    'subcategory',
-    'indicator',
-    'currentLocation'
-  ].forEach(f => {
-    if (search[f] && search[f] !== '') downloadFilters[f] = search[f];
-  });
   return {
     data: getChartData(espData),
     domain: getChartDomainWithYMargins(espData),
@@ -84,7 +76,7 @@ const mapStateToProps = (state, { location }) => {
     error: providers.some(p => state[p].error),
     loading: providers.some(p => state[p].loading) || !filtersSelected.model,
     search,
-    downloadFilters
+    link: getLinkToDataExplorer(espData)
   };
 };
 
@@ -113,8 +105,17 @@ class EmissionPathwayGraphContainer extends PureComponent {
       'indicator',
       'currentLocation'
     ].forEach(f => {
-      if (!search[f] && filtersSelected[f]) {
-        this.updateUrlParam({ name: f, value: filtersSelected[f].value });
+      if (!search[f]) {
+        if (f === 'currentLocation' && filtersSelected.location) {
+          this.updateUrlParam({
+            name: f,
+            value:
+              (filtersSelected[f] && filtersSelected[f].value) ||
+              filtersSelected.location.value
+          });
+        } else if (f !== 'currentLocation' && filtersSelected[f]) {
+          this.updateUrlParam({ name: f, value: filtersSelected[f].value });
+        }
       }
     });
   }

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph.js
@@ -76,7 +76,7 @@ const mapStateToProps = (state, { location }) => {
     error: providers.some(p => state[p].error),
     loading: providers.some(p => state[p].loading) || !filtersSelected.model,
     search,
-    link: getLinkToDataExplorer(espData)
+    downloadLink: getLinkToDataExplorer(espData)
   };
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -36,7 +36,7 @@ class GhgEmissions extends PureComponent {
       providerFilters,
       loading,
       activeFilterRegion,
-      search
+      link
     } = this.props;
 
     const renderButtonGroup = () => (
@@ -56,7 +56,7 @@ class GhgEmissions extends PureComponent {
           {
             type: 'download',
             section: 'ghg-emissions',
-            filters: search
+            link
           },
           {
             type: 'addToUser'
@@ -145,7 +145,7 @@ GhgEmissions.propTypes = {
   handleFilterChange: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   activeFilterRegion: PropTypes.object,
-  search: PropTypes.object
+  link: PropTypes.string
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -36,7 +36,7 @@ class GhgEmissions extends PureComponent {
       providerFilters,
       loading,
       activeFilterRegion,
-      link
+      downloadLink
     } = this.props;
 
     const renderButtonGroup = () => (
@@ -56,7 +56,7 @@ class GhgEmissions extends PureComponent {
           {
             type: 'download',
             section: 'ghg-emissions',
-            link
+            link: downloadLink
           },
           {
             type: 'addToUser'
@@ -145,7 +145,7 @@ GhgEmissions.propTypes = {
   handleFilterChange: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   activeFilterRegion: PropTypes.object,
-  link: PropTypes.string
+  downloadLink: PropTypes.string
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors.js
@@ -5,6 +5,7 @@ import union from 'lodash/union';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
 import { getGhgEmissionDefaults } from 'utils/ghg-emissions';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import {
   getYColumnValue,
   getThemeConfig,
@@ -48,6 +49,7 @@ const getRegions = state => state.regions || null;
 const getVersions = state => (state.meta && state.meta.gwp) || null;
 
 // values from search
+const getSearch = state => state.search || null;
 const getSourceSelection = state => state.search.source || null;
 const getVersionSelection = state => state.search.version || null;
 const getBreakSelection = state => state.search.breakBy || null;
@@ -359,6 +361,11 @@ export const getProviderFilters = createSelector(
     };
   }
 );
+
+export const getLinkToDataExplorer = createSelector([getSearch], search => {
+  const section = 'historical-emissions';
+  return generateLinkToDataExplorer(search, section);
+});
 
 export default {
   getSourceOptions,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -63,7 +63,7 @@ const mapStateToProps = (state, { location }) => {
     selectorDefaults: getSelectorDefaults(ghg),
     activeFilterRegion: getActiveFilterRegion(ghg),
     providerFilters: getProviderFilters(ghg),
-    link: getLinkToDataExplorer(ghg),
+    downloadLink: getLinkToDataExplorer(ghg),
     loading: state.ghgEmissionsMeta.loading || state.emissions.loading,
     groups,
     search

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -22,7 +22,8 @@ import {
   getFiltersSelected,
   getSelectorDefaults,
   getProviderFilters,
-  getActiveFilterRegion
+  getActiveFilterRegion,
+  getLinkToDataExplorer
 } from './ghg-emissions-selectors';
 
 const groups = [
@@ -62,6 +63,7 @@ const mapStateToProps = (state, { location }) => {
     selectorDefaults: getSelectorDefaults(ghg),
     activeFilterRegion: getActiveFilterRegion(ghg),
     providerFilters: getProviderFilters(ghg),
+    link: getLinkToDataExplorer(ghg),
     loading: state.ghgEmissionsMeta.loading || state.emissions.loading,
     groups,
     search

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
@@ -58,7 +58,7 @@ class NdcSdgLinkagesMap extends PureComponent {
     this.setState({ country: country.properties });
 
   render() {
-    const { link } = this.props;
+    const { downloadLink } = this.props;
     return (
       <TabletLandscape>
         {isTablet => (
@@ -88,7 +88,7 @@ class NdcSdgLinkagesMap extends PureComponent {
                     {
                       type: 'download',
                       section: 'ndcs-sdg',
-                      link
+                      link: downloadLink
                     },
                     {
                       type: 'addToUser'
@@ -133,7 +133,7 @@ NdcSdgLinkagesMap.propTypes = {
   handleInfoClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   goalSelected: PropTypes.string,
-  link: PropTypes.string
+  downloadLink: PropTypes.string
 };
 
 export default NdcSdgLinkagesMap;

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-component.jsx
@@ -58,7 +58,7 @@ class NdcSdgLinkagesMap extends PureComponent {
     this.setState({ country: country.properties });
 
   render() {
-    const { search } = this.props;
+    const { link } = this.props;
     return (
       <TabletLandscape>
         {isTablet => (
@@ -88,7 +88,7 @@ class NdcSdgLinkagesMap extends PureComponent {
                     {
                       type: 'download',
                       section: 'ndcs-sdg',
-                      filters: search
+                      link
                     },
                     {
                       type: 'addToUser'
@@ -133,7 +133,7 @@ NdcSdgLinkagesMap.propTypes = {
   handleInfoClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   goalSelected: PropTypes.string,
-  search: PropTypes.object
+  link: PropTypes.string
 };
 
 export default NdcSdgLinkagesMap;

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-selectors.js
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map-selectors.js
@@ -2,7 +2,9 @@ import { createSelector } from 'reselect';
 import { scaleLinear } from 'd3-scale';
 import worldPaths from 'app/data/world-50m-paths';
 import { PATH_LAYERS } from 'app/data/constants';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 
+const getSearch = state => state.search || null;
 const getNdcsSdgsGoalsData = state => state.goalsData || null;
 const getGoalSelected = state => state.goalSelected || null;
 const getGoalHover = state => state.goalHover || null;
@@ -88,6 +90,11 @@ export const getPathsWithStyles = createSelector(
     return paths;
   }
 );
+
+export const getLinkToDataExplorer = createSelector([getSearch], search => {
+  const section = 'ndc-sdg-linkages';
+  return generateLinkToDataExplorer(search, section);
+});
 
 export default {
   getPathsWithStyles

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map.js
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map.js
@@ -9,7 +9,8 @@ import { actions as modalActions } from 'components/modal-metadata';
 import NdcSdgLinkagesMapComponent from './ndc-sdg-linkages-map-component';
 import {
   getNdcsSdgsGoalsDataSelected,
-  getPathsWithStyles
+  getPathsWithStyles,
+  getLinkToDataExplorer
 } from './ndc-sdg-linkages-map-selectors';
 
 const mapStateToProps = (state, { location, goalHover, targetHover }) => {
@@ -20,7 +21,8 @@ const mapStateToProps = (state, { location, goalHover, targetHover }) => {
     goalsData,
     goalSelected,
     goalHover,
-    targetHover
+    targetHover,
+    search
   };
   return {
     goal: getNdcsSdgsGoalsDataSelected(data),
@@ -29,7 +31,7 @@ const mapStateToProps = (state, { location, goalHover, targetHover }) => {
     goalSelected,
     goalHover,
     targetHover,
-    search
+    link: getLinkToDataExplorer(data)
   };
 };
 class NdcSdgLinkagesMapContainer extends PureComponent {

--- a/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map.js
+++ b/app/javascript/app/components/ndc-sdg/ndc-sdg-linkages-map/ndc-sdg-linkages-map.js
@@ -31,7 +31,7 @@ const mapStateToProps = (state, { location, goalHover, targetHover }) => {
     goalSelected,
     goalHover,
     targetHover,
-    link: getLinkToDataExplorer(data)
+    downloadLink: getLinkToDataExplorer(data)
   };
 };
 class NdcSdgLinkagesMapContainer extends PureComponent {

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
@@ -25,7 +25,7 @@ const getTooltip = (country, tooltipTxt) => (
   </Link>
 );
 
-const renderButtonGroup = (clickHandler, link) => (
+const renderButtonGroup = (clickHandler, downloadLink) => (
   <ButtonGroup
     className={styles.buttonGroup}
     buttonsConfig={[
@@ -42,7 +42,7 @@ const renderButtonGroup = (clickHandler, link) => (
       {
         type: 'download',
         section: 'ndcs-content',
-        link
+        link: downloadLink
       },
       {
         type: 'addToUser'
@@ -59,7 +59,7 @@ const NDCMap = ({
   loading,
   paths,
   tooltipTxt,
-  link,
+  downloadLink,
   countryData,
   handleIndicatorChange,
   handleCategoryChange,
@@ -88,7 +88,7 @@ const NDCMap = ({
             hideResetButton
             plain
           />
-          {isTablet && renderButtonGroup(handleInfoClick, link)}
+          {isTablet && renderButtonGroup(handleInfoClick, downloadLink)}
         </div>
         {loading && <Loading light className={styles.loader} />}
         <Map
@@ -135,7 +135,7 @@ NDCMap.propTypes = {
   selectedIndicator: PropTypes.object,
   paths: PropTypes.array.isRequired,
   tooltipTxt: PropTypes.string,
-  link: PropTypes.string,
+  downloadLink: PropTypes.string,
   countryData: PropTypes.object,
   handleCountryClick: PropTypes.func.isRequired,
   handleCountryEnter: PropTypes.func.isRequired,

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-component.jsx
@@ -25,7 +25,7 @@ const getTooltip = (country, tooltipTxt) => (
   </Link>
 );
 
-const renderButtonGroup = clickHandler => (
+const renderButtonGroup = (clickHandler, link) => (
   <ButtonGroup
     className={styles.buttonGroup}
     buttonsConfig={[
@@ -41,7 +41,8 @@ const renderButtonGroup = clickHandler => (
       },
       {
         type: 'download',
-        section: 'ndcs-content'
+        section: 'ndcs-content',
+        link
       },
       {
         type: 'addToUser'
@@ -58,6 +59,7 @@ const NDCMap = ({
   loading,
   paths,
   tooltipTxt,
+  link,
   countryData,
   handleIndicatorChange,
   handleCategoryChange,
@@ -86,7 +88,7 @@ const NDCMap = ({
             hideResetButton
             plain
           />
-          {isTablet && renderButtonGroup(handleInfoClick)}
+          {isTablet && renderButtonGroup(handleInfoClick, link)}
         </div>
         {loading && <Loading light className={styles.loader} />}
         <Map
@@ -133,6 +135,7 @@ NDCMap.propTypes = {
   selectedIndicator: PropTypes.object,
   paths: PropTypes.array.isRequired,
   tooltipTxt: PropTypes.string,
+  link: PropTypes.string,
   countryData: PropTypes.object,
   handleCountryClick: PropTypes.func.isRequired,
   handleCountryEnter: PropTypes.func.isRequired,

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -2,10 +2,12 @@ import { createSelector } from 'reselect';
 import { getColorByIndex, createLegendBuckets } from 'utils/map';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import { PATH_LAYERS } from 'app/data/constants';
 
+const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
 const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
@@ -167,6 +169,11 @@ export const getPathsWithStyles = createSelector(
     return paths;
   }
 );
+
+export const getLinkToDataExplorer = createSelector([getSearch], search => {
+  const section = 'ndc-content';
+  return generateLinkToDataExplorer(search, section);
+});
 
 export default {
   getCategories,

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
@@ -19,7 +19,8 @@ import {
   getSelectedCategory,
   getSelectedIndicator,
   getPathsWithStyles,
-  getISOCountries
+  getISOCountries,
+  getLinkToDataExplorer
 } from './ndcs-map-selectors';
 
 const actions = { ...fetchActions, ...modalActions };
@@ -32,7 +33,8 @@ const mapStateToProps = (state, { location }) => {
     ...data,
     countries: countries.data,
     categorySelected: search.category,
-    indicatorSelected: search.indicator
+    indicatorSelected: search.indicator,
+    search
   };
   return {
     loading,
@@ -41,7 +43,8 @@ const mapStateToProps = (state, { location }) => {
     isoCountries: getISOCountries(ndcsWithSelection),
     indicators: getCategoryIndicators(ndcsWithSelection),
     selectedCategory: getSelectedCategory(ndcsWithSelection),
-    selectedIndicator: getSelectedIndicator(ndcsWithSelection)
+    selectedIndicator: getSelectedIndicator(ndcsWithSelection),
+    link: getLinkToDataExplorer(ndcsWithSelection)
   };
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map.js
@@ -44,7 +44,7 @@ const mapStateToProps = (state, { location }) => {
     indicators: getCategoryIndicators(ndcsWithSelection),
     selectedCategory: getSelectedCategory(ndcsWithSelection),
     selectedIndicator: getSelectedIndicator(ndcsWithSelection),
-    link: getLinkToDataExplorer(ndcsWithSelection)
+    downloadLink: getLinkToDataExplorer(ndcsWithSelection)
   };
 };
 

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -81,6 +81,14 @@ export const DATA_EXPLORER_DEPENDENCIES = {
 };
 
 export const DATA_EXPLORER_EXTERNAL_PREFIX = 'external';
+export const MODULES_TO_DATA_EXPLORER_PARAMS = {
+  'historical-emissions': {
+    filter: 'filter',
+    source: 'data-sources',
+    version: 'gwps',
+    breakBy: 'breakBy'
+  }
+};
 export const DATA_EXPLORER_TO_MODULES_PARAMS = {
   'historical-emissions': {
     data_sources: { key: 'source' },

--- a/app/javascript/app/utils/data-explorer.js
+++ b/app/javascript/app/utils/data-explorer.js
@@ -1,3 +1,6 @@
+import invertBy from 'lodash/invertBy';
+import qs from 'querystring';
+import { DATA_EXPLORER_TO_MODULES_PARAMS } from 'data/data-explorer-constants';
 import { replaceAll } from 'utils/utils';
 import { getStorageWithExpiration } from 'utils/localStorage';
 
@@ -34,4 +37,27 @@ export const openDownloadModal = (downloadUrl, setModalDownloadParams) => {
   });
 };
 
-export default { parseQuery, openDownloadModal };
+const parseFilters = (search, section) => {
+  const modulesToDataExplorerParamsSchema = invertBy(
+    DATA_EXPLORER_TO_MODULES_PARAMS[section],
+    value => value.key
+  );
+  const parsedFilters = {};
+  Object.keys(search).forEach(key => {
+    const parsedKey = `external-${section}-${modulesToDataExplorerParamsSchema[
+      key
+    ]}`.replace('_', '-');
+    parsedFilters[parsedKey] = search[key];
+  });
+  return parsedFilters;
+};
+
+export const generateLinkToDataExplorer = (search, section) => {
+  const sectionUrl = section ? `/${section}` : '';
+  const params = search
+    ? `?${qs.stringify(parseFilters(search, section))}`
+    : '';
+  return `/data-explorer${sectionUrl}${params}`;
+};
+
+export default { parseQuery, openDownloadModal, generateLinkToDataExplorer };


### PR DESCRIPTION
This PR moves modules to Data Explorer links generation logic from `ButtonGroup` to `utils/data-explorer.js` file.
Now `generateLinkToDataExplorer` is used on each module to create a `link` prop that is passed from the module to `ButtonGroup` with the generated `URL`.