### PR TITLE
Fixes to laws and policies

### DIFF
--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
@@ -18,13 +18,10 @@ import styles from './laws-and-policies-styles.scss';
 class LawsAndPolicies extends PureComponent {
   handleSourceChange = sector => {
     const { updateUrlParam } = this.props;
-    updateUrlParam(
-      {
-        name: 'sector',
-        value: sector.value
-      },
-      true
-    );
+    updateUrlParam({
+      name: 'sector',
+      value: sector.value
+    });
   };
 
   handleInfoOnClick = () => {
@@ -148,7 +145,7 @@ class LawsAndPolicies extends PureComponent {
               />
               <CardRow
                 title="Targets"
-                subtitle={currentSector.label}
+                subtitle={currentSector && currentSector.label}
                 description={ndcContent.description}
               />
             </Card>

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 
 const CARDS_IN_ROW = 2;
+const DEFAULT_SECTOR_CODE = 'economy-wide';
 
 const getIso = state => state.iso || null;
 
@@ -31,14 +32,15 @@ const getAllTargets = createSelector(
 export const getCurrentSector = createSelector(
   [getActiveSector, getSectors],
   (activeSector, sectors) => {
+    if (!activeSector || !sectors) return null;
+
     const defaultSector =
-      sectors && sectors.find(sector => sector.value === 'economy-wide');
-    if (isEmpty(activeSector)) {
-      return sectors && sectors.length && defaultSector;
-    }
+      sectors && sectors.find(sector => sector.value === DEFAULT_SECTOR_CODE);
 
     return (
-      sectors && sectors.find(sector => sector.value === activeSector.sector)
+      (sectors &&
+        sectors.find(sector => sector.value === activeSector.sector)) ||
+      defaultSector
     );
   }
 );
@@ -50,8 +52,8 @@ export const getNdcContent = createSelector(
     const activeSector =
       (!isEmpty(currentSector) && currentSector.sector) ||
       (sectors &&
-        sectors.find(sector => sector.value === 'economy-wide') &&
-        sectors.find(sector => sector.value === 'economy-wide').value);
+        sectors.find(sector => sector.value === DEFAULT_SECTOR_CODE) &&
+        sectors.find(sector => sector.value === DEFAULT_SECTOR_CODE).value);
 
     const ndcTargets = targets.filter(target => target.doc_type === 'ndc');
     const parsedNdcsPerSector = groupBy(ndcTargets, 'sector');
@@ -89,8 +91,8 @@ export const getLawsAndPolicies = createSelector(
     const activeSector =
       (!isEmpty(currentSector) && currentSector.sector) ||
       (sectors &&
-        sectors.find(sector => sector.value === 'economy-wide') &&
-        sectors.find(sector => sector.value === 'economy-wide').value);
+        sectors.find(sector => sector.value === DEFAULT_SECTOR_CODE) &&
+        sectors.find(sector => sector.value === DEFAULT_SECTOR_CODE).value);
 
     const lawsTargets = targets.filter(target => target.doc_type === 'law');
     const parsedLawsTargetsPerSector = groupBy(lawsTargets, 'sector');
@@ -163,6 +165,8 @@ const getSectorLabels = createSelector(
 const getNationalPoliciesCount = createSelector(
   [getLawsTargets, getCurrentSector],
   (lawsTargets, currentSector) => {
+    if (!lawsTargets || !currentSector) return 0;
+
     const targetsMatches = lawsTargets.filter(
       target => target.sector === currentSector.value
     );

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies.js
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies.js
@@ -45,9 +45,9 @@ const mapStateToProps = (state, { location, match }) => {
 };
 
 class LawsAndPoliciesContainer extends PureComponent {
-  updateUrlParam = (params, clear) => {
+  updateUrlParam = params => {
     const { history, location } = this.props;
-    history.replace(getLocationParamUpdated(location, params, clear));
+    history.replace(getLocationParamUpdated(location, params));
   };
 
   render() {


### PR DESCRIPTION
This PR fixes couple of issues with laws and policies module:

* Remove occurrences of hardcoded economy-wide sector code - move to const
* Fix setting default sector
* Return 0 instead of null when fetching lawsAndPoliciesCount before it is fetched for better UX
* Do not clear other query params when changing sector query param in laws and policies