### PR TITLE
Feature/embed data explorer

### DIFF
--- a/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/api-documentation/api-documentation-component.jsx
@@ -11,6 +11,10 @@ class ApiDocumentationContent extends PureComponent {
     const { data, handleAnalyticsTryLink } = this.props;
     return (
       <div className={styles.documentation}>
+        <p>
+          To use this data in your own applications, please see our API
+          documentation below:
+        </p>
         <h3 className={styles.sectionTitle}>API Calls</h3>
         {data.map(d => (
           <div key={d.title} className={styles.call}>

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-component.jsx
@@ -47,6 +47,7 @@ class DataExplorerContent extends PureComponent {
           handleSortChange={handleSortChange}
           forcedColumnWidth={tableColumnsWidth[section] || null}
           flexGrow={0}
+          emptyValueLabel="N/A"
         />
       );
     }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -6,6 +6,7 @@ import pick from 'lodash/pick';
 import qs from 'query-string';
 import { findEqual, isANumber, noEmptyValues } from 'utils/utils';
 import { isNoColumnField } from 'utils/data-explorer';
+import { isPageContained } from 'utils/navigation';
 
 import sortBy from 'lodash/sortBy';
 import {
@@ -30,7 +31,8 @@ import {
 import {
   SOURCE_VERSIONS,
   ALL_SELECTED,
-  ALL_SELECTED_OPTION
+  ALL_SELECTED_OPTION,
+  CONTAINED_PATHNAME
 } from 'data/constants';
 import {
   getPathwaysModelOptions,
@@ -279,7 +281,9 @@ export const getLink = createSelector(
       DATA_EXPLORER_SECTIONS[section].moduleName === 'pathways'
         ? '/models'
         : '';
-    return `/${DATA_EXPLORER_SECTIONS[section]
+    return `/${isPageContained
+      ? `${CONTAINED_PATHNAME}/`
+      : ''}${DATA_EXPLORER_SECTIONS[section]
       .moduleName}${subSection}${urlParameters}`;
   }
 );

--- a/app/javascript/app/components/download-menu/download-menu.js
+++ b/app/javascript/app/components/download-menu/download-menu.js
@@ -12,7 +12,7 @@ const { S3_BUCKET_NAME } = process.env;
 const { CW_FILES_PREFIX } = process.env;
 
 const server = `http://${S3_BUCKET_NAME}.s3.amazonaws.com`;
-const folder = `${CW_FILES_PREFIX}climate-watch-download-zip`;
+const folder = `/${CW_FILES_PREFIX}climate-watch-download-zip`;
 const url = `${server}${folder}`;
 
 const downloadMenuOptions = [

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -311,6 +311,3 @@ export const DATA_EXPLORER_TABLE_COLUMNS_WIDTH = {
   'historical-emissions': 100,
   'emission-pathways': 100
 };
-export const SORTING_DEFAULTS = {
-  'historical-emissions': '2014'
-};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "node": ">=8.0.0 <9"
   },
   "scripts": {
-    "start": "run-s rails:db:migrate servers",
+    "start": "run-p -r rails:server js:server",
+    "rails": "run-s rails:db:migrate servers",
     "rails:install": "bundle install",
     "js:install": "yarn install",
     "js:reinstall": "rm -rf ./node_modules && yarn install",
@@ -14,7 +15,6 @@
     "rails:db:migrate": "RAILS_ENV=development bundle exec rails db:migrate",
     "rails:cleanimport": "rails db:drop db:create db:migrate db:import",
     "rails:server": "bundle exec rails s",
-    "servers": "run-p -r rails:server js:server",
     "precommit": "lint-staged",
     "lint": "eslint --ext js --ext jsx .",
     "generate": "plop --plopfile app/javascript/generators/plopfile.js component",


### PR DESCRIPTION
This PR makes some changes requested in the data-explorer feedback:

1. Make http://localhost:3000/contained/data-explorer work
The PT task talks about making it embeddable but its really about making it work in the NDC site so we just need to make the contained version work
https://www.pivotaltracker.com/story/show/162046994

- Fix the 'Vizualize in' link to redirect to the contained versions
- Fix the download bulk files URI

2. Remove hardcoded year:
https://www.pivotaltracker.com/story/show/160991401
2014 was hardcoded as a sorting default for historical emissions. Now we just pick the last year

3. Add API introduction sentence:
https://www.pivotaltracker.com/story/show/162047112
![image](https://user-images.githubusercontent.com/9701591/48711942-d4473800-ec0c-11e8-93bc-914990300d1b.png)

4. Use N/A instead of blank for empty values:
![image](https://user-images.githubusercontent.com/9701591/48711973-e3c68100-ec0c-11e8-9a89-19719a3476e1.png)

Extra: 

- Change npm start to start rails and js server
