### PR TITLE
Removed fake 'Economy-wide' sector from API response

### DIFF
--- a/app/services/api/v1/data/ndc_content/filter.rb
+++ b/app/services/api/v1/data/ndc_content/filter.rb
@@ -109,7 +109,6 @@ module Api
               ::Indc::Sector.where(
                 parent_id: top_level_sector_ids
               ).pluck(:id)
-
             @query = @query.where(sector_id: subsector_ids)
           end
 

--- a/app/services/api/v1/data/ndc_content/filter_columns.rb
+++ b/app/services/api/v1/data/ndc_content/filter_columns.rb
@@ -35,11 +35,11 @@ module Api
                 group: false
               },
               {
-                column: "COALESCE(sectors.name, parent_sectors.name, 'Economy-wide')",
+                column: 'COALESCE(sectors.name, parent_sectors.name)',
                 alias: 'sector'
               },
               {
-                column: "COALESCE(subsectors.name, 'Economy-wide')",
+                column: 'COALESCE(subsectors.name)',
                 alias: 'subsector'
               },
               {


### PR DESCRIPTION
The sector used to be returned as 'Economy-wide' where the sector was empty, but that was confusing because filtering did not work correctly when applying the real 'Economy-wide' sector filter. Now it's back to blank when sector is not provided; it should be part of the data if it's needed.