### PR TITLE
Add Top Emitters region to regions dropdown

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -20,7 +20,8 @@ import {
   FILTERED_FIELDS,
   POSSIBLE_LABEL_FIELDS,
   POSSIBLE_VALUE_FIELDS,
-  NON_COLUMN_KEYS
+  NON_COLUMN_KEYS,
+  TOP_EMITTERS_OPTION
 } from 'data/data-explorer-constants';
 import { SOURCE_VERSIONS } from 'data/constants';
 import {
@@ -303,6 +304,8 @@ export const getFilterOptions = createSelector(
               `${option.dataSourceId}-${option.versionId}`);
           return { ...option, value, label };
         });
+
+        if (f === 'regions') optionsArray.unshift(TOP_EMITTERS_OPTION);
         filterOptions[f] = optionsArray;
       }
     });

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -1,3 +1,5 @@
+import { TOP_EMITTERS } from './constants';
+
 export const DATA_EXPLORER_BLACKLIST = [
   'id',
   'iso_code3',
@@ -221,6 +223,13 @@ export const POSSIBLE_LABEL_FIELDS = [
 
 export const POSSIBLE_VALUE_FIELDS = ['iso_code', 'iso_code3', 'id', 'value'];
 
+export const TOP_EMITTERS_OPTION = {
+  iso_code3: 'TOP',
+  label: 'Top Emitters',
+  value: TOP_EMITTERS.join(','),
+  groupId: 'regions'
+};
+
 export default {
   DATA_EXPLORER_BLACKLIST,
   DATA_EXPLORER_FIRST_TABLE_HEADERS,
@@ -233,5 +242,6 @@ export default {
   GROUPED_SELECT_FIELDS,
   DATA_EXPLORER_PER_PAGE,
   POSSIBLE_LABEL_FIELDS,
-  POSSIBLE_VALUE_FIELDS
+  POSSIBLE_VALUE_FIELDS,
+  TOP_EMITTERS_OPTION
 };


### PR DESCRIPTION
This PR adds the Top Emitters option to the regions in Historical Emissions

Note: As this is a non-backend region it is needed to add all the countries along with the TOP region

![image](https://user-images.githubusercontent.com/9701591/44672507-ec058a80-aa28-11e8-8a1c-d85d4f3422f3.png)
