### PR TITLE
Fix/home page site map links

### DIFF
--- a/app/javascript/app/components/footer/site-map-footer/site-map-footer-component.jsx
+++ b/app/javascript/app/components/footer/site-map-footer/site-map-footer-component.jsx
@@ -6,37 +6,45 @@ import { siteMapData } from './site-map-footer-data';
 
 import styles from './site-map-footer-styles';
 
-const Component = () => (
-  <section className={styles.siteMapContainer}>
-    <div className={styles.contentWrapper}>
-      <div className={styles.link}>
-        <Icon theme={{ icon: styles.logo }} icon={cwLogo} />
-      </div>
-      <div>
-        <div className={styles.sectionsContainer}>
-          {siteMapData.map(section => (
-            <div className={styles.sectionWrapper}>
-              <h4 className={styles.sectionHeader}>{section.title}</h4>
-              <ul className={styles.linksList}>
-                {section.links.map(l => (
-                  <li>
-                    <a
-                      href={l.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={styles.link}
-                    >
-                      {l.title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+const Component = () => {
+  // eslint-disable-next-line react/prop-types
+  const siteMapLink = ({ title, href }) =>
+    (href.startsWith('/') ? (
+      <a href={href} className={styles.link}>
+        {title}
+      </a>
+    ) : (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.link}
+      >
+        {title}
+      </a>
+    ));
+
+  return (
+    <section className={styles.siteMapContainer}>
+      <div className={styles.contentWrapper}>
+        <div className={styles.link}>
+          <Icon theme={{ icon: styles.logo }} icon={cwLogo} />
+        </div>
+        <div>
+          <div className={styles.sectionsContainer}>
+            {siteMapData.map(section => (
+              <div className={styles.sectionWrapper}>
+                <h4 className={styles.sectionHeader}>{section.title}</h4>
+                <ul className={styles.linksList}>
+                  {section.links.map(l => <li>{siteMapLink(l)}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default Component;

--- a/app/javascript/app/components/footer/site-map-footer/site-map-footer-component.jsx
+++ b/app/javascript/app/components/footer/site-map-footer/site-map-footer-component.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Icon } from 'cw-components';
 import cwLogo from 'assets/icons/cw-logo.svg';
+import { NavLink } from 'react-router-dom';
 
 import { siteMapData } from './site-map-footer-data';
-
 import styles from './site-map-footer-styles';
 
 const Component = () => {
   // eslint-disable-next-line react/prop-types
   const siteMapLink = ({ title, href }) =>
     (href.startsWith('/') ? (
-      <a href={href} className={styles.link}>
+      <NavLink to={href} className={styles.link}>
         {title}
-      </a>
+      </NavLink>
     ) : (
       <a
         href={href}
@@ -33,10 +33,12 @@ const Component = () => {
         <div>
           <div className={styles.sectionsContainer}>
             {siteMapData.map(section => (
-              <div className={styles.sectionWrapper}>
+              <div key={section.title} className={styles.sectionWrapper}>
                 <h4 className={styles.sectionHeader}>{section.title}</h4>
                 <ul className={styles.linksList}>
-                  {section.links.map(l => <li>{siteMapLink(l)}</li>)}
+                  {section.links.map(l => (
+                    <li key={l.href}>{siteMapLink(l)}</li>
+                  ))}
                 </ul>
               </div>
             ))}


### PR DESCRIPTION
[Basecamp task](https://www.pivotaltracker.com/n/projects/2083759/stories/162987402)
- Use `NavLink` instead of anchor tag for local links to prevent reload a page,
- Open local pages in this same tab,
- Add `key` property to sections and li elements in sitemap to prevent console errors,