### PR TITLE
Added metadata to agriculture profile

### DIFF
--- a/app/controllers/api/v1/data/agriculture_profile/meat_consumptions_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_consumptions_controller.rb
@@ -3,6 +3,7 @@ module Api
     module Data
       module AgricultureProfile
         class MeatConsumptionsController < Api::V1::Data::ApiController
+          include CountableMetadata
           def index
             meat = ::AgricultureProfile::MeatConsumption.filter(params)
 
@@ -10,7 +11,7 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatConsumptionSerializer,
                    root: :data,
-                   meta: ::AgricultureProfile::Metadatum.meat_consumptions
+                   meta: meta(::AgricultureProfile::MeatConsumption, ::AgricultureProfile::Metadatum.meat_consumptions)
           end
         end
       end

--- a/app/controllers/api/v1/data/agriculture_profile/meat_consumptions_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_consumptions_controller.rb
@@ -11,7 +11,8 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatConsumptionSerializer,
                    root: :data,
-                   meta: meta(::AgricultureProfile::MeatConsumption, ::AgricultureProfile::Metadatum.meat_consumptions)
+                   meta: meta(::AgricultureProfile::MeatConsumption,
+                              ::AgricultureProfile::Metadatum.meat_consumptions)
           end
         end
       end

--- a/app/controllers/api/v1/data/agriculture_profile/meat_productions_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_productions_controller.rb
@@ -11,7 +11,8 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatProductionSerializer,
                    root: :data,
-                   meta: meta(::AgricultureProfile::MeatProduction, ::AgricultureProfile::Metadatum.meat_productions)
+                   meta: meta(::AgricultureProfile::MeatProduction,
+                              ::AgricultureProfile::Metadatum.meat_productions)
           end
         end
       end

--- a/app/controllers/api/v1/data/agriculture_profile/meat_productions_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_productions_controller.rb
@@ -3,6 +3,7 @@ module Api
     module Data
       module AgricultureProfile
         class MeatProductionsController < Api::V1::Data::ApiController
+          include CountableMetadata
           def index
             meat = ::AgricultureProfile::MeatProduction.filter(params)
 
@@ -10,7 +11,7 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatProductionSerializer,
                    root: :data,
-                   meta: ::AgricultureProfile::Metadatum.meat_productions
+                   meta: meta(::AgricultureProfile::MeatProduction, ::AgricultureProfile::Metadatum.meat_productions)
           end
         end
       end

--- a/app/controllers/api/v1/data/agriculture_profile/meat_trades_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_trades_controller.rb
@@ -11,7 +11,8 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatTradeSerializer,
                    root: :data,
-                   meta: meta(::AgricultureProfile::MeatTrade, ::AgricultureProfile::Metadatum.meat_trades)
+                   meta: meta(::AgricultureProfile::MeatTrade,
+                              ::AgricultureProfile::Metadatum.meat_trades)
           end
         end
       end

--- a/app/controllers/api/v1/data/agriculture_profile/meat_trades_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/meat_trades_controller.rb
@@ -3,6 +3,7 @@ module Api
     module Data
       module AgricultureProfile
         class MeatTradesController < Api::V1::Data::ApiController
+          include CountableMetadata
           def index
             meat = ::AgricultureProfile::MeatTrade.filter(params)
 
@@ -10,7 +11,7 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::MeatTradeSerializer,
                    root: :data,
-                   meta: ::AgricultureProfile::Metadatum.meat_trades
+                   meta: meta(::AgricultureProfile::MeatTrade, ::AgricultureProfile::Metadatum.meat_trades)
           end
         end
       end

--- a/app/controllers/concerns/countable_metadata.rb
+++ b/app/controllers/concerns/countable_metadata.rb
@@ -1,0 +1,13 @@
+module CountableMetadata
+  extend ActiveSupport::Concern
+
+  private
+
+  def meta(model, metadata)
+    if params[:year]
+      model.count_locations(params[:year]) + metadata
+    else
+      metadata
+    end
+  end
+end

--- a/app/models/agriculture_profile/meat_consumption.rb
+++ b/app/models/agriculture_profile/meat_consumption.rb
@@ -1,5 +1,6 @@
 module AgricultureProfile
   class MeatConsumption < ApplicationRecord
+    include LocationCountable
     belongs_to :location
 
     validates_presence_of :year

--- a/app/models/agriculture_profile/meat_production.rb
+++ b/app/models/agriculture_profile/meat_production.rb
@@ -1,5 +1,6 @@
 module AgricultureProfile
   class MeatProduction < ApplicationRecord
+    include LocationCountable
     belongs_to :location
 
     validates_presence_of :year

--- a/app/models/agriculture_profile/meat_trade.rb
+++ b/app/models/agriculture_profile/meat_trade.rb
@@ -1,5 +1,6 @@
 module AgricultureProfile
   class MeatTrade < ApplicationRecord
+    include LocationCountable
     belongs_to :location
 
     validates_presence_of :year

--- a/app/models/concerns/location_countable.rb
+++ b/app/models/concerns/location_countable.rb
@@ -1,0 +1,15 @@
+module LocationCountable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :count_locations, ->(year) { select(build_count_query).group(:year).where(year: year) }
+  end
+
+  class_methods do
+    def build_count_query
+      sql_array = []
+      (self.column_names - %w[id year location_id]).each { |c| sql_array << "count(#{c}) as #{c}"}
+      sql_array.join(', ')
+    end
+  end
+end

--- a/app/models/concerns/location_countable.rb
+++ b/app/models/concerns/location_countable.rb
@@ -8,7 +8,7 @@ module LocationCountable
   class_methods do
     def build_count_query
       sql_array = []
-      (self.column_names - %w[id year location_id]).each { |c| sql_array << "count(#{c}) as #{c}"}
+      (column_names - %w[id year location_id]).each { |c| sql_array << "count(#{c}) as #{c}" }
       sql_array.join(', ')
     end
   end


### PR DESCRIPTION
This metadata contains, per year, the number of countries that have not null values for each indicator.

There was another alternative when building this, that would consist on creating a materialized view (MV) with this data on importing the information from the CSVs.
When comparing this approach with the current one, the MV query took about 0.03ms to execute whereas the current query took about 0.3ms to execute.
Both results seemed to be acceptable, so I took this approach as it would require less changes to the code.