### PR TITLE
Fix/data explorer update download href

### DIFF
--- a/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation.js
+++ b/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation.js
@@ -119,8 +119,8 @@ const API_CALLS = {
         indicatorsParam,
         {
           name: 'locations',
-          parameter: 'locations[]',
-          description: 'locations ISO code 3'
+          parameter: 'location_ids[]',
+          description: 'location id'
         },
         startYearParam,
         endYearParam,

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { PureComponent, createElement } from 'react';
-import { openDownloadModal } from 'utils/data-explorer';
+import { parseQuery, openDownloadModal } from 'utils/data-explorer';
 import { isANumber } from 'utils/utils';
 import { getSearch, getLocationParamUpdated } from 'utils/navigation';
 import { PropTypes } from 'prop-types';
@@ -49,7 +49,7 @@ const mapStateToProps = (state, { section, location }) => {
   const devESPURL = section === 'emission-pathways' ? ESP_HOST : '';
   const downloadHref = `${devESPURL}/api/v1/data/${DATA_EXPLORER_SECTIONS[
     section
-  ].label}/download.csv${filterQuery ? `?${filterQuery}` : ''}`;
+  ].label}/download.csv${filterQuery ? `?${parseQuery(filterQuery)}` : ''}`;
   const meta =
     section === 'emission-pathways'
       ? getPathwaysMetodology(dataState)


### PR DESCRIPTION
[Pivotal task](https://www.pivotaltracker.com/story/show/159988248)
This PR updates Data Explorer Pathways API text on `locations` to `location id` instead of `iso_code3`.  

![image](https://user-images.githubusercontent.com/6906348/44581067-9f0d8400-a79c-11e8-9971-3fac33aa7af9.png)

It also  applies the needed parsing to Data Explorer `downloadHref` to download the actual selection.