### PR TITLE
Add countries number to tooltip meat data

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/meat-data-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/meat-data-selectors.js
@@ -62,9 +62,10 @@ const getConsumptionProductionOptions = createSelector(
     return [consumptionMeta, productionMeta].map(
       meta =>
         meta &&
-        meta[0] && {
-          label: meta[0].indicator,
-          value: meta[0].indicator
+        meta.length &&
+        meta[1] && {
+          label: meta[1].indicator,
+          value: meta[1].indicator
         }
     );
   }
@@ -212,7 +213,8 @@ const getChartData = createSelector(
       return null;
     }
 
-    const filterBreakByFn = o => o.short_name.includes(breakByValue);
+    const filterBreakByFn = o =>
+      o.short_name && o.short_name.includes(breakByValue);
 
     const isTradeIndicator =
       selectedFilters[CATEGORY_KEY] &&
@@ -304,7 +306,8 @@ const getAxesConfig = createSelector(
     }
 
     const allMeta = [...productionMeta, ...consumptionMeta, ...tradeMeta];
-    const filterBreakByFn = o => o.short_name.includes(breakByValue);
+    const filterBreakByFn = o =>
+      o.short_name && o.short_name.includes(breakByValue);
 
     const indicatorMeta = allMeta
       .filter(filterBreakByFn)

--- a/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/meat-data-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/meat-data-selectors.js
@@ -45,6 +45,15 @@ const getMeatTradeMeta = ({ meatTrade }) => meatTrade && meatTrade.meta;
 
 const getSearch = ({ search }) => search || null;
 
+const getCountriesCountPerIndicators = createSelector(
+  [getMeatConsumptionMeta, getMeatTradeMeta, getMeatProductionMeta],
+  (consumptionMeta, tradeMeta, productionMeta) => {
+    if (!consumptionMeta || !tradeMeta || !productionMeta) return null;
+
+    return { ...consumptionMeta[0], ...tradeMeta[0], ...productionMeta[0] };
+  }
+);
+
 const getProductionConsumptionMeta = createSelector(
   [getMeatConsumptionMeta, getMeatProductionMeta],
   (consumptionMeta, productionMeta) => {
@@ -184,7 +193,8 @@ const getChartData = createSelector(
     getBreakByValue,
     getWorldConsumptionData,
     getWorldProductionData,
-    getWorldTradeData
+    getWorldTradeData,
+    getCountriesCountPerIndicators
   ],
   (
     selectedFilters,
@@ -198,7 +208,8 @@ const getChartData = createSelector(
     breakByValue,
     worldConsumptionData,
     worldProductionData,
-    worldTradeData
+    worldTradeData,
+    countriesCountPerIndicators
   ) => {
     if (
       !selectedFilters ||
@@ -208,7 +219,8 @@ const getChartData = createSelector(
       isEmpty(selectedCountry) ||
       !worldConsumptionData ||
       !worldProductionData ||
-      !worldTradeData
+      !worldTradeData ||
+      isEmpty(countriesCountPerIndicators)
     ) {
       return null;
     }
@@ -267,7 +279,11 @@ const getChartData = createSelector(
           (!isEmpty(worldData) && worldData[parsedDataID]) || undefined;
         yItems.yOthers = worldValue;
       }
-      const item = { x, ...yItems };
+      const item = {
+        x,
+        ...yItems,
+        countriesCount: countriesCountPerIndicators[parsedDataID]
+      };
       return item;
     });
 

--- a/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/tooltip/tooltip-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/meat-data/tooltip/tooltip-component.jsx
@@ -10,12 +10,16 @@ import styles from './tooltip-styles.scss';
 const Tooltip = ({ content, config }) => {
   const payload = get(content, 'payload[0].payload');
   const category = (payload && payload.x) || '';
+  const countriesCount = payload && payload.countriesCount;
 
   const countryValue = payload && payload.yCountry;
   const otherCountriesValue = payload && payload.yOthers;
 
   const countryName = get(config, 'tooltip.yCountry.label');
-  const othersName = get(config, 'tooltip.yOthers.label');
+  const othersName = `${get(
+    config,
+    'tooltip.yOthers.label'
+  )} (${countriesCount})`;
 
   const countryColor = get(config, 'theme.yCountry.stroke') || '';
   const othersColor = get(config, 'theme.yOthers.stroke') || '';


### PR DESCRIPTION
- Fix agriculture page crashing after changes in the metadata API for meat consumption, production and trade
- Add number of countries to the tooltip to `Other countries` for each indicator (hover on the bar chart to see it)