### PR TITLE
Change the desktop table width

### DIFF
--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -13,7 +13,6 @@ import { deburrCapitalize } from '../../utils/utils';
 const minColumnWidth = 180;
 const getResponsiveWidth = (columns, width) => {
   if (columns.length === 1) return width;
-
   const isMinColumSized = width / columns < minColumnWidth;
 
   let responsiveRatio = 1.4; // Mobile
@@ -23,11 +22,12 @@ const getResponsiveWidth = (columns, width) => {
     responsiveRatio = 1.2; // Tablet
   } else if (width > pixelBreakpoints.landscape) {
     // Desktop
-    responsiveColumnRatio = 0.1;
+    responsiveColumnRatio = 0.07;
     responsiveRatio = 1;
   }
   const columnRatio = isMinColumSized ? responsiveColumnRatio : 0;
   const columnExtraWidth = columnRatio * columns;
+
   return width * responsiveRatio * (1 + columnExtraWidth);
 };
 


### PR DESCRIPTION
This PR changes the table width only in desktop as it was creating to much space for the Data explorer tables.

![image](https://user-images.githubusercontent.com/9701591/45834614-e3dafb00-bd07-11e8-9529-646548c87dbd.png)
