### PR TITLE
Add emissions pathways graph for Agriculture profile

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/drivers-of-emissions-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/drivers-of-emissions-component.jsx
@@ -1,8 +1,14 @@
 import React, { PureComponent } from 'react';
+import EmissionPathwaysGraph from './emission-pathways-graph';
 
 class DriversOfEmissions extends PureComponent {
   render() {
-    return <div style={{ height: '700px' }}>Drivers of emissions</div>;
+    return (
+      <React.Fragment>
+        <div style={{ height: '700px' }}>Drivers of emissions</div>
+        <EmissionPathwaysGraph />
+      </React.Fragment>
+    );
   }
 }
 

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-actions.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-actions.js
@@ -1,0 +1,46 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import isEmpty from 'lodash/isEmpty';
+
+const findAvailableModelsInit = createAction('findAvailableModelsInit');
+const findAvailableModelsReady = createAction('findAvailableModelsReady');
+const findAvailableModelsFail = createAction('findAvailableModelsFail');
+const { ESP_API } = process.env;
+
+const findAvailableModels = createThunkAction(
+  'findAvailableModels',
+  locationId => (dispatch, state) => {
+    const { espGraph } = state();
+    if (isEmpty(espGraph.locations) || !espGraph.locations[locationId]) {
+      dispatch(findAvailableModelsInit());
+      fetch(`${ESP_API}/models?location=${locationId}&time_series=true`)
+        .then(response => {
+          if (response.ok) return response.json();
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          if (data) {
+            dispatch(
+              findAvailableModelsReady({
+                locationId,
+                modelIds: data.map(d => d.id)
+              })
+            );
+          } else {
+            dispatch(findAvailableModelsReady({ locationId, modelIds: {} }));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(findAvailableModelsFail());
+        });
+    }
+  }
+);
+
+export default {
+  findAvailableModels,
+  findAvailableModelsInit,
+  findAvailableModelsReady,
+  findAvailableModelsFail
+};

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -1,0 +1,215 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import EspLocationsProvider from 'providers/esp-locations-provider';
+import EspModelsProvider from 'providers/esp-models-provider';
+import EspScenariosProvider from 'providers/esp-scenarios-provider';
+import EspIndicatorsProvider from 'providers/esp-indicators-provider';
+import EspTimeSeriesProvider from 'providers/esp-time-series-provider';
+import ButtonGroup from 'components/button-group';
+import ModalOverview from 'components/modal-overview';
+import Dropdown from 'components/dropdown';
+import Chart from 'components/charts/chart';
+import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
+
+import layout from 'styles/layout.scss';
+import styles from './emission-pathways-graph-styles.scss';
+
+class EmissionPathwayGraph extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  renderCustomMessage() {
+    const { filtersSelected, handleClearSelection } = this.props;
+    const getName = attribute =>
+      filtersSelected[attribute] && filtersSelected[attribute].label;
+    const unavailableIndicatorName = getName('indicator')
+      ? ` , ${getName('indicator')}`
+      : '';
+    return (
+      <span>
+        {`${getName('location')} doesn't have any data for ${getName(
+          'model'
+        )}${unavailableIndicatorName}. `}
+        <button
+          onClick={handleClearSelection}
+          type="button"
+          className={styles.clearButton}
+        >
+          Clear Selection
+        </button>
+      </span>
+    );
+  }
+
+  render() {
+    const {
+      data,
+      domain,
+      config,
+      loading,
+      error,
+      filtersLoading,
+      filtersOptions,
+      filtersSelected,
+      handleSelectorChange,
+      handleInfoClick,
+      modalData,
+      model,
+      handleModelChange,
+      downloadLink
+    } = this.props;
+    const needsTimeSeries =
+      filtersSelected && filtersSelected.location && filtersSelected.model;
+    const filtersDisabled =
+      filtersLoading.indicators ||
+      filtersLoading.timeseries ||
+      filtersLoading.models;
+
+    return (
+      <div className={styles.wrapper}>
+        <div className={layout.content}>
+          <EspModelsProvider />
+          <EspScenariosProvider />
+          <EspIndicatorsProvider />
+          <EspLocationsProvider withTimeSeries />
+          {needsTimeSeries && (
+            <EspTimeSeriesProvider
+              location={filtersSelected.location.value}
+              model={filtersSelected.model.value}
+            />
+          )}
+          <div className="grid-column-item">
+            <div className={styles.titleAndBtnsWrapper}>
+              <h2 className={styles.title}>Drivers of Emissions</h2>
+              <TabletLandscape>
+                <ButtonGroup
+                  className={styles.btnGroup}
+                  buttonsConfig={[
+                    {
+                      type: 'info',
+                      onClick: handleInfoClick
+                    },
+                    {
+                      type: 'share',
+                      shareUrl: '/embed/pathways',
+                      analyticsGraphName: 'Drivers of Emissions',
+                      positionRight: true
+                    },
+                    {
+                      type: 'download',
+                      section: 'pathways',
+                      link: downloadLink
+                    },
+                    {
+                      type: 'addToUser'
+                    }
+                  ]}
+                />
+              </TabletLandscape>
+            </div>
+          </div>
+          <div className="grid-column-item">
+            <div className={styles.selectorsWrapper}>
+              <Dropdown
+                label="Region"
+                options={filtersOptions.locations}
+                onValueChange={option =>
+                  handleSelectorChange(option, 'currentLocation')}
+                value={filtersSelected.location}
+                hideResetButton
+              />
+              <Dropdown
+                label="Model and scenarios"
+                options={filtersOptions.models}
+                onValueChange={handleModelChange}
+                disabled={filtersLoading.location}
+                value={filtersSelected.model}
+                hideResetButton
+              />
+              <Dropdown
+                label="Indicator"
+                placeholder="Select an indicator"
+                options={filtersOptions.indicators}
+                hideResetButton
+                disabled={filtersDisabled}
+                onValueChange={option =>
+                  handleSelectorChange(option, 'indicator')}
+                value={filtersSelected.indicator}
+              />
+            </div>
+          </div>
+          <Chart
+            className={styles.chartWrapper}
+            type="line"
+            config={config}
+            data={data}
+            domain={domain}
+            dataOptions={filtersOptions.scenarios}
+            dataSelected={filtersSelected.scenario}
+            customMessage={this.renderCustomMessage()}
+            height={600}
+            loading={loading}
+            error={error}
+            targetParam="scenario"
+            forceFixedFormatDecimals={3}
+            margin={{ top: 50 }}
+            espGraph
+            model={model || null}
+          />
+          <TabletPortraitOnly>
+            <ButtonGroup
+              className={styles.btnGroup}
+              buttonsConfig={[
+                {
+                  type: 'info',
+                  onClick: handleInfoClick
+                },
+                {
+                  type: 'share',
+                  shareUrl: '/embed/pathways',
+                  analyticsGraphName: 'Pathways',
+                  positionRight: true
+                },
+                {
+                  type: 'download',
+                  section: 'pathways',
+                  link: downloadLink
+                },
+                {
+                  type: 'addToUser'
+                }
+              ]}
+            />
+          </TabletPortraitOnly>
+          <ModalOverview
+            data={modalData}
+            title={'Pathways Metadata'}
+            tabTitles={[
+              'Model',
+              'Scenarios',
+              filtersSelected.indicator ? 'Indicator' : null
+            ]}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+EmissionPathwayGraph.propTypes = {
+  data: PropTypes.array,
+  domain: PropTypes.object,
+  modalData: PropTypes.array,
+  model: PropTypes.object,
+  config: PropTypes.object,
+  downloadLink: PropTypes.string,
+  loading: PropTypes.bool,
+  error: PropTypes.bool,
+  filtersLoading: PropTypes.object,
+  filtersOptions: PropTypes.object,
+  filtersSelected: PropTypes.object,
+  handleSelectorChange: PropTypes.func,
+  handleInfoClick: PropTypes.func,
+  handleModelChange: PropTypes.func,
+  handleClearSelection: PropTypes.func
+};
+
+export default EmissionPathwayGraph;

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-reducers.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-reducers.js
@@ -1,0 +1,32 @@
+export const initialState = {
+  loading: false,
+  error: false,
+  loaded: false,
+  locations: {}
+};
+
+const setLoading = (loading, state) => ({ ...state, loading });
+const setLoaded = (loaded, state) => ({ ...state, loaded });
+const setError = (error, state) => ({ ...state, error });
+
+export default {
+  findAvailableModelsInit: state => setLoading(true, state),
+  findAvailableModelsReady: (state, { payload }) =>
+    setError(
+      false,
+      setLoaded(
+        true,
+        setLoading(false, {
+          ...state,
+          locations: {
+            ...state.locations,
+            [payload.locationId]: payload.modelIds
+          }
+        })
+      )
+    ),
+  findAvailableModelsFail: state => {
+    setLoading(false, { ...state });
+    setError(true, { ...state });
+  }
+};

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -1,0 +1,568 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import isUndefined from 'lodash/isUndefined';
+import uniqBy from 'lodash/uniqBy';
+import uniq from 'lodash/uniq';
+import groupBy from 'lodash/groupBy';
+import isArray from 'lodash/isArray';
+import sortBy from 'lodash/sortBy';
+import remove from 'lodash/remove';
+import pick from 'lodash/pick';
+import {
+  getYColumnValue,
+  getThemeConfig,
+  getTooltipConfig,
+  setYAxisDomain,
+  setChartColors
+} from 'utils/graphs';
+
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
+
+import {
+  ESP_BLACKLIST,
+  CHART_COLORS,
+  CHART_COLORS_EXTENDED
+} from 'data/constants';
+
+const AXES_CONFIG = {
+  xBottom: {
+    name: 'Year',
+    unit: 'date',
+    format: 'YYYY'
+  },
+  yLeft: {
+    name: 'Emissions',
+    unit: 'CO<sub>2</sub>e',
+    format: 'number'
+  }
+};
+
+const DEFAULT_SELECTIONS = {
+  model: 'Global Change Assessment Model',
+  indicator: 'CO2'
+};
+
+const getSearch = state => state.search || null;
+
+// meta data for selectors
+const getLocations = state => state.locations || null;
+const getModels = state => state.models || null;
+const getAllScenarios = state => state.allScenarios || null;
+const getIndicators = state => state.indicators || null;
+
+const getLocation = state => parseInt(state.location, 10) || null;
+const getModel = state => parseInt(state.model, 10) || null;
+const getScenarios = state => state.scenario || null;
+const getIndicator = state => parseInt(state.indicator, 10) || null;
+const getCategory = () => 3; // 3 is for Agriculture, Land use and Forestry
+
+// data for the graph
+const getData = state => state.data || null;
+
+// Selector options
+export const getLocationsOptions = createSelector([getLocations], locations => {
+  if (!locations || !locations.length) return [];
+  return sortBy(locations, 'name').map(l => ({
+    label: l.name,
+    value: l.id
+  }));
+});
+
+const getLocationSelected = createSelector(
+  [getLocationsOptions, getLocation],
+  (locations, locationSelected) => {
+    if (!locations) return null;
+    if (!locationSelected) {
+      const defaultLocation = locations.find(l => l.label === 'World');
+      return defaultLocation || locations[0];
+    }
+    return locations.find(l => locationSelected === l.value);
+  }
+);
+
+const getAvailableModels = createSelector(
+  [state => state.availableModels, getLocationSelected],
+  (availableModels, location) => {
+    if (isEmpty(availableModels) || !location) return null;
+    return availableModels[location.value];
+  }
+);
+
+export const getModelsOptions = createSelector(
+  [getModels, getAvailableModels],
+  (models, availableModels) => {
+    if (
+      !models ||
+      !models.length ||
+      !availableModels ||
+      isEmpty(availableModels)
+    ) {
+      return null;
+    }
+    const modelOptions = [];
+    models.forEach(m => {
+      if (availableModels.indexOf(m.id) > -1) {
+        modelOptions.push({
+          label: m.full_name,
+          value: m.id,
+          scenarios: m.scenario_ids,
+          logo: m.logo,
+          url: m.url
+        });
+      }
+    });
+    return modelOptions;
+  }
+);
+
+export const getModelSelected = createSelector(
+  [getModelsOptions, getModel, getModels],
+  (models, modelSelected, allModels) => {
+    if (!models || isEmpty(allModels)) return null;
+    if (!modelSelected) {
+      const defaultModel = models.find(
+        m => m.label === DEFAULT_SELECTIONS.model
+      );
+      return defaultModel || models[0];
+    }
+    return models.find(m => modelSelected === m.value);
+  }
+);
+
+export const getUnavailableModelSelected = createSelector(
+  [getModel, getModelSelected, getModels],
+  (modelSelected, availableModel, allModels) => {
+    if (isEmpty(allModels) || !modelSelected) return null;
+    if (availableModel) return availableModel;
+    const unavailableModel = allModels.find(m => modelSelected === m.id);
+    return { label: unavailableModel.full_name };
+  }
+);
+
+export const getScenariosOptions = createSelector(
+  [getAllScenarios, getModelSelected],
+  (allScenarios, modelSelected) => {
+    if (!modelSelected || !allScenarios || !allScenarios.length) return null;
+    const filteredScenarios = allScenarios.filter(
+      s => modelSelected.scenarios.indexOf(s.id) > -1
+    );
+    return filteredScenarios.map(s => ({
+      label: s.name,
+      value: s.id,
+      purpose: s.purpose_or_objective || ''
+    }));
+  }
+);
+
+export const getScenariosSelected = createSelector(
+  [getScenariosOptions, getScenarios, getModelSelected],
+  (scenarios, scenariosSelected, model) => {
+    if (!scenarios || !model) return null;
+    if ((!scenariosSelected && !model.scenarios) || scenariosSelected === '') {
+      return null;
+    }
+    if (!scenariosSelected) {
+      return scenarios;
+    }
+    const scenarioSelectedArray = isArray(scenariosSelected)
+      ? scenariosSelected
+      : scenariosSelected.split(',');
+    const scenarioSelectedParsed = scenarioSelectedArray.map(s =>
+      parseInt(s, 10)
+    );
+    return scenarios.filter(s => scenarioSelectedParsed.indexOf(s.value) > -1);
+  }
+);
+
+// Map the data from the API
+export const filterDataByScenario = createSelector(
+  [getData, getScenariosSelected],
+  (data, scenarios) => {
+    if (!data || isEmpty(data) || scenarios === '') return null;
+    if (!scenarios) return data;
+    return data.filter(
+      d => scenarios.map(s => s.value).indexOf(d.scenario_id) > -1
+    );
+  }
+);
+
+const getIndicatorsWithData = createSelector(
+  [filterDataByScenario, getIndicators, getModelSelected],
+  (data, indicators, modelSelected) => {
+    if (!data || !indicators || !indicators.length || !modelSelected) {
+      return null;
+    }
+    const indicatorsWithData = uniq(data.map(d => d.indicator_id));
+    return indicators.filter(
+      i => i.name && indicatorsWithData.indexOf(i.id) > -1
+    );
+  }
+);
+
+export const getCategoryOptions = createSelector(
+  [getIndicatorsWithData],
+  indicators => {
+    if (!indicators) return null;
+    const categories = indicators.filter(i => i.category).map(i => ({
+      label: i.category.name,
+      value: i.category.id
+    }));
+    return uniqBy(categories, 'value');
+  }
+);
+
+export const getCategorySelected = createSelector(
+  [getCategoryOptions, getCategory],
+  (categories, categorySelected) => {
+    if (!categories) return null;
+    if (!categorySelected) {
+      return categories[0];
+    }
+
+    return categories.find(i => i.value === categorySelected);
+  }
+);
+
+export const getIndicatorsOptions = createSelector(
+  [getIndicatorsWithData, getCategory],
+  (indicators, category) => {
+    if (!indicators || !indicators.length || !category) return [];
+    let filteredIndicators = indicators;
+
+    if (category) {
+      filteredIndicators = indicators.filter(
+        i => i.category && i.category.id === category
+      );
+    }
+
+    return filteredIndicators.map(i => ({
+      label: i.name || i.composite_name || '',
+      value: i.id,
+      unit: i.unit,
+      subcategory: i.subcategory.name
+    }));
+  }
+);
+
+export const getIndicatorSelected = createSelector(
+  [getIndicatorsOptions, getIndicator],
+  (indicators, indicatorSelected) => {
+    if (!indicators || !indicators.length) return null;
+    if (!indicatorSelected) {
+      const defaultIndicator = indicators.find(
+        i => i.label === DEFAULT_SELECTIONS.indicator
+      );
+      return defaultIndicator || indicators[0];
+    }
+    return indicators.find(i => indicatorSelected === i.value);
+  }
+);
+
+export const getUnavailableIndicatorSelected = createSelector(
+  [getIndicator, getIndicatorSelected, getIndicators],
+  (indicatorSelected, availableIndicator, allIndicators) => {
+    if (isEmpty(allIndicators)) return null;
+    if (!isUndefined(availableIndicator)) return availableIndicator;
+    const unavailableIndicator = allIndicators.find(
+      m => indicatorSelected === m.id
+    );
+    return { label: unavailableIndicator.name };
+  }
+);
+
+export const filterDataByIndicator = createSelector(
+  [filterDataByScenario, getIndicatorSelected],
+  (data, indicator) => {
+    if (!data || isEmpty(data) || !indicator) return null;
+    return data.filter(d => d.indicator_id === indicator.value);
+  }
+);
+
+export const getFiltersOptions = createSelector(
+  [
+    getLocationsOptions,
+    getModelsOptions,
+    getScenariosOptions,
+    getIndicatorsOptions,
+    getCategoryOptions
+  ],
+  (locations, models, scenarios, indicators, category) => ({
+    locations,
+    models,
+    scenarios,
+    indicators,
+    category
+  })
+);
+
+export const getFiltersSelected = createSelector(
+  [
+    getLocationSelected,
+    getModelSelected,
+    getUnavailableModelSelected,
+    getScenariosSelected,
+    getCategorySelected,
+    getIndicatorSelected,
+    getUnavailableIndicatorSelected
+  ],
+  (
+    location,
+    model,
+    unavailableModel,
+    scenario,
+    category,
+    indicator,
+    unavailableIndicator
+  ) => ({
+    location,
+    model: model || unavailableModel,
+    scenario,
+    category,
+    indicator: indicator || unavailableIndicator
+  })
+);
+
+export const getChartData = createSelector([filterDataByIndicator], data => {
+  if (!data) return null;
+  const groupByYear = groupBy(data, 'year');
+  const xValues = Object.keys(groupByYear);
+  const dataMapped = [];
+  xValues.forEach(x => {
+    const yValues = {};
+    const groupedByScenario = groupBy(groupByYear[x], 'scenario_id');
+    Object.keys(groupedByScenario).forEach(i => {
+      yValues[`y${i}`] = parseFloat(groupedByScenario[i][0].value);
+    });
+    dataMapped.push({
+      x,
+      ...yValues
+    });
+  });
+  return dataMapped;
+});
+
+export const getChartDomain = createSelector([getChartData], data => {
+  if (!data) return null;
+  const xValues = data.map(d => d.x);
+
+  return {
+    x: [Math.min(...xValues), Math.max(...xValues)],
+    y: setYAxisDomain()
+  };
+});
+
+export const getChartNeededPrecision = createSelector(
+  [getChartDomain],
+  domain => {
+    if (!domain) return null;
+    const yValuesDifference = domain.y[1] - domain.y[0];
+    const decimalZerosBeforeNumber = String(yValuesDifference).match(
+      /0\.(0+)[^0]/
+    );
+    const neededPrecision =
+      decimalZerosBeforeNumber &&
+      decimalZerosBeforeNumber[1] &&
+      decimalZerosBeforeNumber.length;
+    return neededPrecision && neededPrecision + 1;
+  }
+);
+// The y axis domain has some margins added when the values are very similar to each other to represent this little difference
+export const getChartDomainWithYMargins = createSelector(
+  [getChartDomain, getChartNeededPrecision],
+  (domain, neededPrecision) => {
+    if (!domain) return null;
+    if (!neededPrecision) return domain;
+    const y = [
+      dataMin => dataMin - 10 ** ((neededPrecision - 1) * -1),
+      dataMax => dataMax + 10 ** ((neededPrecision - 1) * -1)
+    ];
+    return {
+      x: domain.x,
+      y
+    };
+  }
+);
+
+// variable that caches chart elements assigned color
+// to avoid element color changing when the chart is updated
+let colorThemeCache = {};
+
+export const getChartConfig = createSelector(
+  [
+    filterDataByIndicator,
+    getAllScenarios,
+    getScenariosOptions,
+    getIndicatorSelected,
+    getChartNeededPrecision
+  ],
+  (data, allScenarios, scenariosInChart, indicator, precision) => {
+    if (!data || !allScenarios) return null;
+    const yColumns = data.map(d => {
+      const scenario = scenariosInChart.find(
+        s => parseInt(s.value, 10) === d.scenario_id
+      );
+      return {
+        label: scenario ? scenario.label : null,
+        value: getYColumnValue(d.scenario_id),
+        url: `/pathways/scenarios/${scenario.value}`,
+        legendTooltip: scenario.purpose
+      };
+    });
+
+    const yColumnsChecked = uniqBy(yColumns, 'value');
+    const chartColors = setChartColors(
+      yColumnsChecked,
+      CHART_COLORS,
+      CHART_COLORS_EXTENDED
+    );
+    const theme = getThemeConfig(yColumnsChecked, chartColors);
+    colorThemeCache = { ...theme, ...colorThemeCache };
+    const tooltip = getTooltipConfig(yColumnsChecked);
+    const axes = indicator
+      ? {
+        ...AXES_CONFIG,
+        yLeft: { ...AXES_CONFIG.yLeft, unit: indicator.unit }
+      }
+      : AXES_CONFIG;
+    return {
+      axes,
+      theme: colorThemeCache,
+      tooltip,
+      precision,
+      columns: {
+        x: [{ label: 'year', value: 'x' }],
+        y: yColumnsChecked
+      },
+      legendNote: true
+    };
+  }
+);
+
+// Parse Metadata for Modal
+const getModelSelectedMetadata = createSelector(
+  [getModels, getModelSelected],
+  (models, modelSelected) => {
+    if (!models || !modelSelected) return null;
+    return models.find(m => modelSelected.value === m.id);
+  }
+);
+
+const addLinktoModelSelectedMetadata = createSelector(
+  [getModelSelectedMetadata],
+  model => {
+    if (!model) return null;
+    return {
+      ...model,
+      Link: `/pathways/models/${model.id}`
+    };
+  }
+);
+
+export const getScenariosSelectedMetadata = createSelector(
+  [getAllScenarios, getScenariosSelected],
+  (allScenarios, scenariosSelected) => {
+    if (isEmpty(allScenarios) || !scenariosSelected) return null;
+    const selectedScenarioIds = scenariosSelected.map(s => s.value);
+    const scenariosMetadata = allScenarios.filter(
+      s => selectedScenarioIds.indexOf(s.id) > -1
+    );
+    return (
+      scenariosMetadata.length > 0 &&
+      scenariosMetadata.map(s => ({
+        name: s.name,
+        description: s.description,
+        Link: `/pathways/scenarios/${s.id}`
+      }))
+    );
+  }
+);
+
+export const getIndicatorSelectedMetadata = createSelector(
+  [getIndicators, getIndicatorSelected],
+  (indicators, indicatorSelected) => {
+    if (!indicators || !indicatorSelected) return null;
+    return indicators.find(i => indicatorSelected.value === i.id);
+  }
+);
+
+export const filterModelsByBlackList = createSelector(
+  [addLinktoModelSelectedMetadata],
+  data => {
+    if (!data || isEmpty(data)) return null;
+    const whiteList = remove(
+      Object.keys(data),
+      n => ESP_BLACKLIST.models.indexOf(n) === -1
+    );
+    return pick(data, whiteList);
+  }
+);
+
+const filterIndicatorsByBlackList = createSelector(
+  [getIndicatorSelectedMetadata],
+  data => {
+    if (!data || isEmpty(data)) return null;
+    const whiteList = remove(
+      Object.keys(data),
+      n => ESP_BLACKLIST.indicators.indexOf(n) === -1
+    );
+    return pick(data, whiteList);
+  }
+);
+
+export const parseObjectsInIndicators = createSelector(
+  [filterIndicatorsByBlackList],
+  data => {
+    if (isEmpty(data)) return null;
+    const parsedData = {};
+    Object.keys(data).forEach(key => {
+      let fieldData = data[key];
+      if (
+        fieldData &&
+        typeof fieldData !== 'string' &&
+        typeof fieldData !== 'number'
+      ) {
+        fieldData = fieldData.name;
+      }
+      parsedData[key] = fieldData;
+    });
+    return parsedData;
+  }
+);
+
+export const getModalData = createSelector(
+  [
+    filterModelsByBlackList,
+    getScenariosSelectedMetadata,
+    parseObjectsInIndicators
+  ],
+  (model, scenarios, indicator) => [model, scenarios, indicator]
+);
+
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getAllScenarios],
+  (search, allScenarios) => {
+    const section = 'emission-pathways';
+    if (!allScenarios.length) return null;
+    if (!search.scenario && search.model) {
+      // Adds the first scenario belonging to the selected model to populate
+      // Data Explorer dropdown and table in case there's no scenario selected
+      const scenarioId = allScenarios.find(
+        s => s.model.id === parseInt(search.model, 10)
+      ).id;
+      const filtersWithScenario = {
+        ...search,
+        scenario: scenarioId
+      };
+      return generateLinkToDataExplorer(filtersWithScenario, section);
+    }
+    return generateLinkToDataExplorer(search, section);
+  }
+);
+
+export default {
+  getChartData,
+  getChartDomainWithYMargins,
+  getChartConfig,
+  getFiltersOptions,
+  getFiltersSelected
+};

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-styles.scss
@@ -1,0 +1,79 @@
+@import '~styles/layout.scss';
+
+$min-height: 450px;
+
+.wrapper {
+  border-bottom: solid 1px $theme-border;
+  min-height: 450px;
+  padding-bottom: 50px;
+}
+
+.titleAndBtnsWrapper {
+  @include columns(6);
+
+  > * {
+    @include xy-gutters($gutter-position: ('bottom'));
+  }
+
+  @media #{$tablet-landscape} {
+    > *:last-child {
+      @include column-offset(7.2, $gutters: true);
+    }
+
+    @include columns(2.4);
+  }
+}
+
+.selectorsWrapper {
+  @include columns(6);
+
+  > * {
+    @include xy-gutters($gutter-position: ('bottom'));
+  }
+
+  @media #{$tablet-landscape} {
+    @include columns(2.4);
+  }
+}
+
+.titleAndBtnsWrapper {
+  @include xy-gutters($gutter-position: ('bottom'));
+
+  margin-top: $gutter-padding;
+}
+
+.selectorsWrapper {
+  margin-bottom: 40px;
+}
+
+.title {
+  font-size: $font-size-large;
+  font-weight: $font-weight;
+  color: $theme-color;
+  margin-bottom: 10px;
+}
+
+.chartWrapper {
+  position: relative;
+  min-height: $min-height;
+}
+
+.loader {
+  min-height: 450px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+}
+
+.noContent {
+  min-height: $min-height;
+}
+
+.clearButton {
+  color: $theme-color;
+  border-bottom: 1px solid $theme-secondary;
+  vertical-align: bottom;
+  font-size: 1em;
+  cursor: pointer;
+}

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
@@ -1,0 +1,195 @@
+import { PureComponent, createElement } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import qs from 'query-string';
+import { getLocationParamUpdated } from 'utils/navigation';
+import isArray from 'lodash/isArray';
+
+import { actions as modalActions } from 'components/modal-overview';
+
+import ownActions from './emission-pathways-graph-actions';
+import reducers, { initialState } from './emission-pathways-graph-reducers';
+
+import EmissionPathwayGraphComponent from './emission-pathways-graph-component';
+import {
+  getChartData,
+  getChartDomainWithYMargins,
+  getChartConfig,
+  getFiltersOptions,
+  getFiltersSelected,
+  getModalData,
+  getModelSelected,
+  getLinkToDataExplorer
+} from './emission-pathways-graph-selectors';
+
+const actions = { ...ownActions, ...modalActions };
+
+const mapStateToProps = (state, { location }) => {
+  const { data } = state.espTimeSeries;
+  const search = qs.parse(location.search);
+  const { currentLocation, model, indicator, scenario } = search;
+  const espData = {
+    data,
+    locations: state.espLocations.data,
+    models: state.espModels.data,
+    allScenarios: state.espScenarios.data,
+    indicators: state.espIndicators.data,
+    location: currentLocation,
+    availableModels: state.espGraph.locations,
+    model,
+    indicator,
+    scenario,
+    search
+  };
+  const providers = [
+    'espTimeSeries',
+    'espLocations',
+    'espModels',
+    'espScenarios',
+    'espIndicators',
+    'espGraph'
+  ];
+  const filtersSelected = getFiltersSelected(espData);
+  return {
+    data: getChartData(espData),
+    domain: getChartDomainWithYMargins(espData),
+    config: getChartConfig(espData),
+    filtersLoading: {
+      timeseries: state.espTimeSeries.loading,
+      locations: state.espLocations.loading,
+      models: state.espModels.loading,
+      indicators: state.espIndicators.loading
+    },
+    filtersOptions: getFiltersOptions(espData),
+    filtersSelected,
+    modalData: getModalData(espData),
+    model: getModelSelected(espData),
+    error: providers.some(p => state[p].error),
+    loading: providers.some(p => state[p].loading) || !filtersSelected.model,
+    search,
+    downloadLink: getLinkToDataExplorer(espData)
+  };
+};
+
+class EmissionPathwayGraphContainer extends PureComponent {
+  componentDidMount() {
+    const { location } = this.props.filtersSelected;
+    if (location) {
+      const locationId = location.value || location;
+      this.props.findAvailableModels(locationId);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.filtersSelected.location !== this.props.filtersSelected.location
+    ) {
+      const currentLocation = this.props.filtersSelected.location;
+      this.props.findAvailableModels(currentLocation.value);
+    }
+
+    const { search, filtersSelected } = this.props;
+    this.updateUrlWithNewParams(search, filtersSelected);
+  }
+
+  updateUrlWithNewParams = (search, filtersSelected) => {
+    const possibleParams = [
+      'model',
+      'indicator',
+      'currentLocation',
+      'scenario'
+    ];
+    const paramsToUpdate = [];
+    const getFilterParamValue = f => {
+      if (isArray(filtersSelected[f])) {
+        return search[f]
+          ? filtersSelected[f]
+            .filter(selectedFilter =>
+              search[f].includes(selectedFilter.value)
+            )
+            .join(',')
+          : filtersSelected[f].map(filter => filter.value).join(',');
+      }
+      return filtersSelected[f].value;
+    };
+
+    possibleParams.forEach(f => {
+      if (!search[f]) {
+        if (f === 'currentLocation' && filtersSelected.location) {
+          paramsToUpdate.push({
+            name: f,
+            value:
+              (filtersSelected[f] && filtersSelected[f].value) ||
+              filtersSelected.location.value
+          });
+        } else if (f !== 'currentLocation' && filtersSelected[f]) {
+          const value = getFilterParamValue(f);
+          if (value) paramsToUpdate.push({ name: f, value });
+        }
+      }
+    });
+    if (paramsToUpdate.length) this.updateUrlParam(paramsToUpdate);
+  };
+
+  handleModelChange = model => {
+    const { location } = this.props.filtersSelected;
+    const params = [
+      { name: 'model', value: model.value },
+      {
+        name: 'scenario',
+        value: model.scenarios ? model.scenarios.toString() : ''
+      }
+    ];
+    if (location && location.value) {
+      params.push({ name: 'currentLocation', value: location.value });
+    }
+    this.updateUrlParam(params, true);
+  };
+
+  handleSelectorChange = (option, param, clear) => {
+    const params = [{ name: param, value: option ? option.value : '' }];
+    this.updateUrlParam(params, clear);
+  };
+
+  handleClearSelection = () => {
+    const { location } = this.props.filtersSelected;
+    this.updateUrlParam(
+      { name: 'currentLocation', value: location.value },
+      true
+    );
+  };
+
+  updateUrlParam(params, clear) {
+    const { history, location } = this.props;
+    history.replace(getLocationParamUpdated(location, params, clear));
+  }
+
+  handleInfoClick = () => {
+    this.props.toggleModalOverview({ open: true });
+  };
+
+  render() {
+    return createElement(EmissionPathwayGraphComponent, {
+      ...this.props,
+      handleInfoClick: this.handleInfoClick,
+      handleModelChange: this.handleModelChange,
+      handleSelectorChange: this.handleSelectorChange,
+      handleClearSelection: this.handleClearSelection
+    });
+  }
+}
+
+EmissionPathwayGraphContainer.propTypes = {
+  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  filtersSelected: PropTypes.object.isRequired,
+  toggleModalOverview: PropTypes.func.isRequired,
+  findAvailableModels: PropTypes.func.isRequired,
+  search: PropTypes.object
+};
+
+export { actions, reducers, initialState };
+export default withRouter(
+  connect(mapStateToProps, actions)(EmissionPathwayGraphContainer)
+);


### PR DESCRIPTION
Add Future Pathways graph for Agriculture profile.
Basically copied the code for the emissions pathways and cleaned it up from selecting category & subcategory.

![image](https://user-images.githubusercontent.com/6136899/51472785-60dbb700-1d72-11e9-9378-1111f79acd5f.png)
