### PR TITLE
Don't retry fetching failed laws and policies request

### DIFF
--- a/app/javascript/app/providers/laws-and-policies-provider/laws-and-policies-provider-actions.js
+++ b/app/javascript/app/providers/laws-and-policies-provider/laws-and-policies-provider-actions.js
@@ -34,7 +34,12 @@ const fetchLawsAndPolicies = createThunkAction(
         })
         .catch(error => {
           console.info(error);
-          dispatch(fetchLawsAndPoliciesReady({}));
+          dispatch(
+            fetchLawsAndPoliciesReady({
+              iso_code3: iso,
+              payload: { payload: null }
+            })
+          );
         });
     }
   }

--- a/app/javascript/app/providers/laws-and-policies-provider/laws-and-policies-provider-actions.js
+++ b/app/javascript/app/providers/laws-and-policies-provider/laws-and-policies-provider-actions.js
@@ -2,7 +2,6 @@ import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
 
-// TODO: Fill the LSE API endpoint once it is ready
 const LSE_BASE_API =
   'http://www.lse.ac.uk/GranthamInstitute/wp-json/wri/v1/targets';
 


### PR DESCRIPTION
Don't retry fetching failed laws and policies request

You can test it adding extra `/` to the LSE endpoint