### PR TITLE
Add idle sort icon when the row header is not sorted

### DIFF
--- a/app/javascript/app/assets/icons/collapse.svg
+++ b/app/javascript/app/assets/icons/collapse.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="28px" height="32px" viewBox="0 0 28 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 52.3 (67297) - http://www.bohemiancoding.com/sketch -->
+    <title>076D3681-8EA9-4C35-BB9E-1E5C0FD6CF3C</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="ui" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="GENERAL-UI-COMPONENT" transform="translate(-458.000000, -2334.000000)" fill="#868697" fill-rule="nonzero">
+            <g id="icon/collapse" transform="translate(458.000000, 2334.000000)">
+                <g id="collapse">
+                    <path d="M14,0 L0.909,12.8 L27.091,12.8 L14,0 Z M14,32 L27.091,19.2 L0.909,19.2 L14,32 Z" id="Shape"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/javascript/app/components/table/header-row-renderer-component.jsx
+++ b/app/javascript/app/components/table/header-row-renderer-component.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import idleSort from 'assets/icons/collapse.svg';
 import Icon from 'components/icon';
-import cx from 'classnames';
 import styles from './table-styles.scss';
 
 const headerRowRenderer = props => {
@@ -12,7 +11,7 @@ const headerRowRenderer = props => {
       {columns.map(c => {
         if (!c.props['aria-sort']) {
           c.props.children.push(
-            <Icon icon={idleSort} className={cx(styles.idleSortIcon)} />
+            <Icon icon={idleSort} className={styles.idleSortIcon} />
           );
         }
         return c;

--- a/app/javascript/app/components/table/header-row-renderer-component.jsx
+++ b/app/javascript/app/components/table/header-row-renderer-component.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import idleSort from 'assets/icons/collapse.svg';
+import Icon from 'components/icon';
+import cx from 'classnames';
+import styles from './table-styles.scss';
+
+const headerRowRenderer = props => {
+  const { className, columns, style } = props;
+  return (
+    <div className={className} role="row" style={style}>
+      {columns.map(c => {
+        if (!c.props['aria-sort']) {
+          c.props.children.push(
+            <Icon icon={idleSort} className={cx(styles.idleSortIcon)} />
+          );
+        }
+        return c;
+      })}
+    </div>
+  );
+};
+
+headerRowRenderer.propTypes = {
+  className: PropTypes.object,
+  columns: PropTypes.array,
+  style: PropTypes.object
+};
+
+export default headerRowRenderer;

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -7,6 +7,7 @@ import { pixelBreakpoints } from 'components/responsive';
 import difference from 'lodash/difference';
 import 'react-virtualized/styles.css'; // only needs to be imported once
 import cellRenderer from './cell-renderer-component';
+import headerRowRenderer from './header-row-renderer-component';
 import styles from './table-styles.scss';
 import { deburrCapitalize } from '../../utils/utils';
 
@@ -104,6 +105,7 @@ class SimpleTable extends PureComponent {
                 sortBy={sortBy}
                 sortDirection={sortDirection}
                 rowGetter={({ index }) => data[index]}
+                headerRowRenderer={headerRowRenderer}
               >
                 {columnData.map(column => (
                   <Column

--- a/app/javascript/app/components/table/table-styles.scss
+++ b/app/javascript/app/components/table/table-styles.scss
@@ -141,3 +141,10 @@
   font-style: italic;
   font-weight: $font-weight-light;
 }
+
+.idleSortIcon {
+  width: 8px;
+  height: 8px;
+  margin-left: 4px;
+  transform: translateY(-30%);
+}

--- a/app/javascript/app/components/table/table-styles.scss
+++ b/app/javascript/app/components/table/table-styles.scss
@@ -145,6 +145,6 @@
 .idleSortIcon {
   width: 8px;
   height: 8px;
-  margin-left: 4px;
+  margin-left: 3px;
   transform: translateY(-30%);
 }


### PR DESCRIPTION
Add idle sort in all tables when the row header is not sorted
Try data explorer table:

![image](https://user-images.githubusercontent.com/9701591/48716424-a2879e80-ec17-11e8-898f-aa23636e8347.png)
