### PR TITLE
Add checks for existence

### DIFF
--- a/db/secondbase/migrate/20180917120344_devise_create_admin_users.rb
+++ b/db/secondbase/migrate/20180917120344_devise_create_admin_users.rb
@@ -2,6 +2,7 @@
 
 class DeviseCreateAdminUsers < ActiveRecord::Migration[5.2]
   def change
+    return if table_exists? :admin_users
     create_table :admin_users do |t|
       ## Database authenticatable
       t.string :email,              null: false, default: ''

--- a/db/secondbase/migrate/20181004091403_add_role_to_admin_user.rb
+++ b/db/secondbase/migrate/20181004091403_add_role_to_admin_user.rb
@@ -1,5 +1,6 @@
 class AddRoleToAdminUser < ActiveRecord::Migration[5.2]
   def change
+    return if column_exists? :admin_users, :role
     add_column :admin_users, :role, :string
   end
 end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -21,8 +22,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -31,7 +30,7 @@ SET default_with_oids = false;
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE admin_users (
+CREATE TABLE public.admin_users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -48,7 +47,7 @@ CREATE TABLE admin_users (
 -- Name: admin_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE admin_users_id_seq
+CREATE SEQUENCE public.admin_users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -60,14 +59,14 @@ CREATE SEQUENCE admin_users_id_seq
 -- Name: admin_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE admin_users_id_seq OWNED BY admin_users.id;
+ALTER SEQUENCE public.admin_users_id_seq OWNED BY public.admin_users.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -79,7 +78,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -88,14 +87,14 @@ CREATE TABLE schema_migrations (
 -- Name: admin_users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_users ALTER COLUMN id SET DEFAULT nextval('admin_users_id_seq'::regclass);
+ALTER TABLE ONLY public.admin_users ALTER COLUMN id SET DEFAULT nextval('public.admin_users_id_seq'::regclass);
 
 
 --
 -- Name: admin_users admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_users
+ALTER TABLE ONLY public.admin_users
     ADD CONSTRAINT admin_users_pkey PRIMARY KEY (id);
 
 
@@ -103,7 +102,7 @@ ALTER TABLE ONLY admin_users
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -111,7 +110,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -119,14 +118,14 @@ ALTER TABLE ONLY schema_migrations
 -- Name: index_admin_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_email ON admin_users USING btree (email);
+CREATE UNIQUE INDEX index_admin_users_on_email ON public.admin_users USING btree (email);
 
 
 --
 -- Name: index_admin_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_reset_password_token ON admin_users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_admin_users_on_reset_password_token ON public.admin_users USING btree (reset_password_token);
 
 
 --
@@ -137,6 +136,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20180917120344'),
-('20181004091403');
+('20181004091403'),
+('20181108100120');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -21,13 +22,11 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
-
 --
 -- Name: emissions_filter_by_year_range(jsonb, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION emissions_filter_by_year_range(emissions jsonb, start_year integer, end_year integer) RETURNS jsonb
+CREATE FUNCTION public.emissions_filter_by_year_range(emissions jsonb, start_year integer, end_year integer) RETURNS jsonb
     LANGUAGE sql IMMUTABLE
     AS $$
 
@@ -50,7 +49,7 @@ SET default_with_oids = false;
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE active_storage_attachments (
+CREATE TABLE public.active_storage_attachments (
     id bigint NOT NULL,
     name character varying NOT NULL,
     record_type character varying NOT NULL,
@@ -64,7 +63,7 @@ CREATE TABLE active_storage_attachments (
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE active_storage_attachments_id_seq
+CREATE SEQUENCE public.active_storage_attachments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -76,14 +75,14 @@ CREATE SEQUENCE active_storage_attachments_id_seq
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE active_storage_attachments_id_seq OWNED BY active_storage_attachments.id;
+ALTER SEQUENCE public.active_storage_attachments_id_seq OWNED BY public.active_storage_attachments.id;
 
 
 --
 -- Name: active_storage_blobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE active_storage_blobs (
+CREATE TABLE public.active_storage_blobs (
     id bigint NOT NULL,
     key character varying NOT NULL,
     filename character varying NOT NULL,
@@ -99,7 +98,7 @@ CREATE TABLE active_storage_blobs (
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE active_storage_blobs_id_seq
+CREATE SEQUENCE public.active_storage_blobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -111,14 +110,14 @@ CREATE SEQUENCE active_storage_blobs_id_seq
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE active_storage_blobs_id_seq OWNED BY active_storage_blobs.id;
+ALTER SEQUENCE public.active_storage_blobs_id_seq OWNED BY public.active_storage_blobs.id;
 
 
 --
 -- Name: adaptation_values; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE adaptation_values (
+CREATE TABLE public.adaptation_values (
     id bigint NOT NULL,
     variable_id bigint,
     location_id bigint,
@@ -137,7 +136,7 @@ CREATE TABLE adaptation_values (
 -- Name: adaptation_values_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE adaptation_values_id_seq
+CREATE SEQUENCE public.adaptation_values_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -149,14 +148,14 @@ CREATE SEQUENCE adaptation_values_id_seq
 -- Name: adaptation_values_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE adaptation_values_id_seq OWNED BY adaptation_values.id;
+ALTER SEQUENCE public.adaptation_values_id_seq OWNED BY public.adaptation_values.id;
 
 
 --
 -- Name: adaptation_variables; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE adaptation_variables (
+CREATE TABLE public.adaptation_variables (
     id bigint NOT NULL,
     slug text,
     name text,
@@ -169,7 +168,7 @@ CREATE TABLE adaptation_variables (
 -- Name: adaptation_variables_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE adaptation_variables_id_seq
+CREATE SEQUENCE public.adaptation_variables_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -181,14 +180,14 @@ CREATE SEQUENCE adaptation_variables_id_seq
 -- Name: adaptation_variables_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE adaptation_variables_id_seq OWNED BY adaptation_variables.id;
+ALTER SEQUENCE public.adaptation_variables_id_seq OWNED BY public.adaptation_variables.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -200,7 +199,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: datasets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE datasets (
+CREATE TABLE public.datasets (
     id bigint NOT NULL,
     name character varying,
     section_id bigint
@@ -211,7 +210,7 @@ CREATE TABLE datasets (
 -- Name: datasets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE datasets_id_seq
+CREATE SEQUENCE public.datasets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -223,14 +222,14 @@ CREATE SEQUENCE datasets_id_seq
 -- Name: datasets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE datasets_id_seq OWNED BY datasets.id;
+ALTER SEQUENCE public.datasets_id_seq OWNED BY public.datasets.id;
 
 
 --
 -- Name: documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE documents (
+CREATE TABLE public.documents (
     id bigint NOT NULL,
     platform_name character varying
 );
@@ -240,7 +239,7 @@ CREATE TABLE documents (
 -- Name: documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE documents_id_seq
+CREATE SEQUENCE public.documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -252,14 +251,14 @@ CREATE SEQUENCE documents_id_seq
 -- Name: documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE documents_id_seq OWNED BY documents.id;
+ALTER SEQUENCE public.documents_id_seq OWNED BY public.documents.id;
 
 
 --
 -- Name: historical_emissions_data_sources; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE historical_emissions_data_sources (
+CREATE TABLE public.historical_emissions_data_sources (
     id bigint NOT NULL,
     name text,
     created_at timestamp without time zone NOT NULL,
@@ -271,7 +270,7 @@ CREATE TABLE historical_emissions_data_sources (
 -- Name: historical_emissions_data_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE historical_emissions_data_sources_id_seq
+CREATE SEQUENCE public.historical_emissions_data_sources_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -283,14 +282,14 @@ CREATE SEQUENCE historical_emissions_data_sources_id_seq
 -- Name: historical_emissions_data_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE historical_emissions_data_sources_id_seq OWNED BY historical_emissions_data_sources.id;
+ALTER SEQUENCE public.historical_emissions_data_sources_id_seq OWNED BY public.historical_emissions_data_sources.id;
 
 
 --
 -- Name: historical_emissions_gases; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE historical_emissions_gases (
+CREATE TABLE public.historical_emissions_gases (
     id bigint NOT NULL,
     name text,
     created_at timestamp without time zone NOT NULL,
@@ -302,7 +301,7 @@ CREATE TABLE historical_emissions_gases (
 -- Name: historical_emissions_gases_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE historical_emissions_gases_id_seq
+CREATE SEQUENCE public.historical_emissions_gases_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -314,14 +313,14 @@ CREATE SEQUENCE historical_emissions_gases_id_seq
 -- Name: historical_emissions_gases_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE historical_emissions_gases_id_seq OWNED BY historical_emissions_gases.id;
+ALTER SEQUENCE public.historical_emissions_gases_id_seq OWNED BY public.historical_emissions_gases.id;
 
 
 --
 -- Name: historical_emissions_gwps; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE historical_emissions_gwps (
+CREATE TABLE public.historical_emissions_gwps (
     id bigint NOT NULL,
     name text,
     created_at timestamp without time zone NOT NULL,
@@ -333,7 +332,7 @@ CREATE TABLE historical_emissions_gwps (
 -- Name: historical_emissions_gwps_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE historical_emissions_gwps_id_seq
+CREATE SEQUENCE public.historical_emissions_gwps_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -345,14 +344,14 @@ CREATE SEQUENCE historical_emissions_gwps_id_seq
 -- Name: historical_emissions_gwps_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE historical_emissions_gwps_id_seq OWNED BY historical_emissions_gwps.id;
+ALTER SEQUENCE public.historical_emissions_gwps_id_seq OWNED BY public.historical_emissions_gwps.id;
 
 
 --
 -- Name: historical_emissions_records; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE historical_emissions_records (
+CREATE TABLE public.historical_emissions_records (
     id bigint NOT NULL,
     location_id bigint,
     data_source_id bigint,
@@ -367,7 +366,7 @@ CREATE TABLE historical_emissions_records (
 -- Name: historical_emissions_normalised_records; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW historical_emissions_normalised_records AS
+CREATE MATERIALIZED VIEW public.historical_emissions_normalised_records AS
  SELECT historical_emissions_records.id,
     historical_emissions_records.data_source_id,
     historical_emissions_records.gwp_id,
@@ -376,7 +375,7 @@ CREATE MATERIALIZED VIEW historical_emissions_normalised_records AS
     historical_emissions_records.gas_id,
     ((jsonb_array_elements(historical_emissions_records.emissions) ->> 'year'::text))::integer AS year,
     (jsonb_array_elements(historical_emissions_records.emissions) ->> 'value'::text) AS value
-   FROM historical_emissions_records
+   FROM public.historical_emissions_records
   WITH NO DATA;
 
 
@@ -384,11 +383,11 @@ CREATE MATERIALIZED VIEW historical_emissions_normalised_records AS
 -- Name: historical_emissions_records_emissions; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW historical_emissions_records_emissions AS
+CREATE MATERIALIZED VIEW public.historical_emissions_records_emissions AS
  SELECT historical_emissions_normalised_records.id,
     jsonb_agg(jsonb_build_object('year', historical_emissions_normalised_records.year, 'value', round((historical_emissions_normalised_records.value)::numeric, 2))) AS emissions,
     jsonb_object_agg(historical_emissions_normalised_records.year, round((historical_emissions_normalised_records.value)::numeric, 2)) AS emissions_dict
-   FROM historical_emissions_normalised_records
+   FROM public.historical_emissions_normalised_records
   GROUP BY historical_emissions_normalised_records.id
   WITH NO DATA;
 
@@ -397,7 +396,7 @@ CREATE MATERIALIZED VIEW historical_emissions_records_emissions AS
 -- Name: historical_emissions_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE historical_emissions_records_id_seq
+CREATE SEQUENCE public.historical_emissions_records_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -409,14 +408,14 @@ CREATE SEQUENCE historical_emissions_records_id_seq
 -- Name: historical_emissions_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE historical_emissions_records_id_seq OWNED BY historical_emissions_records.id;
+ALTER SEQUENCE public.historical_emissions_records_id_seq OWNED BY public.historical_emissions_records.id;
 
 
 --
 -- Name: historical_emissions_sectors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE historical_emissions_sectors (
+CREATE TABLE public.historical_emissions_sectors (
     id bigint NOT NULL,
     parent_id bigint,
     data_source_id bigint,
@@ -431,7 +430,7 @@ CREATE TABLE historical_emissions_sectors (
 -- Name: locations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE locations (
+CREATE TABLE public.locations (
     id bigint NOT NULL,
     iso_code3 text NOT NULL,
     pik_name text,
@@ -453,7 +452,7 @@ CREATE TABLE locations (
 -- Name: historical_emissions_searchable_records; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW historical_emissions_searchable_records AS
+CREATE MATERIALIZED VIEW public.historical_emissions_searchable_records AS
  SELECT records.id,
     records.data_source_id,
     data_sources.name AS data_source,
@@ -468,13 +467,13 @@ CREATE MATERIALIZED VIEW historical_emissions_searchable_records AS
     gases.name AS gas,
     records_emissions.emissions,
     records_emissions.emissions_dict
-   FROM ((((((historical_emissions_records records
-     JOIN historical_emissions_data_sources data_sources ON ((data_sources.id = records.data_source_id)))
-     JOIN historical_emissions_gwps gwps ON ((gwps.id = records.gwp_id)))
-     JOIN locations ON ((locations.id = records.location_id)))
-     JOIN historical_emissions_sectors sectors ON ((sectors.id = records.sector_id)))
-     JOIN historical_emissions_gases gases ON ((gases.id = records.gas_id)))
-     LEFT JOIN historical_emissions_records_emissions records_emissions ON ((records.id = records_emissions.id)))
+   FROM ((((((public.historical_emissions_records records
+     JOIN public.historical_emissions_data_sources data_sources ON ((data_sources.id = records.data_source_id)))
+     JOIN public.historical_emissions_gwps gwps ON ((gwps.id = records.gwp_id)))
+     JOIN public.locations ON ((locations.id = records.location_id)))
+     JOIN public.historical_emissions_sectors sectors ON ((sectors.id = records.sector_id)))
+     JOIN public.historical_emissions_gases gases ON ((gases.id = records.gas_id)))
+     LEFT JOIN public.historical_emissions_records_emissions records_emissions ON ((records.id = records_emissions.id)))
   WITH NO DATA;
 
 
@@ -482,7 +481,7 @@ CREATE MATERIALIZED VIEW historical_emissions_searchable_records AS
 -- Name: historical_emissions_sectors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE historical_emissions_sectors_id_seq
+CREATE SEQUENCE public.historical_emissions_sectors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -494,14 +493,14 @@ CREATE SEQUENCE historical_emissions_sectors_id_seq
 -- Name: historical_emissions_sectors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE historical_emissions_sectors_id_seq OWNED BY historical_emissions_sectors.id;
+ALTER SEQUENCE public.historical_emissions_sectors_id_seq OWNED BY public.historical_emissions_sectors.id;
 
 
 --
 -- Name: indc_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_categories (
+CREATE TABLE public.indc_categories (
     id bigint NOT NULL,
     category_type_id bigint NOT NULL,
     parent_id bigint,
@@ -517,7 +516,7 @@ CREATE TABLE indc_categories (
 -- Name: indc_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_categories_id_seq
+CREATE SEQUENCE public.indc_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -529,14 +528,14 @@ CREATE SEQUENCE indc_categories_id_seq
 -- Name: indc_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_categories_id_seq OWNED BY indc_categories.id;
+ALTER SEQUENCE public.indc_categories_id_seq OWNED BY public.indc_categories.id;
 
 
 --
 -- Name: indc_category_types; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_category_types (
+CREATE TABLE public.indc_category_types (
     id bigint NOT NULL,
     name text NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -548,7 +547,7 @@ CREATE TABLE indc_category_types (
 -- Name: indc_category_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_category_types_id_seq
+CREATE SEQUENCE public.indc_category_types_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -560,14 +559,14 @@ CREATE SEQUENCE indc_category_types_id_seq
 -- Name: indc_category_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_category_types_id_seq OWNED BY indc_category_types.id;
+ALTER SEQUENCE public.indc_category_types_id_seq OWNED BY public.indc_category_types.id;
 
 
 --
 -- Name: indc_indicators; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_indicators (
+CREATE TABLE public.indc_indicators (
     id bigint NOT NULL,
     source_id bigint NOT NULL,
     slug text NOT NULL,
@@ -583,7 +582,7 @@ CREATE TABLE indc_indicators (
 -- Name: indc_indicators_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_indicators_categories (
+CREATE TABLE public.indc_indicators_categories (
     id bigint NOT NULL,
     indicator_id bigint NOT NULL,
     category_id bigint NOT NULL,
@@ -596,7 +595,7 @@ CREATE TABLE indc_indicators_categories (
 -- Name: indc_indicators_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_indicators_categories_id_seq
+CREATE SEQUENCE public.indc_indicators_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -608,14 +607,14 @@ CREATE SEQUENCE indc_indicators_categories_id_seq
 -- Name: indc_indicators_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_indicators_categories_id_seq OWNED BY indc_indicators_categories.id;
+ALTER SEQUENCE public.indc_indicators_categories_id_seq OWNED BY public.indc_indicators_categories.id;
 
 
 --
 -- Name: indc_indicators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_indicators_id_seq
+CREATE SEQUENCE public.indc_indicators_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -627,14 +626,14 @@ CREATE SEQUENCE indc_indicators_id_seq
 -- Name: indc_indicators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_indicators_id_seq OWNED BY indc_indicators.id;
+ALTER SEQUENCE public.indc_indicators_id_seq OWNED BY public.indc_indicators.id;
 
 
 --
 -- Name: indc_labels; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_labels (
+CREATE TABLE public.indc_labels (
     id bigint NOT NULL,
     indicator_id bigint NOT NULL,
     value text NOT NULL,
@@ -648,7 +647,7 @@ CREATE TABLE indc_labels (
 -- Name: indc_labels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_labels_id_seq
+CREATE SEQUENCE public.indc_labels_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -660,14 +659,14 @@ CREATE SEQUENCE indc_labels_id_seq
 -- Name: indc_labels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_labels_id_seq OWNED BY indc_labels.id;
+ALTER SEQUENCE public.indc_labels_id_seq OWNED BY public.indc_labels.id;
 
 
 --
 -- Name: indc_sectors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_sectors (
+CREATE TABLE public.indc_sectors (
     id bigint NOT NULL,
     parent_id bigint,
     name text NOT NULL,
@@ -680,7 +679,7 @@ CREATE TABLE indc_sectors (
 -- Name: indc_sectors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_sectors_id_seq
+CREATE SEQUENCE public.indc_sectors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -692,14 +691,14 @@ CREATE SEQUENCE indc_sectors_id_seq
 -- Name: indc_sectors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_sectors_id_seq OWNED BY indc_sectors.id;
+ALTER SEQUENCE public.indc_sectors_id_seq OWNED BY public.indc_sectors.id;
 
 
 --
 -- Name: indc_sources; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_sources (
+CREATE TABLE public.indc_sources (
     id bigint NOT NULL,
     name text NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -711,7 +710,7 @@ CREATE TABLE indc_sources (
 -- Name: indc_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_sources_id_seq
+CREATE SEQUENCE public.indc_sources_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -723,14 +722,14 @@ CREATE SEQUENCE indc_sources_id_seq
 -- Name: indc_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_sources_id_seq OWNED BY indc_sources.id;
+ALTER SEQUENCE public.indc_sources_id_seq OWNED BY public.indc_sources.id;
 
 
 --
 -- Name: indc_submissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_submissions (
+CREATE TABLE public.indc_submissions (
     id bigint NOT NULL,
     location_id bigint NOT NULL,
     submission_type text NOT NULL,
@@ -746,7 +745,7 @@ CREATE TABLE indc_submissions (
 -- Name: indc_submissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_submissions_id_seq
+CREATE SEQUENCE public.indc_submissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -758,14 +757,14 @@ CREATE SEQUENCE indc_submissions_id_seq
 -- Name: indc_submissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_submissions_id_seq OWNED BY indc_submissions.id;
+ALTER SEQUENCE public.indc_submissions_id_seq OWNED BY public.indc_submissions.id;
 
 
 --
 -- Name: indc_values; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE indc_values (
+CREATE TABLE public.indc_values (
     id bigint NOT NULL,
     indicator_id bigint NOT NULL,
     location_id bigint NOT NULL,
@@ -781,7 +780,7 @@ CREATE TABLE indc_values (
 -- Name: indc_values_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE indc_values_id_seq
+CREATE SEQUENCE public.indc_values_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -793,14 +792,14 @@ CREATE SEQUENCE indc_values_id_seq
 -- Name: indc_values_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE indc_values_id_seq OWNED BY indc_values.id;
+ALTER SEQUENCE public.indc_values_id_seq OWNED BY public.indc_values.id;
 
 
 --
 -- Name: location_members; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE location_members (
+CREATE TABLE public.location_members (
     id bigint NOT NULL,
     location_id bigint,
     member_id bigint,
@@ -813,7 +812,7 @@ CREATE TABLE location_members (
 -- Name: location_members_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE location_members_id_seq
+CREATE SEQUENCE public.location_members_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -825,14 +824,14 @@ CREATE SEQUENCE location_members_id_seq
 -- Name: location_members_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE location_members_id_seq OWNED BY location_members.id;
+ALTER SEQUENCE public.location_members_id_seq OWNED BY public.location_members.id;
 
 
 --
 -- Name: locations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE locations_id_seq
+CREATE SEQUENCE public.locations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -844,14 +843,14 @@ CREATE SEQUENCE locations_id_seq
 -- Name: locations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE locations_id_seq OWNED BY locations.id;
+ALTER SEQUENCE public.locations_id_seq OWNED BY public.locations.id;
 
 
 --
 -- Name: ndc_sdg_goals; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndc_sdg_goals (
+CREATE TABLE public.ndc_sdg_goals (
     id bigint NOT NULL,
     number text NOT NULL,
     title text NOT NULL,
@@ -866,7 +865,7 @@ CREATE TABLE ndc_sdg_goals (
 -- Name: ndc_sdg_goals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndc_sdg_goals_id_seq
+CREATE SEQUENCE public.ndc_sdg_goals_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -878,14 +877,14 @@ CREATE SEQUENCE ndc_sdg_goals_id_seq
 -- Name: ndc_sdg_goals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndc_sdg_goals_id_seq OWNED BY ndc_sdg_goals.id;
+ALTER SEQUENCE public.ndc_sdg_goals_id_seq OWNED BY public.ndc_sdg_goals.id;
 
 
 --
 -- Name: ndc_sdg_ndc_target_sectors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndc_sdg_ndc_target_sectors (
+CREATE TABLE public.ndc_sdg_ndc_target_sectors (
     id bigint NOT NULL,
     ndc_target_id bigint,
     created_at timestamp without time zone NOT NULL,
@@ -898,7 +897,7 @@ CREATE TABLE ndc_sdg_ndc_target_sectors (
 -- Name: ndc_sdg_ndc_target_sectors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndc_sdg_ndc_target_sectors_id_seq
+CREATE SEQUENCE public.ndc_sdg_ndc_target_sectors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -910,14 +909,14 @@ CREATE SEQUENCE ndc_sdg_ndc_target_sectors_id_seq
 -- Name: ndc_sdg_ndc_target_sectors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndc_sdg_ndc_target_sectors_id_seq OWNED BY ndc_sdg_ndc_target_sectors.id;
+ALTER SEQUENCE public.ndc_sdg_ndc_target_sectors_id_seq OWNED BY public.ndc_sdg_ndc_target_sectors.id;
 
 
 --
 -- Name: ndc_sdg_ndc_targets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndc_sdg_ndc_targets (
+CREATE TABLE public.ndc_sdg_ndc_targets (
     id bigint NOT NULL,
     ndc_id bigint,
     target_id bigint,
@@ -936,7 +935,7 @@ CREATE TABLE ndc_sdg_ndc_targets (
 -- Name: ndc_sdg_ndc_targets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndc_sdg_ndc_targets_id_seq
+CREATE SEQUENCE public.ndc_sdg_ndc_targets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -948,14 +947,14 @@ CREATE SEQUENCE ndc_sdg_ndc_targets_id_seq
 -- Name: ndc_sdg_ndc_targets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndc_sdg_ndc_targets_id_seq OWNED BY ndc_sdg_ndc_targets.id;
+ALTER SEQUENCE public.ndc_sdg_ndc_targets_id_seq OWNED BY public.ndc_sdg_ndc_targets.id;
 
 
 --
 -- Name: ndc_sdg_sectors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndc_sdg_sectors (
+CREATE TABLE public.ndc_sdg_sectors (
     id bigint NOT NULL,
     name text,
     created_at timestamp without time zone NOT NULL,
@@ -967,7 +966,7 @@ CREATE TABLE ndc_sdg_sectors (
 -- Name: ndc_sdg_sectors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndc_sdg_sectors_id_seq
+CREATE SEQUENCE public.ndc_sdg_sectors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -979,14 +978,14 @@ CREATE SEQUENCE ndc_sdg_sectors_id_seq
 -- Name: ndc_sdg_sectors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndc_sdg_sectors_id_seq OWNED BY ndc_sdg_sectors.id;
+ALTER SEQUENCE public.ndc_sdg_sectors_id_seq OWNED BY public.ndc_sdg_sectors.id;
 
 
 --
 -- Name: ndc_sdg_targets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndc_sdg_targets (
+CREATE TABLE public.ndc_sdg_targets (
     id bigint NOT NULL,
     number text NOT NULL,
     title text NOT NULL,
@@ -1000,7 +999,7 @@ CREATE TABLE ndc_sdg_targets (
 -- Name: ndc_sdg_targets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndc_sdg_targets_id_seq
+CREATE SEQUENCE public.ndc_sdg_targets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1012,14 +1011,14 @@ CREATE SEQUENCE ndc_sdg_targets_id_seq
 -- Name: ndc_sdg_targets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndc_sdg_targets_id_seq OWNED BY ndc_sdg_targets.id;
+ALTER SEQUENCE public.ndc_sdg_targets_id_seq OWNED BY public.ndc_sdg_targets.id;
 
 
 --
 -- Name: ndcs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ndcs (
+CREATE TABLE public.ndcs (
     id bigint NOT NULL,
     location_id bigint,
     full_text text,
@@ -1036,7 +1035,7 @@ CREATE TABLE ndcs (
 -- Name: ndcs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ndcs_id_seq
+CREATE SEQUENCE public.ndcs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1048,14 +1047,14 @@ CREATE SEQUENCE ndcs_id_seq
 -- Name: ndcs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ndcs_id_seq OWNED BY ndcs.id;
+ALTER SEQUENCE public.ndcs_id_seq OWNED BY public.ndcs.id;
 
 
 --
 -- Name: platforms; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE platforms (
+CREATE TABLE public.platforms (
     id bigint NOT NULL,
     name character varying
 );
@@ -1065,7 +1064,7 @@ CREATE TABLE platforms (
 -- Name: platforms_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE platforms_id_seq
+CREATE SEQUENCE public.platforms_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1077,14 +1076,14 @@ CREATE SEQUENCE platforms_id_seq
 -- Name: platforms_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE platforms_id_seq OWNED BY platforms.id;
+ALTER SEQUENCE public.platforms_id_seq OWNED BY public.platforms.id;
 
 
 --
 -- Name: quantification_labels; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quantification_labels (
+CREATE TABLE public.quantification_labels (
     id bigint NOT NULL,
     name text NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -1096,7 +1095,7 @@ CREATE TABLE quantification_labels (
 -- Name: quantification_labels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quantification_labels_id_seq
+CREATE SEQUENCE public.quantification_labels_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1108,14 +1107,14 @@ CREATE SEQUENCE quantification_labels_id_seq
 -- Name: quantification_labels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quantification_labels_id_seq OWNED BY quantification_labels.id;
+ALTER SEQUENCE public.quantification_labels_id_seq OWNED BY public.quantification_labels.id;
 
 
 --
 -- Name: quantification_values; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE quantification_values (
+CREATE TABLE public.quantification_values (
     id bigint NOT NULL,
     location_id bigint,
     label_id bigint,
@@ -1131,7 +1130,7 @@ CREATE TABLE quantification_values (
 -- Name: quantification_values_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE quantification_values_id_seq
+CREATE SEQUENCE public.quantification_values_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1143,14 +1142,14 @@ CREATE SEQUENCE quantification_values_id_seq
 -- Name: quantification_values_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE quantification_values_id_seq OWNED BY quantification_values.id;
+ALTER SEQUENCE public.quantification_values_id_seq OWNED BY public.quantification_values.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -1159,7 +1158,7 @@ CREATE TABLE schema_migrations (
 -- Name: sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sections (
+CREATE TABLE public.sections (
     id bigint NOT NULL,
     name character varying,
     platform_id bigint
@@ -1170,7 +1169,7 @@ CREATE TABLE sections (
 -- Name: sections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sections_id_seq
+CREATE SEQUENCE public.sections_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1182,14 +1181,14 @@ CREATE SEQUENCE sections_id_seq
 -- Name: sections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sections_id_seq OWNED BY sections.id;
+ALTER SEQUENCE public.sections_id_seq OWNED BY public.sections.id;
 
 
 --
 -- Name: socioeconomic_indicators; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE socioeconomic_indicators (
+CREATE TABLE public.socioeconomic_indicators (
     id bigint NOT NULL,
     location_id bigint,
     year smallint NOT NULL,
@@ -1210,7 +1209,7 @@ CREATE TABLE socioeconomic_indicators (
 -- Name: socioeconomic_indicators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE socioeconomic_indicators_id_seq
+CREATE SEQUENCE public.socioeconomic_indicators_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1222,14 +1221,14 @@ CREATE SEQUENCE socioeconomic_indicators_id_seq
 -- Name: socioeconomic_indicators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE socioeconomic_indicators_id_seq OWNED BY socioeconomic_indicators.id;
+ALTER SEQUENCE public.socioeconomic_indicators_id_seq OWNED BY public.socioeconomic_indicators.id;
 
 
 --
 -- Name: stories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stories (
+CREATE TABLE public.stories (
     id bigint NOT NULL,
     title character varying,
     description text,
@@ -1246,7 +1245,7 @@ CREATE TABLE stories (
 -- Name: stories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stories_id_seq
+CREATE SEQUENCE public.stories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1258,14 +1257,14 @@ CREATE SEQUENCE stories_id_seq
 -- Name: stories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stories_id_seq OWNED BY stories.id;
+ALTER SEQUENCE public.stories_id_seq OWNED BY public.stories.id;
 
 
 --
 -- Name: timeline_documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE timeline_documents (
+CREATE TABLE public.timeline_documents (
     id bigint NOT NULL,
     source_id bigint,
     location_id bigint,
@@ -1282,7 +1281,7 @@ CREATE TABLE timeline_documents (
 -- Name: timeline_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE timeline_documents_id_seq
+CREATE SEQUENCE public.timeline_documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1294,14 +1293,14 @@ CREATE SEQUENCE timeline_documents_id_seq
 -- Name: timeline_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE timeline_documents_id_seq OWNED BY timeline_documents.id;
+ALTER SEQUENCE public.timeline_documents_id_seq OWNED BY public.timeline_documents.id;
 
 
 --
 -- Name: timeline_notes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE timeline_notes (
+CREATE TABLE public.timeline_notes (
     id bigint NOT NULL,
     document_id bigint,
     note text,
@@ -1314,7 +1313,7 @@ CREATE TABLE timeline_notes (
 -- Name: timeline_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE timeline_notes_id_seq
+CREATE SEQUENCE public.timeline_notes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1326,14 +1325,14 @@ CREATE SEQUENCE timeline_notes_id_seq
 -- Name: timeline_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE timeline_notes_id_seq OWNED BY timeline_notes.id;
+ALTER SEQUENCE public.timeline_notes_id_seq OWNED BY public.timeline_notes.id;
 
 
 --
 -- Name: timeline_sources; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE timeline_sources (
+CREATE TABLE public.timeline_sources (
     id bigint NOT NULL,
     name text
 );
@@ -1343,7 +1342,7 @@ CREATE TABLE timeline_sources (
 -- Name: timeline_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE timeline_sources_id_seq
+CREATE SEQUENCE public.timeline_sources_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1355,14 +1354,14 @@ CREATE SEQUENCE timeline_sources_id_seq
 -- Name: timeline_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE timeline_sources_id_seq OWNED BY timeline_sources.id;
+ALTER SEQUENCE public.timeline_sources_id_seq OWNED BY public.timeline_sources.id;
 
 
 --
 -- Name: user_stories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE user_stories (
+CREATE TABLE public.user_stories (
     id bigint NOT NULL,
     title character varying,
     body jsonb,
@@ -1377,7 +1376,7 @@ CREATE TABLE user_stories (
 -- Name: user_stories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE user_stories_id_seq
+CREATE SEQUENCE public.user_stories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1389,14 +1388,14 @@ CREATE SEQUENCE user_stories_id_seq
 -- Name: user_stories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE user_stories_id_seq OWNED BY user_stories.id;
+ALTER SEQUENCE public.user_stories_id_seq OWNED BY public.user_stories.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id bigint NOT NULL,
     ct_id character varying,
     created_at timestamp without time zone NOT NULL,
@@ -1415,7 +1414,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1427,14 +1426,14 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: visualizations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE visualizations (
+CREATE TABLE public.visualizations (
     id bigint NOT NULL,
     title character varying,
     description text,
@@ -1449,7 +1448,7 @@ CREATE TABLE visualizations (
 -- Name: visualizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE visualizations_id_seq
+CREATE SEQUENCE public.visualizations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1461,14 +1460,14 @@ CREATE SEQUENCE visualizations_id_seq
 -- Name: visualizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE visualizations_id_seq OWNED BY visualizations.id;
+ALTER SEQUENCE public.visualizations_id_seq OWNED BY public.visualizations.id;
 
 
 --
 -- Name: wb_extra_country_data; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE wb_extra_country_data (
+CREATE TABLE public.wb_extra_country_data (
     id bigint NOT NULL,
     location_id bigint,
     year integer,
@@ -1483,7 +1482,7 @@ CREATE TABLE wb_extra_country_data (
 -- Name: wb_extra_country_data_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE wb_extra_country_data_id_seq
+CREATE SEQUENCE public.wb_extra_country_data_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1495,14 +1494,14 @@ CREATE SEQUENCE wb_extra_country_data_id_seq
 -- Name: wb_extra_country_data_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE wb_extra_country_data_id_seq OWNED BY wb_extra_country_data.id;
+ALTER SEQUENCE public.wb_extra_country_data_id_seq OWNED BY public.wb_extra_country_data.id;
 
 
 --
 -- Name: worker_logs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE worker_logs (
+CREATE TABLE public.worker_logs (
     id bigint NOT NULL,
     state integer,
     jid character varying,
@@ -1517,7 +1516,7 @@ CREATE TABLE worker_logs (
 -- Name: worker_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE worker_logs_id_seq
+CREATE SEQUENCE public.worker_logs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1529,14 +1528,14 @@ CREATE SEQUENCE worker_logs_id_seq
 -- Name: worker_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE worker_logs_id_seq OWNED BY worker_logs.id;
+ALTER SEQUENCE public.worker_logs_id_seq OWNED BY public.worker_logs.id;
 
 
 --
 -- Name: wri_metadata_acronyms; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE wri_metadata_acronyms (
+CREATE TABLE public.wri_metadata_acronyms (
     id bigint NOT NULL,
     acronym text,
     definition text,
@@ -1549,7 +1548,7 @@ CREATE TABLE wri_metadata_acronyms (
 -- Name: wri_metadata_acronyms_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE wri_metadata_acronyms_id_seq
+CREATE SEQUENCE public.wri_metadata_acronyms_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1561,14 +1560,14 @@ CREATE SEQUENCE wri_metadata_acronyms_id_seq
 -- Name: wri_metadata_acronyms_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE wri_metadata_acronyms_id_seq OWNED BY wri_metadata_acronyms.id;
+ALTER SEQUENCE public.wri_metadata_acronyms_id_seq OWNED BY public.wri_metadata_acronyms.id;
 
 
 --
 -- Name: wri_metadata_properties; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE wri_metadata_properties (
+CREATE TABLE public.wri_metadata_properties (
     id bigint NOT NULL,
     slug text,
     name text,
@@ -1581,7 +1580,7 @@ CREATE TABLE wri_metadata_properties (
 -- Name: wri_metadata_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE wri_metadata_properties_id_seq
+CREATE SEQUENCE public.wri_metadata_properties_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1593,14 +1592,14 @@ CREATE SEQUENCE wri_metadata_properties_id_seq
 -- Name: wri_metadata_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE wri_metadata_properties_id_seq OWNED BY wri_metadata_properties.id;
+ALTER SEQUENCE public.wri_metadata_properties_id_seq OWNED BY public.wri_metadata_properties.id;
 
 
 --
 -- Name: wri_metadata_sources; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE wri_metadata_sources (
+CREATE TABLE public.wri_metadata_sources (
     id bigint NOT NULL,
     name text,
     created_at timestamp without time zone NOT NULL,
@@ -1612,7 +1611,7 @@ CREATE TABLE wri_metadata_sources (
 -- Name: wri_metadata_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE wri_metadata_sources_id_seq
+CREATE SEQUENCE public.wri_metadata_sources_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1624,14 +1623,14 @@ CREATE SEQUENCE wri_metadata_sources_id_seq
 -- Name: wri_metadata_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE wri_metadata_sources_id_seq OWNED BY wri_metadata_sources.id;
+ALTER SEQUENCE public.wri_metadata_sources_id_seq OWNED BY public.wri_metadata_sources.id;
 
 
 --
 -- Name: wri_metadata_values; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE wri_metadata_values (
+CREATE TABLE public.wri_metadata_values (
     id bigint NOT NULL,
     source_id bigint,
     property_id bigint,
@@ -1645,7 +1644,7 @@ CREATE TABLE wri_metadata_values (
 -- Name: wri_metadata_values_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE wri_metadata_values_id_seq
+CREATE SEQUENCE public.wri_metadata_values_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1657,336 +1656,336 @@ CREATE SEQUENCE wri_metadata_values_id_seq
 -- Name: wri_metadata_values_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE wri_metadata_values_id_seq OWNED BY wri_metadata_values.id;
+ALTER SEQUENCE public.wri_metadata_values_id_seq OWNED BY public.wri_metadata_values.id;
 
 
 --
 -- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('active_storage_attachments_id_seq'::regclass);
+ALTER TABLE ONLY public.active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('public.active_storage_attachments_id_seq'::regclass);
 
 
 --
 -- Name: active_storage_blobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('active_storage_blobs_id_seq'::regclass);
+ALTER TABLE ONLY public.active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('public.active_storage_blobs_id_seq'::regclass);
 
 
 --
 -- Name: adaptation_values id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_values ALTER COLUMN id SET DEFAULT nextval('adaptation_values_id_seq'::regclass);
+ALTER TABLE ONLY public.adaptation_values ALTER COLUMN id SET DEFAULT nextval('public.adaptation_values_id_seq'::regclass);
 
 
 --
 -- Name: adaptation_variables id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_variables ALTER COLUMN id SET DEFAULT nextval('adaptation_variables_id_seq'::regclass);
+ALTER TABLE ONLY public.adaptation_variables ALTER COLUMN id SET DEFAULT nextval('public.adaptation_variables_id_seq'::regclass);
 
 
 --
 -- Name: datasets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY datasets ALTER COLUMN id SET DEFAULT nextval('datasets_id_seq'::regclass);
+ALTER TABLE ONLY public.datasets ALTER COLUMN id SET DEFAULT nextval('public.datasets_id_seq'::regclass);
 
 
 --
 -- Name: documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY documents ALTER COLUMN id SET DEFAULT nextval('documents_id_seq'::regclass);
+ALTER TABLE ONLY public.documents ALTER COLUMN id SET DEFAULT nextval('public.documents_id_seq'::regclass);
 
 
 --
 -- Name: historical_emissions_data_sources id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_data_sources ALTER COLUMN id SET DEFAULT nextval('historical_emissions_data_sources_id_seq'::regclass);
+ALTER TABLE ONLY public.historical_emissions_data_sources ALTER COLUMN id SET DEFAULT nextval('public.historical_emissions_data_sources_id_seq'::regclass);
 
 
 --
 -- Name: historical_emissions_gases id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_gases ALTER COLUMN id SET DEFAULT nextval('historical_emissions_gases_id_seq'::regclass);
+ALTER TABLE ONLY public.historical_emissions_gases ALTER COLUMN id SET DEFAULT nextval('public.historical_emissions_gases_id_seq'::regclass);
 
 
 --
 -- Name: historical_emissions_gwps id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_gwps ALTER COLUMN id SET DEFAULT nextval('historical_emissions_gwps_id_seq'::regclass);
+ALTER TABLE ONLY public.historical_emissions_gwps ALTER COLUMN id SET DEFAULT nextval('public.historical_emissions_gwps_id_seq'::regclass);
 
 
 --
 -- Name: historical_emissions_records id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records ALTER COLUMN id SET DEFAULT nextval('historical_emissions_records_id_seq'::regclass);
+ALTER TABLE ONLY public.historical_emissions_records ALTER COLUMN id SET DEFAULT nextval('public.historical_emissions_records_id_seq'::regclass);
 
 
 --
 -- Name: historical_emissions_sectors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_sectors ALTER COLUMN id SET DEFAULT nextval('historical_emissions_sectors_id_seq'::regclass);
+ALTER TABLE ONLY public.historical_emissions_sectors ALTER COLUMN id SET DEFAULT nextval('public.historical_emissions_sectors_id_seq'::regclass);
 
 
 --
 -- Name: indc_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_categories ALTER COLUMN id SET DEFAULT nextval('indc_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_categories ALTER COLUMN id SET DEFAULT nextval('public.indc_categories_id_seq'::regclass);
 
 
 --
 -- Name: indc_category_types id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_category_types ALTER COLUMN id SET DEFAULT nextval('indc_category_types_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_category_types ALTER COLUMN id SET DEFAULT nextval('public.indc_category_types_id_seq'::regclass);
 
 
 --
 -- Name: indc_indicators id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators ALTER COLUMN id SET DEFAULT nextval('indc_indicators_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_indicators ALTER COLUMN id SET DEFAULT nextval('public.indc_indicators_id_seq'::regclass);
 
 
 --
 -- Name: indc_indicators_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators_categories ALTER COLUMN id SET DEFAULT nextval('indc_indicators_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_indicators_categories ALTER COLUMN id SET DEFAULT nextval('public.indc_indicators_categories_id_seq'::regclass);
 
 
 --
 -- Name: indc_labels id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_labels ALTER COLUMN id SET DEFAULT nextval('indc_labels_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_labels ALTER COLUMN id SET DEFAULT nextval('public.indc_labels_id_seq'::regclass);
 
 
 --
 -- Name: indc_sectors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_sectors ALTER COLUMN id SET DEFAULT nextval('indc_sectors_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_sectors ALTER COLUMN id SET DEFAULT nextval('public.indc_sectors_id_seq'::regclass);
 
 
 --
 -- Name: indc_sources id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_sources ALTER COLUMN id SET DEFAULT nextval('indc_sources_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_sources ALTER COLUMN id SET DEFAULT nextval('public.indc_sources_id_seq'::regclass);
 
 
 --
 -- Name: indc_submissions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_submissions ALTER COLUMN id SET DEFAULT nextval('indc_submissions_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_submissions ALTER COLUMN id SET DEFAULT nextval('public.indc_submissions_id_seq'::regclass);
 
 
 --
 -- Name: indc_values id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values ALTER COLUMN id SET DEFAULT nextval('indc_values_id_seq'::regclass);
+ALTER TABLE ONLY public.indc_values ALTER COLUMN id SET DEFAULT nextval('public.indc_values_id_seq'::regclass);
 
 
 --
 -- Name: location_members id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY location_members ALTER COLUMN id SET DEFAULT nextval('location_members_id_seq'::regclass);
+ALTER TABLE ONLY public.location_members ALTER COLUMN id SET DEFAULT nextval('public.location_members_id_seq'::regclass);
 
 
 --
 -- Name: locations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY locations ALTER COLUMN id SET DEFAULT nextval('locations_id_seq'::regclass);
+ALTER TABLE ONLY public.locations ALTER COLUMN id SET DEFAULT nextval('public.locations_id_seq'::regclass);
 
 
 --
 -- Name: ndc_sdg_goals id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_goals ALTER COLUMN id SET DEFAULT nextval('ndc_sdg_goals_id_seq'::regclass);
+ALTER TABLE ONLY public.ndc_sdg_goals ALTER COLUMN id SET DEFAULT nextval('public.ndc_sdg_goals_id_seq'::regclass);
 
 
 --
 -- Name: ndc_sdg_ndc_target_sectors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_target_sectors ALTER COLUMN id SET DEFAULT nextval('ndc_sdg_ndc_target_sectors_id_seq'::regclass);
+ALTER TABLE ONLY public.ndc_sdg_ndc_target_sectors ALTER COLUMN id SET DEFAULT nextval('public.ndc_sdg_ndc_target_sectors_id_seq'::regclass);
 
 
 --
 -- Name: ndc_sdg_ndc_targets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_targets ALTER COLUMN id SET DEFAULT nextval('ndc_sdg_ndc_targets_id_seq'::regclass);
+ALTER TABLE ONLY public.ndc_sdg_ndc_targets ALTER COLUMN id SET DEFAULT nextval('public.ndc_sdg_ndc_targets_id_seq'::regclass);
 
 
 --
 -- Name: ndc_sdg_sectors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_sectors ALTER COLUMN id SET DEFAULT nextval('ndc_sdg_sectors_id_seq'::regclass);
+ALTER TABLE ONLY public.ndc_sdg_sectors ALTER COLUMN id SET DEFAULT nextval('public.ndc_sdg_sectors_id_seq'::regclass);
 
 
 --
 -- Name: ndc_sdg_targets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_targets ALTER COLUMN id SET DEFAULT nextval('ndc_sdg_targets_id_seq'::regclass);
+ALTER TABLE ONLY public.ndc_sdg_targets ALTER COLUMN id SET DEFAULT nextval('public.ndc_sdg_targets_id_seq'::regclass);
 
 
 --
 -- Name: ndcs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndcs ALTER COLUMN id SET DEFAULT nextval('ndcs_id_seq'::regclass);
+ALTER TABLE ONLY public.ndcs ALTER COLUMN id SET DEFAULT nextval('public.ndcs_id_seq'::regclass);
 
 
 --
 -- Name: platforms id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY platforms ALTER COLUMN id SET DEFAULT nextval('platforms_id_seq'::regclass);
+ALTER TABLE ONLY public.platforms ALTER COLUMN id SET DEFAULT nextval('public.platforms_id_seq'::regclass);
 
 
 --
 -- Name: quantification_labels id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_labels ALTER COLUMN id SET DEFAULT nextval('quantification_labels_id_seq'::regclass);
+ALTER TABLE ONLY public.quantification_labels ALTER COLUMN id SET DEFAULT nextval('public.quantification_labels_id_seq'::regclass);
 
 
 --
 -- Name: quantification_values id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_values ALTER COLUMN id SET DEFAULT nextval('quantification_values_id_seq'::regclass);
+ALTER TABLE ONLY public.quantification_values ALTER COLUMN id SET DEFAULT nextval('public.quantification_values_id_seq'::regclass);
 
 
 --
 -- Name: sections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections ALTER COLUMN id SET DEFAULT nextval('sections_id_seq'::regclass);
+ALTER TABLE ONLY public.sections ALTER COLUMN id SET DEFAULT nextval('public.sections_id_seq'::regclass);
 
 
 --
 -- Name: socioeconomic_indicators id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY socioeconomic_indicators ALTER COLUMN id SET DEFAULT nextval('socioeconomic_indicators_id_seq'::regclass);
+ALTER TABLE ONLY public.socioeconomic_indicators ALTER COLUMN id SET DEFAULT nextval('public.socioeconomic_indicators_id_seq'::regclass);
 
 
 --
 -- Name: stories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stories ALTER COLUMN id SET DEFAULT nextval('stories_id_seq'::regclass);
+ALTER TABLE ONLY public.stories ALTER COLUMN id SET DEFAULT nextval('public.stories_id_seq'::regclass);
 
 
 --
 -- Name: timeline_documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_documents ALTER COLUMN id SET DEFAULT nextval('timeline_documents_id_seq'::regclass);
+ALTER TABLE ONLY public.timeline_documents ALTER COLUMN id SET DEFAULT nextval('public.timeline_documents_id_seq'::regclass);
 
 
 --
 -- Name: timeline_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_notes ALTER COLUMN id SET DEFAULT nextval('timeline_notes_id_seq'::regclass);
+ALTER TABLE ONLY public.timeline_notes ALTER COLUMN id SET DEFAULT nextval('public.timeline_notes_id_seq'::regclass);
 
 
 --
 -- Name: timeline_sources id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_sources ALTER COLUMN id SET DEFAULT nextval('timeline_sources_id_seq'::regclass);
+ALTER TABLE ONLY public.timeline_sources ALTER COLUMN id SET DEFAULT nextval('public.timeline_sources_id_seq'::regclass);
 
 
 --
 -- Name: user_stories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_stories ALTER COLUMN id SET DEFAULT nextval('user_stories_id_seq'::regclass);
+ALTER TABLE ONLY public.user_stories ALTER COLUMN id SET DEFAULT nextval('public.user_stories_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: visualizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY visualizations ALTER COLUMN id SET DEFAULT nextval('visualizations_id_seq'::regclass);
+ALTER TABLE ONLY public.visualizations ALTER COLUMN id SET DEFAULT nextval('public.visualizations_id_seq'::regclass);
 
 
 --
 -- Name: wb_extra_country_data id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wb_extra_country_data ALTER COLUMN id SET DEFAULT nextval('wb_extra_country_data_id_seq'::regclass);
+ALTER TABLE ONLY public.wb_extra_country_data ALTER COLUMN id SET DEFAULT nextval('public.wb_extra_country_data_id_seq'::regclass);
 
 
 --
 -- Name: worker_logs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY worker_logs ALTER COLUMN id SET DEFAULT nextval('worker_logs_id_seq'::regclass);
+ALTER TABLE ONLY public.worker_logs ALTER COLUMN id SET DEFAULT nextval('public.worker_logs_id_seq'::regclass);
 
 
 --
 -- Name: wri_metadata_acronyms id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_acronyms ALTER COLUMN id SET DEFAULT nextval('wri_metadata_acronyms_id_seq'::regclass);
+ALTER TABLE ONLY public.wri_metadata_acronyms ALTER COLUMN id SET DEFAULT nextval('public.wri_metadata_acronyms_id_seq'::regclass);
 
 
 --
 -- Name: wri_metadata_properties id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_properties ALTER COLUMN id SET DEFAULT nextval('wri_metadata_properties_id_seq'::regclass);
+ALTER TABLE ONLY public.wri_metadata_properties ALTER COLUMN id SET DEFAULT nextval('public.wri_metadata_properties_id_seq'::regclass);
 
 
 --
 -- Name: wri_metadata_sources id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_sources ALTER COLUMN id SET DEFAULT nextval('wri_metadata_sources_id_seq'::regclass);
+ALTER TABLE ONLY public.wri_metadata_sources ALTER COLUMN id SET DEFAULT nextval('public.wri_metadata_sources_id_seq'::regclass);
 
 
 --
 -- Name: wri_metadata_values id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_values ALTER COLUMN id SET DEFAULT nextval('wri_metadata_values_id_seq'::regclass);
+ALTER TABLE ONLY public.wri_metadata_values ALTER COLUMN id SET DEFAULT nextval('public.wri_metadata_values_id_seq'::regclass);
 
 
 --
 -- Name: indc_values indc_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values
+ALTER TABLE ONLY public.indc_values
     ADD CONSTRAINT indc_values_pkey PRIMARY KEY (id);
 
 
@@ -1994,7 +1993,7 @@ ALTER TABLE ONLY indc_values
 -- Name: indc_searchable_values; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW indc_searchable_values AS
+CREATE MATERIALIZED VIEW public.indc_searchable_values AS
  SELECT indc_values.id,
     indc_indicators.source_id,
     indc_sources.name AS source,
@@ -2011,37 +2010,37 @@ CREATE MATERIALIZED VIEW indc_searchable_values AS
     indc_indicators.slug AS indicator_slug,
     indc_indicators.name AS indicator_name,
     indc_values.value
-   FROM ((((((((indc_values
-     JOIN locations ON ((locations.id = indc_values.location_id)))
-     JOIN indc_indicators ON ((indc_indicators.id = indc_values.indicator_id)))
-     JOIN indc_sources ON ((indc_sources.id = indc_indicators.source_id)))
+   FROM ((((((((public.indc_values
+     JOIN public.locations ON ((locations.id = indc_values.location_id)))
+     JOIN public.indc_indicators ON ((indc_indicators.id = indc_values.indicator_id)))
+     JOIN public.indc_sources ON ((indc_sources.id = indc_indicators.source_id)))
      LEFT JOIN ( SELECT indc_sectors.id,
             indc_sectors.parent_id,
             indc_sectors.name
-           FROM indc_sectors
+           FROM public.indc_sectors
           WHERE (indc_sectors.parent_id IS NOT NULL)) subsectors ON ((indc_values.sector_id = subsectors.id)))
      LEFT JOIN ( SELECT indc_sectors.id,
             indc_sectors.parent_id,
             indc_sectors.name
-           FROM indc_sectors
+           FROM public.indc_sectors
           WHERE (indc_sectors.parent_id IS NULL)) sectors ON ((indc_values.sector_id = sectors.id)))
      LEFT JOIN ( SELECT indc_sectors.id,
             indc_sectors.parent_id,
             indc_sectors.name
-           FROM indc_sectors
+           FROM public.indc_sectors
           WHERE (indc_sectors.parent_id IS NULL)) parent_sectors ON ((subsectors.parent_id = parent_sectors.id)))
      LEFT JOIN ( SELECT ic.category_id,
             ic.indicator_id,
             c.name
-           FROM ((indc_indicators_categories ic
-             JOIN indc_categories c ON ((ic.category_id = c.id)))
-             JOIN indc_category_types ct ON (((c.category_type_id = ct.id) AND (upper(ct.name) = 'GLOBAL'::text))))) global_categories ON ((global_categories.indicator_id = indc_indicators.id)))
+           FROM ((public.indc_indicators_categories ic
+             JOIN public.indc_categories c ON ((ic.category_id = c.id)))
+             JOIN public.indc_category_types ct ON (((c.category_type_id = ct.id) AND (upper(ct.name) = 'GLOBAL'::text))))) global_categories ON ((global_categories.indicator_id = indc_indicators.id)))
      LEFT JOIN ( SELECT ic.category_id,
             ic.indicator_id,
             c.name
-           FROM ((indc_indicators_categories ic
-             JOIN indc_categories c ON ((ic.category_id = c.id)))
-             JOIN indc_category_types ct ON (((c.category_type_id = ct.id) AND (upper(ct.name) = 'OVERVIEW'::text))))) overview_categories ON ((overview_categories.indicator_id = indc_indicators.id)))
+           FROM ((public.indc_indicators_categories ic
+             JOIN public.indc_categories c ON ((ic.category_id = c.id)))
+             JOIN public.indc_category_types ct ON (((c.category_type_id = ct.id) AND (upper(ct.name) = 'OVERVIEW'::text))))) overview_categories ON ((overview_categories.indicator_id = indc_indicators.id)))
   GROUP BY indc_values.id, indc_indicators.source_id, indc_sources.name, locations.iso_code3, locations.wri_standard_name, COALESCE(sectors.name, parent_sectors.name), COALESCE(subsectors.name), indc_indicators.slug, indc_indicators.name, indc_values.value
   ORDER BY locations.wri_standard_name
   WITH NO DATA;
@@ -2051,7 +2050,7 @@ CREATE MATERIALIZED VIEW indc_searchable_values AS
 -- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_attachments
+ALTER TABLE ONLY public.active_storage_attachments
     ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
 
 
@@ -2059,7 +2058,7 @@ ALTER TABLE ONLY active_storage_attachments
 -- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_blobs
+ALTER TABLE ONLY public.active_storage_blobs
     ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
@@ -2067,7 +2066,7 @@ ALTER TABLE ONLY active_storage_blobs
 -- Name: adaptation_values adaptation_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_values
+ALTER TABLE ONLY public.adaptation_values
     ADD CONSTRAINT adaptation_values_pkey PRIMARY KEY (id);
 
 
@@ -2075,7 +2074,7 @@ ALTER TABLE ONLY adaptation_values
 -- Name: adaptation_variables adaptation_variables_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_variables
+ALTER TABLE ONLY public.adaptation_variables
     ADD CONSTRAINT adaptation_variables_pkey PRIMARY KEY (id);
 
 
@@ -2083,7 +2082,7 @@ ALTER TABLE ONLY adaptation_variables
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -2091,7 +2090,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: datasets datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY datasets
+ALTER TABLE ONLY public.datasets
     ADD CONSTRAINT datasets_pkey PRIMARY KEY (id);
 
 
@@ -2099,7 +2098,7 @@ ALTER TABLE ONLY datasets
 -- Name: datasets datasets_section_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY datasets
+ALTER TABLE ONLY public.datasets
     ADD CONSTRAINT datasets_section_id_name_key UNIQUE (section_id, name);
 
 
@@ -2107,7 +2106,7 @@ ALTER TABLE ONLY datasets
 -- Name: documents documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY documents
+ALTER TABLE ONLY public.documents
     ADD CONSTRAINT documents_pkey PRIMARY KEY (id);
 
 
@@ -2115,7 +2114,7 @@ ALTER TABLE ONLY documents
 -- Name: historical_emissions_data_sources historical_emissions_data_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_data_sources
+ALTER TABLE ONLY public.historical_emissions_data_sources
     ADD CONSTRAINT historical_emissions_data_sources_pkey PRIMARY KEY (id);
 
 
@@ -2123,7 +2122,7 @@ ALTER TABLE ONLY historical_emissions_data_sources
 -- Name: historical_emissions_gases historical_emissions_gases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_gases
+ALTER TABLE ONLY public.historical_emissions_gases
     ADD CONSTRAINT historical_emissions_gases_pkey PRIMARY KEY (id);
 
 
@@ -2131,7 +2130,7 @@ ALTER TABLE ONLY historical_emissions_gases
 -- Name: historical_emissions_gwps historical_emissions_gwps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_gwps
+ALTER TABLE ONLY public.historical_emissions_gwps
     ADD CONSTRAINT historical_emissions_gwps_pkey PRIMARY KEY (id);
 
 
@@ -2139,7 +2138,7 @@ ALTER TABLE ONLY historical_emissions_gwps
 -- Name: historical_emissions_records historical_emissions_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
+ALTER TABLE ONLY public.historical_emissions_records
     ADD CONSTRAINT historical_emissions_records_pkey PRIMARY KEY (id);
 
 
@@ -2147,7 +2146,7 @@ ALTER TABLE ONLY historical_emissions_records
 -- Name: historical_emissions_sectors historical_emissions_sectors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_sectors
+ALTER TABLE ONLY public.historical_emissions_sectors
     ADD CONSTRAINT historical_emissions_sectors_pkey PRIMARY KEY (id);
 
 
@@ -2155,7 +2154,7 @@ ALTER TABLE ONLY historical_emissions_sectors
 -- Name: indc_categories indc_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_categories
+ALTER TABLE ONLY public.indc_categories
     ADD CONSTRAINT indc_categories_pkey PRIMARY KEY (id);
 
 
@@ -2163,7 +2162,7 @@ ALTER TABLE ONLY indc_categories
 -- Name: indc_category_types indc_category_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_category_types
+ALTER TABLE ONLY public.indc_category_types
     ADD CONSTRAINT indc_category_types_pkey PRIMARY KEY (id);
 
 
@@ -2171,7 +2170,7 @@ ALTER TABLE ONLY indc_category_types
 -- Name: indc_indicators_categories indc_indicators_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators_categories
+ALTER TABLE ONLY public.indc_indicators_categories
     ADD CONSTRAINT indc_indicators_categories_pkey PRIMARY KEY (id);
 
 
@@ -2179,7 +2178,7 @@ ALTER TABLE ONLY indc_indicators_categories
 -- Name: indc_indicators indc_indicators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators
+ALTER TABLE ONLY public.indc_indicators
     ADD CONSTRAINT indc_indicators_pkey PRIMARY KEY (id);
 
 
@@ -2187,7 +2186,7 @@ ALTER TABLE ONLY indc_indicators
 -- Name: indc_labels indc_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_labels
+ALTER TABLE ONLY public.indc_labels
     ADD CONSTRAINT indc_labels_pkey PRIMARY KEY (id);
 
 
@@ -2195,7 +2194,7 @@ ALTER TABLE ONLY indc_labels
 -- Name: indc_sectors indc_sectors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_sectors
+ALTER TABLE ONLY public.indc_sectors
     ADD CONSTRAINT indc_sectors_pkey PRIMARY KEY (id);
 
 
@@ -2203,7 +2202,7 @@ ALTER TABLE ONLY indc_sectors
 -- Name: indc_sources indc_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_sources
+ALTER TABLE ONLY public.indc_sources
     ADD CONSTRAINT indc_sources_pkey PRIMARY KEY (id);
 
 
@@ -2211,7 +2210,7 @@ ALTER TABLE ONLY indc_sources
 -- Name: indc_submissions indc_submissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_submissions
+ALTER TABLE ONLY public.indc_submissions
     ADD CONSTRAINT indc_submissions_pkey PRIMARY KEY (id);
 
 
@@ -2219,7 +2218,7 @@ ALTER TABLE ONLY indc_submissions
 -- Name: location_members location_members_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY location_members
+ALTER TABLE ONLY public.location_members
     ADD CONSTRAINT location_members_pkey PRIMARY KEY (id);
 
 
@@ -2227,7 +2226,7 @@ ALTER TABLE ONLY location_members
 -- Name: locations locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY locations
+ALTER TABLE ONLY public.locations
     ADD CONSTRAINT locations_pkey PRIMARY KEY (id);
 
 
@@ -2235,7 +2234,7 @@ ALTER TABLE ONLY locations
 -- Name: ndc_sdg_goals ndc_sdg_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_goals
+ALTER TABLE ONLY public.ndc_sdg_goals
     ADD CONSTRAINT ndc_sdg_goals_pkey PRIMARY KEY (id);
 
 
@@ -2243,7 +2242,7 @@ ALTER TABLE ONLY ndc_sdg_goals
 -- Name: ndc_sdg_ndc_target_sectors ndc_sdg_ndc_target_sectors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_target_sectors
+ALTER TABLE ONLY public.ndc_sdg_ndc_target_sectors
     ADD CONSTRAINT ndc_sdg_ndc_target_sectors_pkey PRIMARY KEY (id);
 
 
@@ -2251,7 +2250,7 @@ ALTER TABLE ONLY ndc_sdg_ndc_target_sectors
 -- Name: ndc_sdg_ndc_targets ndc_sdg_ndc_targets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_targets
+ALTER TABLE ONLY public.ndc_sdg_ndc_targets
     ADD CONSTRAINT ndc_sdg_ndc_targets_pkey PRIMARY KEY (id);
 
 
@@ -2259,7 +2258,7 @@ ALTER TABLE ONLY ndc_sdg_ndc_targets
 -- Name: ndc_sdg_sectors ndc_sdg_sectors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_sectors
+ALTER TABLE ONLY public.ndc_sdg_sectors
     ADD CONSTRAINT ndc_sdg_sectors_pkey PRIMARY KEY (id);
 
 
@@ -2267,7 +2266,7 @@ ALTER TABLE ONLY ndc_sdg_sectors
 -- Name: ndc_sdg_targets ndc_sdg_targets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_targets
+ALTER TABLE ONLY public.ndc_sdg_targets
     ADD CONSTRAINT ndc_sdg_targets_pkey PRIMARY KEY (id);
 
 
@@ -2275,7 +2274,7 @@ ALTER TABLE ONLY ndc_sdg_targets
 -- Name: ndcs ndcs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndcs
+ALTER TABLE ONLY public.ndcs
     ADD CONSTRAINT ndcs_pkey PRIMARY KEY (id);
 
 
@@ -2283,7 +2282,7 @@ ALTER TABLE ONLY ndcs
 -- Name: platforms platforms_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY platforms
+ALTER TABLE ONLY public.platforms
     ADD CONSTRAINT platforms_name_key UNIQUE (name);
 
 
@@ -2291,7 +2290,7 @@ ALTER TABLE ONLY platforms
 -- Name: platforms platforms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY platforms
+ALTER TABLE ONLY public.platforms
     ADD CONSTRAINT platforms_pkey PRIMARY KEY (id);
 
 
@@ -2299,7 +2298,7 @@ ALTER TABLE ONLY platforms
 -- Name: quantification_labels quantification_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_labels
+ALTER TABLE ONLY public.quantification_labels
     ADD CONSTRAINT quantification_labels_pkey PRIMARY KEY (id);
 
 
@@ -2307,7 +2306,7 @@ ALTER TABLE ONLY quantification_labels
 -- Name: quantification_values quantification_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_values
+ALTER TABLE ONLY public.quantification_values
     ADD CONSTRAINT quantification_values_pkey PRIMARY KEY (id);
 
 
@@ -2315,7 +2314,7 @@ ALTER TABLE ONLY quantification_values
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -2323,7 +2322,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: sections sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections
+ALTER TABLE ONLY public.sections
     ADD CONSTRAINT sections_pkey PRIMARY KEY (id);
 
 
@@ -2331,7 +2330,7 @@ ALTER TABLE ONLY sections
 -- Name: sections sections_platform_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections
+ALTER TABLE ONLY public.sections
     ADD CONSTRAINT sections_platform_id_name_key UNIQUE (platform_id, name);
 
 
@@ -2339,7 +2338,7 @@ ALTER TABLE ONLY sections
 -- Name: socioeconomic_indicators socioeconomic_indicators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY socioeconomic_indicators
+ALTER TABLE ONLY public.socioeconomic_indicators
     ADD CONSTRAINT socioeconomic_indicators_pkey PRIMARY KEY (id);
 
 
@@ -2347,7 +2346,7 @@ ALTER TABLE ONLY socioeconomic_indicators
 -- Name: stories stories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stories
+ALTER TABLE ONLY public.stories
     ADD CONSTRAINT stories_pkey PRIMARY KEY (id);
 
 
@@ -2355,7 +2354,7 @@ ALTER TABLE ONLY stories
 -- Name: timeline_documents timeline_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_documents
+ALTER TABLE ONLY public.timeline_documents
     ADD CONSTRAINT timeline_documents_pkey PRIMARY KEY (id);
 
 
@@ -2363,7 +2362,7 @@ ALTER TABLE ONLY timeline_documents
 -- Name: timeline_notes timeline_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_notes
+ALTER TABLE ONLY public.timeline_notes
     ADD CONSTRAINT timeline_notes_pkey PRIMARY KEY (id);
 
 
@@ -2371,7 +2370,7 @@ ALTER TABLE ONLY timeline_notes
 -- Name: timeline_sources timeline_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_sources
+ALTER TABLE ONLY public.timeline_sources
     ADD CONSTRAINT timeline_sources_pkey PRIMARY KEY (id);
 
 
@@ -2379,7 +2378,7 @@ ALTER TABLE ONLY timeline_sources
 -- Name: user_stories user_stories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_stories
+ALTER TABLE ONLY public.user_stories
     ADD CONSTRAINT user_stories_pkey PRIMARY KEY (id);
 
 
@@ -2387,7 +2386,7 @@ ALTER TABLE ONLY user_stories
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -2395,7 +2394,7 @@ ALTER TABLE ONLY users
 -- Name: visualizations visualizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY visualizations
+ALTER TABLE ONLY public.visualizations
     ADD CONSTRAINT visualizations_pkey PRIMARY KEY (id);
 
 
@@ -2403,7 +2402,7 @@ ALTER TABLE ONLY visualizations
 -- Name: wb_extra_country_data wb_extra_country_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wb_extra_country_data
+ALTER TABLE ONLY public.wb_extra_country_data
     ADD CONSTRAINT wb_extra_country_data_pkey PRIMARY KEY (id);
 
 
@@ -2411,7 +2410,7 @@ ALTER TABLE ONLY wb_extra_country_data
 -- Name: worker_logs worker_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY worker_logs
+ALTER TABLE ONLY public.worker_logs
     ADD CONSTRAINT worker_logs_pkey PRIMARY KEY (id);
 
 
@@ -2419,7 +2418,7 @@ ALTER TABLE ONLY worker_logs
 -- Name: wri_metadata_acronyms wri_metadata_acronyms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_acronyms
+ALTER TABLE ONLY public.wri_metadata_acronyms
     ADD CONSTRAINT wri_metadata_acronyms_pkey PRIMARY KEY (id);
 
 
@@ -2427,7 +2426,7 @@ ALTER TABLE ONLY wri_metadata_acronyms
 -- Name: wri_metadata_properties wri_metadata_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_properties
+ALTER TABLE ONLY public.wri_metadata_properties
     ADD CONSTRAINT wri_metadata_properties_pkey PRIMARY KEY (id);
 
 
@@ -2435,7 +2434,7 @@ ALTER TABLE ONLY wri_metadata_properties
 -- Name: wri_metadata_sources wri_metadata_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_sources
+ALTER TABLE ONLY public.wri_metadata_sources
     ADD CONSTRAINT wri_metadata_sources_pkey PRIMARY KEY (id);
 
 
@@ -2443,7 +2442,7 @@ ALTER TABLE ONLY wri_metadata_sources
 -- Name: wri_metadata_values wri_metadata_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_values
+ALTER TABLE ONLY public.wri_metadata_values
     ADD CONSTRAINT wri_metadata_values_pkey PRIMARY KEY (id);
 
 
@@ -2451,925 +2450,925 @@ ALTER TABLE ONLY wri_metadata_values
 -- Name: indc_indicators_categories_uniq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX indc_indicators_categories_uniq ON indc_indicators_categories USING btree (indicator_id, category_id);
+CREATE UNIQUE INDEX indc_indicators_categories_uniq ON public.indc_indicators_categories USING btree (indicator_id, category_id);
 
 
 --
 -- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
+CREATE INDEX index_active_storage_attachments_on_blob_id ON public.active_storage_attachments USING btree (blob_id);
 
 
 --
 -- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON public.active_storage_attachments USING btree (record_type, record_id, name, blob_id);
 
 
 --
 -- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_blobs USING btree (key);
 
 
 --
 -- Name: index_adaptation_values_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_adaptation_values_on_location_id ON adaptation_values USING btree (location_id);
+CREATE INDEX index_adaptation_values_on_location_id ON public.adaptation_values USING btree (location_id);
 
 
 --
 -- Name: index_adaptation_values_on_variable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_adaptation_values_on_variable_id ON adaptation_values USING btree (variable_id);
+CREATE INDEX index_adaptation_values_on_variable_id ON public.adaptation_values USING btree (variable_id);
 
 
 --
 -- Name: index_adaptation_variables_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_adaptation_variables_on_slug ON adaptation_variables USING btree (slug);
+CREATE UNIQUE INDEX index_adaptation_variables_on_slug ON public.adaptation_variables USING btree (slug);
 
 
 --
 -- Name: index_datasets_on_section_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_datasets_on_section_id ON datasets USING btree (section_id);
+CREATE INDEX index_datasets_on_section_id ON public.datasets USING btree (section_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_data_source_id ON historical_emissions_normalised_records USING btree (data_source_id);
+CREATE INDEX index_historical_emissions_normalised_records_on_data_source_id ON public.historical_emissions_normalised_records USING btree (data_source_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_gas_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_gas_id ON historical_emissions_normalised_records USING btree (gas_id);
+CREATE INDEX index_historical_emissions_normalised_records_on_gas_id ON public.historical_emissions_normalised_records USING btree (gas_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_gwp_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_gwp_id ON historical_emissions_normalised_records USING btree (gwp_id);
+CREATE INDEX index_historical_emissions_normalised_records_on_gwp_id ON public.historical_emissions_normalised_records USING btree (gwp_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_id_and_year; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_historical_emissions_normalised_records_on_id_and_year ON historical_emissions_normalised_records USING btree (id, year);
+CREATE UNIQUE INDEX index_historical_emissions_normalised_records_on_id_and_year ON public.historical_emissions_normalised_records USING btree (id, year);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_location_id ON historical_emissions_normalised_records USING btree (location_id);
+CREATE INDEX index_historical_emissions_normalised_records_on_location_id ON public.historical_emissions_normalised_records USING btree (location_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_sector_id ON historical_emissions_normalised_records USING btree (sector_id);
+CREATE INDEX index_historical_emissions_normalised_records_on_sector_id ON public.historical_emissions_normalised_records USING btree (sector_id);
 
 
 --
 -- Name: index_historical_emissions_normalised_records_on_year; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_normalised_records_on_year ON historical_emissions_normalised_records USING btree (year);
+CREATE INDEX index_historical_emissions_normalised_records_on_year ON public.historical_emissions_normalised_records USING btree (year);
 
 
 --
 -- Name: index_historical_emissions_records_emissions_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_historical_emissions_records_emissions_on_id ON historical_emissions_records_emissions USING btree (id);
+CREATE UNIQUE INDEX index_historical_emissions_records_emissions_on_id ON public.historical_emissions_records_emissions USING btree (id);
 
 
 --
 -- Name: index_historical_emissions_records_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_records_on_data_source_id ON historical_emissions_records USING btree (data_source_id);
+CREATE INDEX index_historical_emissions_records_on_data_source_id ON public.historical_emissions_records USING btree (data_source_id);
 
 
 --
 -- Name: index_historical_emissions_records_on_gas_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_records_on_gas_id ON historical_emissions_records USING btree (gas_id);
+CREATE INDEX index_historical_emissions_records_on_gas_id ON public.historical_emissions_records USING btree (gas_id);
 
 
 --
 -- Name: index_historical_emissions_records_on_gwp_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_records_on_gwp_id ON historical_emissions_records USING btree (gwp_id);
+CREATE INDEX index_historical_emissions_records_on_gwp_id ON public.historical_emissions_records USING btree (gwp_id);
 
 
 --
 -- Name: index_historical_emissions_records_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_records_on_location_id ON historical_emissions_records USING btree (location_id);
+CREATE INDEX index_historical_emissions_records_on_location_id ON public.historical_emissions_records USING btree (location_id);
 
 
 --
 -- Name: index_historical_emissions_records_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_records_on_sector_id ON historical_emissions_records USING btree (sector_id);
+CREATE INDEX index_historical_emissions_records_on_sector_id ON public.historical_emissions_records USING btree (sector_id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_searchable_records_on_data_source_id ON historical_emissions_searchable_records USING btree (data_source_id);
+CREATE INDEX index_historical_emissions_searchable_records_on_data_source_id ON public.historical_emissions_searchable_records USING btree (data_source_id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_gas_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_searchable_records_on_gas_id ON historical_emissions_searchable_records USING btree (gas_id);
+CREATE INDEX index_historical_emissions_searchable_records_on_gas_id ON public.historical_emissions_searchable_records USING btree (gas_id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_gwp_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_searchable_records_on_gwp_id ON historical_emissions_searchable_records USING btree (gwp_id);
+CREATE INDEX index_historical_emissions_searchable_records_on_gwp_id ON public.historical_emissions_searchable_records USING btree (gwp_id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_historical_emissions_searchable_records_on_id ON historical_emissions_searchable_records USING btree (id);
+CREATE UNIQUE INDEX index_historical_emissions_searchable_records_on_id ON public.historical_emissions_searchable_records USING btree (id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_searchable_records_on_location_id ON historical_emissions_searchable_records USING btree (location_id);
+CREATE INDEX index_historical_emissions_searchable_records_on_location_id ON public.historical_emissions_searchable_records USING btree (location_id);
 
 
 --
 -- Name: index_historical_emissions_searchable_records_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_searchable_records_on_sector_id ON historical_emissions_searchable_records USING btree (sector_id);
+CREATE INDEX index_historical_emissions_searchable_records_on_sector_id ON public.historical_emissions_searchable_records USING btree (sector_id);
 
 
 --
 -- Name: index_historical_emissions_sectors_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_sectors_on_data_source_id ON historical_emissions_sectors USING btree (data_source_id);
+CREATE INDEX index_historical_emissions_sectors_on_data_source_id ON public.historical_emissions_sectors USING btree (data_source_id);
 
 
 --
 -- Name: index_historical_emissions_sectors_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_historical_emissions_sectors_on_parent_id ON historical_emissions_sectors USING btree (parent_id);
+CREATE INDEX index_historical_emissions_sectors_on_parent_id ON public.historical_emissions_sectors USING btree (parent_id);
 
 
 --
 -- Name: index_indc_categories_on_category_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_categories_on_category_type_id ON indc_categories USING btree (category_type_id);
+CREATE INDEX index_indc_categories_on_category_type_id ON public.indc_categories USING btree (category_type_id);
 
 
 --
 -- Name: index_indc_categories_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_categories_on_parent_id ON indc_categories USING btree (parent_id);
+CREATE INDEX index_indc_categories_on_parent_id ON public.indc_categories USING btree (parent_id);
 
 
 --
 -- Name: index_indc_categories_on_slug_and_category_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_indc_categories_on_slug_and_category_type_id ON indc_categories USING btree (slug, category_type_id);
+CREATE UNIQUE INDEX index_indc_categories_on_slug_and_category_type_id ON public.indc_categories USING btree (slug, category_type_id);
 
 
 --
 -- Name: index_indc_category_types_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_indc_category_types_on_name ON indc_category_types USING btree (name);
+CREATE UNIQUE INDEX index_indc_category_types_on_name ON public.indc_category_types USING btree (name);
 
 
 --
 -- Name: index_indc_indicators_categories_on_category_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_indicators_categories_on_category_id ON indc_indicators_categories USING btree (category_id);
+CREATE INDEX index_indc_indicators_categories_on_category_id ON public.indc_indicators_categories USING btree (category_id);
 
 
 --
 -- Name: index_indc_indicators_categories_on_indicator_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_indicators_categories_on_indicator_id ON indc_indicators_categories USING btree (indicator_id);
+CREATE INDEX index_indc_indicators_categories_on_indicator_id ON public.indc_indicators_categories USING btree (indicator_id);
 
 
 --
 -- Name: index_indc_indicators_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_indc_indicators_on_slug ON indc_indicators USING btree (slug);
+CREATE UNIQUE INDEX index_indc_indicators_on_slug ON public.indc_indicators USING btree (slug);
 
 
 --
 -- Name: index_indc_indicators_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_indicators_on_source_id ON indc_indicators USING btree (source_id);
+CREATE INDEX index_indc_indicators_on_source_id ON public.indc_indicators USING btree (source_id);
 
 
 --
 -- Name: index_indc_labels_on_indicator_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_labels_on_indicator_id ON indc_labels USING btree (indicator_id);
+CREATE INDEX index_indc_labels_on_indicator_id ON public.indc_labels USING btree (indicator_id);
 
 
 --
 -- Name: index_indc_searchable_values_on_global_categories_ids; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_global_categories_ids ON indc_searchable_values USING btree (global_categories_ids);
+CREATE INDEX index_indc_searchable_values_on_global_categories_ids ON public.indc_searchable_values USING btree (global_categories_ids);
 
 
 --
 -- Name: index_indc_searchable_values_on_indicator_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_indicator_id ON indc_searchable_values USING btree (indicator_id);
+CREATE INDEX index_indc_searchable_values_on_indicator_id ON public.indc_searchable_values USING btree (indicator_id);
 
 
 --
 -- Name: index_indc_searchable_values_on_iso_code3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_iso_code3 ON indc_searchable_values USING btree (iso_code3);
+CREATE INDEX index_indc_searchable_values_on_iso_code3 ON public.indc_searchable_values USING btree (iso_code3);
 
 
 --
 -- Name: index_indc_searchable_values_on_overview_categories_ids; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_overview_categories_ids ON indc_searchable_values USING btree (overview_categories_ids);
+CREATE INDEX index_indc_searchable_values_on_overview_categories_ids ON public.indc_searchable_values USING btree (overview_categories_ids);
 
 
 --
 -- Name: index_indc_searchable_values_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_sector_id ON indc_searchable_values USING btree (sector_id);
+CREATE INDEX index_indc_searchable_values_on_sector_id ON public.indc_searchable_values USING btree (sector_id);
 
 
 --
 -- Name: index_indc_searchable_values_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_searchable_values_on_source_id ON indc_searchable_values USING btree (source_id);
+CREATE INDEX index_indc_searchable_values_on_source_id ON public.indc_searchable_values USING btree (source_id);
 
 
 --
 -- Name: index_indc_sectors_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_sectors_on_parent_id ON indc_sectors USING btree (parent_id);
+CREATE INDEX index_indc_sectors_on_parent_id ON public.indc_sectors USING btree (parent_id);
 
 
 --
 -- Name: index_indc_sources_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_indc_sources_on_name ON indc_sources USING btree (name);
+CREATE UNIQUE INDEX index_indc_sources_on_name ON public.indc_sources USING btree (name);
 
 
 --
 -- Name: index_indc_submissions_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_submissions_on_location_id ON indc_submissions USING btree (location_id);
+CREATE INDEX index_indc_submissions_on_location_id ON public.indc_submissions USING btree (location_id);
 
 
 --
 -- Name: index_indc_values_on_indicator_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_values_on_indicator_id ON indc_values USING btree (indicator_id);
+CREATE INDEX index_indc_values_on_indicator_id ON public.indc_values USING btree (indicator_id);
 
 
 --
 -- Name: index_indc_values_on_label_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_values_on_label_id ON indc_values USING btree (label_id);
+CREATE INDEX index_indc_values_on_label_id ON public.indc_values USING btree (label_id);
 
 
 --
 -- Name: index_indc_values_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_values_on_location_id ON indc_values USING btree (location_id);
+CREATE INDEX index_indc_values_on_location_id ON public.indc_values USING btree (location_id);
 
 
 --
 -- Name: index_indc_values_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_indc_values_on_sector_id ON indc_values USING btree (sector_id);
+CREATE INDEX index_indc_values_on_sector_id ON public.indc_values USING btree (sector_id);
 
 
 --
 -- Name: index_location_members_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_location_members_on_location_id ON location_members USING btree (location_id);
+CREATE INDEX index_location_members_on_location_id ON public.location_members USING btree (location_id);
 
 
 --
 -- Name: index_location_members_on_member_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_location_members_on_member_id ON location_members USING btree (member_id);
+CREATE INDEX index_location_members_on_member_id ON public.location_members USING btree (member_id);
 
 
 --
 -- Name: index_locations_on_iso_code2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_locations_on_iso_code2 ON locations USING btree (iso_code2);
+CREATE INDEX index_locations_on_iso_code2 ON public.locations USING btree (iso_code2);
 
 
 --
 -- Name: index_locations_on_iso_code3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_locations_on_iso_code3 ON locations USING btree (iso_code3);
+CREATE INDEX index_locations_on_iso_code3 ON public.locations USING btree (iso_code3);
 
 
 --
 -- Name: index_ndc_sdg_goals_on_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ndc_sdg_goals_on_number ON ndc_sdg_goals USING btree (number);
+CREATE UNIQUE INDEX index_ndc_sdg_goals_on_number ON public.ndc_sdg_goals USING btree (number);
 
 
 --
 -- Name: index_ndc_sdg_ndc_target_sectors_on_ndc_target_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndc_sdg_ndc_target_sectors_on_ndc_target_id ON ndc_sdg_ndc_target_sectors USING btree (ndc_target_id);
+CREATE INDEX index_ndc_sdg_ndc_target_sectors_on_ndc_target_id ON public.ndc_sdg_ndc_target_sectors USING btree (ndc_target_id);
 
 
 --
 -- Name: index_ndc_sdg_ndc_target_sectors_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndc_sdg_ndc_target_sectors_on_sector_id ON ndc_sdg_ndc_target_sectors USING btree (sector_id);
+CREATE INDEX index_ndc_sdg_ndc_target_sectors_on_sector_id ON public.ndc_sdg_ndc_target_sectors USING btree (sector_id);
 
 
 --
 -- Name: index_ndc_sdg_ndc_targets_on_ndc_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndc_sdg_ndc_targets_on_ndc_id ON ndc_sdg_ndc_targets USING btree (ndc_id);
+CREATE INDEX index_ndc_sdg_ndc_targets_on_ndc_id ON public.ndc_sdg_ndc_targets USING btree (ndc_id);
 
 
 --
 -- Name: index_ndc_sdg_ndc_targets_on_target_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndc_sdg_ndc_targets_on_target_id ON ndc_sdg_ndc_targets USING btree (target_id);
+CREATE INDEX index_ndc_sdg_ndc_targets_on_target_id ON public.ndc_sdg_ndc_targets USING btree (target_id);
 
 
 --
 -- Name: index_ndc_sdg_targets_on_goal_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndc_sdg_targets_on_goal_id ON ndc_sdg_targets USING btree (goal_id);
+CREATE INDEX index_ndc_sdg_targets_on_goal_id ON public.ndc_sdg_targets USING btree (goal_id);
 
 
 --
 -- Name: index_ndc_sdg_targets_on_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ndc_sdg_targets_on_number ON ndc_sdg_targets USING btree (number);
+CREATE UNIQUE INDEX index_ndc_sdg_targets_on_number ON public.ndc_sdg_targets USING btree (number);
 
 
 --
 -- Name: index_ndcs_on_full_text_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndcs_on_full_text_tsv ON ndcs USING gin (full_text_tsv);
+CREATE INDEX index_ndcs_on_full_text_tsv ON public.ndcs USING gin (full_text_tsv);
 
 
 --
 -- Name: index_ndcs_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ndcs_on_location_id ON ndcs USING btree (location_id);
+CREATE INDEX index_ndcs_on_location_id ON public.ndcs USING btree (location_id);
 
 
 --
 -- Name: index_quantification_labels_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_quantification_labels_on_name ON quantification_labels USING btree (name);
+CREATE UNIQUE INDEX index_quantification_labels_on_name ON public.quantification_labels USING btree (name);
 
 
 --
 -- Name: index_quantification_values_on_label_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quantification_values_on_label_id ON quantification_values USING btree (label_id);
+CREATE INDEX index_quantification_values_on_label_id ON public.quantification_values USING btree (label_id);
 
 
 --
 -- Name: index_quantification_values_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quantification_values_on_location_id ON quantification_values USING btree (location_id);
+CREATE INDEX index_quantification_values_on_location_id ON public.quantification_values USING btree (location_id);
 
 
 --
 -- Name: index_searchable_emissions_path_ops; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_searchable_emissions_path_ops ON historical_emissions_searchable_records USING gin (emissions_dict jsonb_path_ops);
+CREATE INDEX index_searchable_emissions_path_ops ON public.historical_emissions_searchable_records USING gin (emissions_dict jsonb_path_ops);
 
 
 --
 -- Name: index_sections_on_platform_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sections_on_platform_id ON sections USING btree (platform_id);
+CREATE INDEX index_sections_on_platform_id ON public.sections USING btree (platform_id);
 
 
 --
 -- Name: index_socioeconomic_indicators_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_socioeconomic_indicators_on_location_id ON socioeconomic_indicators USING btree (location_id);
+CREATE INDEX index_socioeconomic_indicators_on_location_id ON public.socioeconomic_indicators USING btree (location_id);
 
 
 --
 -- Name: index_socioeconomic_indicators_on_location_id_and_year; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_socioeconomic_indicators_on_location_id_and_year ON socioeconomic_indicators USING btree (location_id, year);
+CREATE UNIQUE INDEX index_socioeconomic_indicators_on_location_id_and_year ON public.socioeconomic_indicators USING btree (location_id, year);
 
 
 --
 -- Name: index_timeline_documents_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_timeline_documents_on_location_id ON timeline_documents USING btree (location_id);
+CREATE INDEX index_timeline_documents_on_location_id ON public.timeline_documents USING btree (location_id);
 
 
 --
 -- Name: index_timeline_documents_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_timeline_documents_on_source_id ON timeline_documents USING btree (source_id);
+CREATE INDEX index_timeline_documents_on_source_id ON public.timeline_documents USING btree (source_id);
 
 
 --
 -- Name: index_timeline_notes_on_document_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_timeline_notes_on_document_id ON timeline_notes USING btree (document_id);
+CREATE INDEX index_timeline_notes_on_document_id ON public.timeline_notes USING btree (document_id);
 
 
 --
 -- Name: index_users_on_ct_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_ct_id ON users USING btree (ct_id);
+CREATE INDEX index_users_on_ct_id ON public.users USING btree (ct_id);
 
 
 --
 -- Name: index_wb_extra_country_data_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_wb_extra_country_data_on_location_id ON wb_extra_country_data USING btree (location_id);
+CREATE INDEX index_wb_extra_country_data_on_location_id ON public.wb_extra_country_data USING btree (location_id);
 
 
 --
 -- Name: index_worker_logs_on_jid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_worker_logs_on_jid ON worker_logs USING btree (jid);
+CREATE INDEX index_worker_logs_on_jid ON public.worker_logs USING btree (jid);
 
 
 --
 -- Name: index_worker_logs_on_section_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_worker_logs_on_section_id ON worker_logs USING btree (section_id);
+CREATE INDEX index_worker_logs_on_section_id ON public.worker_logs USING btree (section_id);
 
 
 --
 -- Name: index_wri_metadata_acronyms_on_acronym; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_wri_metadata_acronyms_on_acronym ON wri_metadata_acronyms USING btree (acronym);
+CREATE UNIQUE INDEX index_wri_metadata_acronyms_on_acronym ON public.wri_metadata_acronyms USING btree (acronym);
 
 
 --
 -- Name: index_wri_metadata_properties_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_wri_metadata_properties_on_slug ON wri_metadata_properties USING btree (slug);
+CREATE UNIQUE INDEX index_wri_metadata_properties_on_slug ON public.wri_metadata_properties USING btree (slug);
 
 
 --
 -- Name: index_wri_metadata_values_on_property_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_wri_metadata_values_on_property_id ON wri_metadata_values USING btree (property_id);
+CREATE INDEX index_wri_metadata_values_on_property_id ON public.wri_metadata_values USING btree (property_id);
 
 
 --
 -- Name: index_wri_metadata_values_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_wri_metadata_values_on_source_id ON wri_metadata_values USING btree (source_id);
+CREATE INDEX index_wri_metadata_values_on_source_id ON public.wri_metadata_values USING btree (source_id);
 
 
 --
 -- Name: source_id_property_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX source_id_property_id_index ON wri_metadata_values USING btree (source_id, property_id);
+CREATE UNIQUE INDEX source_id_property_id_index ON public.wri_metadata_values USING btree (source_id, property_id);
 
 
 --
 -- Name: wri_metadata_values fk_rails_079e0dfdee; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_values
-    ADD CONSTRAINT fk_rails_079e0dfdee FOREIGN KEY (property_id) REFERENCES wri_metadata_properties(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.wri_metadata_values
+    ADD CONSTRAINT fk_rails_079e0dfdee FOREIGN KEY (property_id) REFERENCES public.wri_metadata_properties(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_indicators_categories fk_rails_0aab1cd23e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators_categories
-    ADD CONSTRAINT fk_rails_0aab1cd23e FOREIGN KEY (category_id) REFERENCES indc_categories(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_indicators_categories
+    ADD CONSTRAINT fk_rails_0aab1cd23e FOREIGN KEY (category_id) REFERENCES public.indc_categories(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_records fk_rails_0c4499c126; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
-    ADD CONSTRAINT fk_rails_0c4499c126 FOREIGN KEY (sector_id) REFERENCES historical_emissions_sectors(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_records
+    ADD CONSTRAINT fk_rails_0c4499c126 FOREIGN KEY (sector_id) REFERENCES public.historical_emissions_sectors(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_sectors fk_rails_172dcdfbe0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_sectors
-    ADD CONSTRAINT fk_rails_172dcdfbe0 FOREIGN KEY (parent_id) REFERENCES indc_sectors(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_sectors
+    ADD CONSTRAINT fk_rails_172dcdfbe0 FOREIGN KEY (parent_id) REFERENCES public.indc_sectors(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndcs fk_rails_19d1c9c3f7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndcs
-    ADD CONSTRAINT fk_rails_19d1c9c3f7 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ndcs
+    ADD CONSTRAINT fk_rails_19d1c9c3f7 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_categories fk_rails_2684980181; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_categories
-    ADD CONSTRAINT fk_rails_2684980181 FOREIGN KEY (parent_id) REFERENCES indc_categories(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_categories
+    ADD CONSTRAINT fk_rails_2684980181 FOREIGN KEY (parent_id) REFERENCES public.indc_categories(id) ON DELETE CASCADE;
 
 
 --
 -- Name: timeline_documents fk_rails_2ac4f5f0c8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_documents
-    ADD CONSTRAINT fk_rails_2ac4f5f0c8 FOREIGN KEY (source_id) REFERENCES timeline_sources(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.timeline_documents
+    ADD CONSTRAINT fk_rails_2ac4f5f0c8 FOREIGN KEY (source_id) REFERENCES public.timeline_sources(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_values fk_rails_3d45bd9e1b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values
-    ADD CONSTRAINT fk_rails_3d45bd9e1b FOREIGN KEY (indicator_id) REFERENCES indc_indicators(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_values
+    ADD CONSTRAINT fk_rails_3d45bd9e1b FOREIGN KEY (indicator_id) REFERENCES public.indc_indicators(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndc_sdg_ndc_target_sectors fk_rails_3db44d6b30; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_target_sectors
-    ADD CONSTRAINT fk_rails_3db44d6b30 FOREIGN KEY (ndc_target_id) REFERENCES ndc_sdg_ndc_targets(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ndc_sdg_ndc_target_sectors
+    ADD CONSTRAINT fk_rails_3db44d6b30 FOREIGN KEY (ndc_target_id) REFERENCES public.ndc_sdg_ndc_targets(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_categories fk_rails_3e5bc702f2; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_categories
-    ADD CONSTRAINT fk_rails_3e5bc702f2 FOREIGN KEY (category_type_id) REFERENCES indc_category_types(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_categories
+    ADD CONSTRAINT fk_rails_3e5bc702f2 FOREIGN KEY (category_type_id) REFERENCES public.indc_category_types(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndc_sdg_ndc_target_sectors fk_rails_4391f3a35d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_target_sectors
-    ADD CONSTRAINT fk_rails_4391f3a35d FOREIGN KEY (sector_id) REFERENCES ndc_sdg_sectors(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ndc_sdg_ndc_target_sectors
+    ADD CONSTRAINT fk_rails_4391f3a35d FOREIGN KEY (sector_id) REFERENCES public.ndc_sdg_sectors(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_submissions fk_rails_47352eee01; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_submissions
-    ADD CONSTRAINT fk_rails_47352eee01 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_submissions
+    ADD CONSTRAINT fk_rails_47352eee01 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: wb_extra_country_data fk_rails_498e2daf90; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wb_extra_country_data
-    ADD CONSTRAINT fk_rails_498e2daf90 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.wb_extra_country_data
+    ADD CONSTRAINT fk_rails_498e2daf90 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: datasets fk_rails_4cf1467767; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY datasets
-    ADD CONSTRAINT fk_rails_4cf1467767 FOREIGN KEY (section_id) REFERENCES sections(id);
+ALTER TABLE ONLY public.datasets
+    ADD CONSTRAINT fk_rails_4cf1467767 FOREIGN KEY (section_id) REFERENCES public.sections(id);
 
 
 --
 -- Name: indc_values fk_rails_78b5d1bae9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values
-    ADD CONSTRAINT fk_rails_78b5d1bae9 FOREIGN KEY (sector_id) REFERENCES indc_sectors(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_values
+    ADD CONSTRAINT fk_rails_78b5d1bae9 FOREIGN KEY (sector_id) REFERENCES public.indc_sectors(id) ON DELETE CASCADE;
 
 
 --
 -- Name: sections fk_rails_79731eb272; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections
-    ADD CONSTRAINT fk_rails_79731eb272 FOREIGN KEY (platform_id) REFERENCES platforms(id);
+ALTER TABLE ONLY public.sections
+    ADD CONSTRAINT fk_rails_79731eb272 FOREIGN KEY (platform_id) REFERENCES public.platforms(id);
 
 
 --
 -- Name: indc_indicators_categories fk_rails_7f8ee8d66f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators_categories
-    ADD CONSTRAINT fk_rails_7f8ee8d66f FOREIGN KEY (indicator_id) REFERENCES indc_indicators(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_indicators_categories
+    ADD CONSTRAINT fk_rails_7f8ee8d66f FOREIGN KEY (indicator_id) REFERENCES public.indc_indicators(id) ON DELETE CASCADE;
 
 
 --
 -- Name: worker_logs fk_rails_81b253936f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY worker_logs
-    ADD CONSTRAINT fk_rails_81b253936f FOREIGN KEY (section_id) REFERENCES sections(id);
+ALTER TABLE ONLY public.worker_logs
+    ADD CONSTRAINT fk_rails_81b253936f FOREIGN KEY (section_id) REFERENCES public.sections(id);
 
 
 --
 -- Name: quantification_values fk_rails_86ebcd5ef2; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_values
-    ADD CONSTRAINT fk_rails_86ebcd5ef2 FOREIGN KEY (label_id) REFERENCES quantification_labels(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.quantification_values
+    ADD CONSTRAINT fk_rails_86ebcd5ef2 FOREIGN KEY (label_id) REFERENCES public.quantification_labels(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndc_sdg_ndc_targets fk_rails_898d96a83b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_targets
-    ADD CONSTRAINT fk_rails_898d96a83b FOREIGN KEY (target_id) REFERENCES ndc_sdg_targets(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ndc_sdg_ndc_targets
+    ADD CONSTRAINT fk_rails_898d96a83b FOREIGN KEY (target_id) REFERENCES public.ndc_sdg_targets(id) ON DELETE CASCADE;
 
 
 --
 -- Name: socioeconomic_indicators fk_rails_8c7796599b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY socioeconomic_indicators
-    ADD CONSTRAINT fk_rails_8c7796599b FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.socioeconomic_indicators
+    ADD CONSTRAINT fk_rails_8c7796599b FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndc_sdg_ndc_targets fk_rails_923c2f7e20; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_ndc_targets
-    ADD CONSTRAINT fk_rails_923c2f7e20 FOREIGN KEY (ndc_id) REFERENCES ndcs(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.ndc_sdg_ndc_targets
+    ADD CONSTRAINT fk_rails_923c2f7e20 FOREIGN KEY (ndc_id) REFERENCES public.ndcs(id) ON DELETE CASCADE;
 
 
 --
 -- Name: visualizations fk_rails_a3de285f9a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY visualizations
-    ADD CONSTRAINT fk_rails_a3de285f9a FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.visualizations
+    ADD CONSTRAINT fk_rails_a3de285f9a FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: adaptation_values fk_rails_a4c627cc64; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_values
-    ADD CONSTRAINT fk_rails_a4c627cc64 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.adaptation_values
+    ADD CONSTRAINT fk_rails_a4c627cc64 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: ndc_sdg_targets fk_rails_ada759fb26; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ndc_sdg_targets
-    ADD CONSTRAINT fk_rails_ada759fb26 FOREIGN KEY (goal_id) REFERENCES ndc_sdg_goals(id);
+ALTER TABLE ONLY public.ndc_sdg_targets
+    ADD CONSTRAINT fk_rails_ada759fb26 FOREIGN KEY (goal_id) REFERENCES public.ndc_sdg_goals(id);
 
 
 --
 -- Name: wri_metadata_values fk_rails_b2362e90f1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY wri_metadata_values
-    ADD CONSTRAINT fk_rails_b2362e90f1 FOREIGN KEY (source_id) REFERENCES wri_metadata_sources(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.wri_metadata_values
+    ADD CONSTRAINT fk_rails_b2362e90f1 FOREIGN KEY (source_id) REFERENCES public.wri_metadata_sources(id) ON DELETE CASCADE;
 
 
 --
 -- Name: location_members fk_rails_b5628ffc75; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY location_members
-    ADD CONSTRAINT fk_rails_b5628ffc75 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.location_members
+    ADD CONSTRAINT fk_rails_b5628ffc75 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: timeline_notes fk_rails_b7e3f5033a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_notes
-    ADD CONSTRAINT fk_rails_b7e3f5033a FOREIGN KEY (document_id) REFERENCES timeline_documents(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.timeline_notes
+    ADD CONSTRAINT fk_rails_b7e3f5033a FOREIGN KEY (document_id) REFERENCES public.timeline_documents(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_sectors fk_rails_bac381b199; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_sectors
-    ADD CONSTRAINT fk_rails_bac381b199 FOREIGN KEY (data_source_id) REFERENCES historical_emissions_data_sources(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_sectors
+    ADD CONSTRAINT fk_rails_bac381b199 FOREIGN KEY (data_source_id) REFERENCES public.historical_emissions_data_sources(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_records fk_rails_bf53b0a2c4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
-    ADD CONSTRAINT fk_rails_bf53b0a2c4 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_records
+    ADD CONSTRAINT fk_rails_bf53b0a2c4 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: quantification_values fk_rails_c3ca9bbcf7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY quantification_values
-    ADD CONSTRAINT fk_rails_c3ca9bbcf7 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.quantification_values
+    ADD CONSTRAINT fk_rails_c3ca9bbcf7 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_values fk_rails_c54a901967; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values
-    ADD CONSTRAINT fk_rails_c54a901967 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_values
+    ADD CONSTRAINT fk_rails_c54a901967 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: user_stories fk_rails_c5856684d6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_stories
-    ADD CONSTRAINT fk_rails_c5856684d6 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.user_stories
+    ADD CONSTRAINT fk_rails_c5856684d6 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: historical_emissions_sectors fk_rails_c62660f611; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_sectors
-    ADD CONSTRAINT fk_rails_c62660f611 FOREIGN KEY (parent_id) REFERENCES historical_emissions_sectors(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_sectors
+    ADD CONSTRAINT fk_rails_c62660f611 FOREIGN KEY (parent_id) REFERENCES public.historical_emissions_sectors(id) ON DELETE CASCADE;
 
 
 --
 -- Name: location_members fk_rails_c76de7d5fc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY location_members
-    ADD CONSTRAINT fk_rails_c76de7d5fc FOREIGN KEY (member_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.location_members
+    ADD CONSTRAINT fk_rails_c76de7d5fc FOREIGN KEY (member_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_records fk_rails_d47c0f188e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
-    ADD CONSTRAINT fk_rails_d47c0f188e FOREIGN KEY (gas_id) REFERENCES historical_emissions_gases(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_records
+    ADD CONSTRAINT fk_rails_d47c0f188e FOREIGN KEY (gas_id) REFERENCES public.historical_emissions_gases(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_records fk_rails_d6211ecb28; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
-    ADD CONSTRAINT fk_rails_d6211ecb28 FOREIGN KEY (data_source_id) REFERENCES historical_emissions_data_sources(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.historical_emissions_records
+    ADD CONSTRAINT fk_rails_d6211ecb28 FOREIGN KEY (data_source_id) REFERENCES public.historical_emissions_data_sources(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_labels fk_rails_e3ff491fe6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_labels
-    ADD CONSTRAINT fk_rails_e3ff491fe6 FOREIGN KEY (indicator_id) REFERENCES indc_indicators(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_labels
+    ADD CONSTRAINT fk_rails_e3ff491fe6 FOREIGN KEY (indicator_id) REFERENCES public.indc_indicators(id) ON DELETE CASCADE;
 
 
 --
 -- Name: timeline_documents fk_rails_e4ed014ad2; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY timeline_documents
-    ADD CONSTRAINT fk_rails_e4ed014ad2 FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.timeline_documents
+    ADD CONSTRAINT fk_rails_e4ed014ad2 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
 
 
 --
 -- Name: adaptation_values fk_rails_f59219f112; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY adaptation_values
-    ADD CONSTRAINT fk_rails_f59219f112 FOREIGN KEY (variable_id) REFERENCES adaptation_variables(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.adaptation_values
+    ADD CONSTRAINT fk_rails_f59219f112 FOREIGN KEY (variable_id) REFERENCES public.adaptation_variables(id) ON DELETE CASCADE;
 
 
 --
 -- Name: historical_emissions_records fk_rails_f6973beb7a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY historical_emissions_records
-    ADD CONSTRAINT fk_rails_f6973beb7a FOREIGN KEY (gwp_id) REFERENCES historical_emissions_gwps(id);
+ALTER TABLE ONLY public.historical_emissions_records
+    ADD CONSTRAINT fk_rails_f6973beb7a FOREIGN KEY (gwp_id) REFERENCES public.historical_emissions_gwps(id);
 
 
 --
 -- Name: indc_indicators fk_rails_f8dc47815d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_indicators
-    ADD CONSTRAINT fk_rails_f8dc47815d FOREIGN KEY (source_id) REFERENCES indc_sources(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_indicators
+    ADD CONSTRAINT fk_rails_f8dc47815d FOREIGN KEY (source_id) REFERENCES public.indc_sources(id) ON DELETE CASCADE;
 
 
 --
 -- Name: indc_values fk_rails_f9f8ebf207; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY indc_values
-    ADD CONSTRAINT fk_rails_f9f8ebf207 FOREIGN KEY (label_id) REFERENCES indc_labels(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.indc_values
+    ADD CONSTRAINT fk_rails_f9f8ebf207 FOREIGN KEY (label_id) REFERENCES public.indc_labels(id) ON DELETE CASCADE;
 
 
 --
@@ -3498,7 +3497,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181002152649'),
 ('20181003090648'),
 ('20181009120234'),
-('20181024105552'),
 ('20181026095008');
 
 


### PR DESCRIPTION
Add checks to the secondbase migrations to avoid errors if table and column already exist.