### PR TITLE
Edge doesn't support flatMap, replacing with an alternative

### DIFF
--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-selectors.js
@@ -170,7 +170,10 @@ const getNationalPoliciesCount = createSelector(
     const targetsMatches = lawsTargets.filter(
       target => target.sector === currentSector.value
     );
-    const lawsMatches = targetsMatches.flatMap(t => t.sources);
+    const lawsMatches = targetsMatches.reduce(
+      (acc, t) => acc.concat(t.sources),
+      []
+    );
 
     return lawsMatches.length > 0 ? uniqBy(lawsMatches, 'id').length : 0;
   }


### PR DESCRIPTION
Alternative taken from here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Alternative