### PR TITLE
Updates Swazilands name

### DIFF
--- a/app/javascript/app/data/world-50m-topo.json
+++ b/app/javascript/app/data/world-50m-topo.json
@@ -162437,7 +162437,7 @@
           "properties": {
             "id": "SWZ",
             "layer": "COUNTRIES",
-            "name": "Swaziland"
+            "name": "Eswatini"
           }
         },
         {


### PR DESCRIPTION
Swaziland changed their name, now it's called Eswatini.

This PR makes a small change to update the name on the map we are using.

If you want to update your database run this:

```
rails console
Location.where(wri_standard_name: 'Swaziland').update_all(wri_standard_name: 'Eswatini', pik_name: 'Eswatini', cait_name: 'Eswatini')
```

I'll update the import files so that any reimport takes the right name.