### PR TITLE
Feature/year ordering pathways

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -665,10 +665,17 @@ export const getTitleLinks = createSelector(
     });
   }
 );
-export const getFirstTableHeaders = createSelector([parseData], data => {
-  if (!data || !data.length) return null;
-  const yearColumnKeys = Object.keys(data[0])
-    .filter(k => isANumber(k))
-    .reverse();
-  return DATA_EXPLORER_FIRST_TABLE_HEADERS.concat(yearColumnKeys);
-});
+export const getFirstTableHeaders = createSelector(
+  [parseData, getSection],
+  (data, section) => {
+    if (!data || !data.length) return null;
+    const yearColumnKeys = Object.keys(data[0]).filter(k => isANumber(k));
+    const reversedYearColumnKeys = yearColumnKeys.slice().reverse();
+    switch (section) {
+      case 'emission-pathways':
+        return DATA_EXPLORER_FIRST_TABLE_HEADERS.concat(yearColumnKeys);
+      default:
+        return DATA_EXPLORER_FIRST_TABLE_HEADERS.concat(reversedYearColumnKeys);
+    }
+  }
+);

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -670,7 +670,7 @@ export const getFirstTableHeaders = createSelector(
   (data, section) => {
     if (!data || !data.length) return null;
     const yearColumnKeys = Object.keys(data[0]).filter(k => isANumber(k));
-    const reversedYearColumnKeys = yearColumnKeys.slice().reverse();
+    const reversedYearColumnKeys = [...yearColumnKeys].reverse();
     switch (section) {
       case 'emission-pathways':
         return DATA_EXPLORER_FIRST_TABLE_HEADERS.concat(yearColumnKeys);


### PR DESCRIPTION
[Pivotal task](https://www.pivotaltracker.com/story/show/159961025)
This PR rearranges year ordering on Pathways table to be shown in a ascending order (instead of the default descending order shown in Historical Emissions) 