### PR TITLE
Get total laws & policies count from API to display on the GRI/LSE logo

### DIFF
--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
@@ -44,7 +44,8 @@ class LawsAndPolicies extends PureComponent {
       lawsTargets,
       countryProfileLink,
       currentSector,
-      country
+      country,
+      lawsAndPoliciesCount
     } = this.props;
 
     const countryName = country && `${country.wri_standard_name}`;
@@ -71,7 +72,7 @@ class LawsAndPolicies extends PureComponent {
             >
               <span
                 className={styles.logoText}
-              >{`See all ${lawsTargets.length} ${countryName} national policies on Climate Change Laws of the World.`}</span>
+              >{`See all ${lawsAndPoliciesCount} ${countryName} national policies on Climate Change Laws of the World.`}</span>
             </a>
           </div>
         </div>
@@ -153,7 +154,11 @@ LawsAndPolicies.propTypes = {
   currentSector: PropTypes.object,
   country: PropTypes.object,
   updateUrlParam: PropTypes.func.isRequired,
-  countryProfileLink: PropTypes.string
+  countryProfileLink: PropTypes.string,
+  lawsAndPoliciesCount: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ])
 };
 
 export default LawsAndPolicies;

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
@@ -57,14 +57,22 @@ export const getNdcContent = createSelector(
   }
 );
 
-export const getCountryProfileLink = createSelector(
-  [getIso, getData],
-  (iso, { data }) => {
-    if (!data) return null;
+const getCountryMeta = createSelector([getIso, getData], (iso, { data }) => {
+  if (!data) return null;
 
-    const countryMeta = data && data[iso] && data[iso].country_meta;
-    return countryMeta && countryMeta[iso] && countryMeta[iso].country_profile;
-  }
+  return (data && data[iso] && data[iso].country_meta) || null;
+});
+
+export const getCountryProfileLink = createSelector(
+  [getCountryMeta, getIso],
+  (countryMeta, iso) =>
+    countryMeta && countryMeta[iso] && countryMeta[iso].country_profile
+);
+
+export const getLawsAndPoliciesCount = createSelector(
+  [getCountryMeta, getIso],
+  (countryMeta, iso) =>
+    (countryMeta && countryMeta[iso] && countryMeta[iso].lnp_count) || 0
 );
 
 export const getLawsAndPolicies = createSelector(
@@ -135,5 +143,6 @@ export const getAllData = createStructuredSelector({
   ndcContent: getNdcContent,
   lawsTargets: getLawsAndPolicies,
   currentSector: getCurrentSector,
-  countryProfileLink: getCountryProfileLink
+  countryProfileLink: getCountryProfileLink,
+  lawsAndPoliciesCount: getLawsAndPoliciesCount
 });


### PR DESCRIPTION
* Get total laws & policies count from the API - this is not the same as the number of laws and policies next to selector which shows the number of laws per that sector
![image](https://user-images.githubusercontent.com/6136899/47578060-54e18400-d940-11e8-867a-633e74616846.png)
