### PR TITLE
Fix hash section navigation in sectors/agriculture

### DIFF
--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-styles.scss
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-styles.scss
@@ -10,4 +10,14 @@
 
 .sectionComponent {
   margin-bottom: 100px;
+  position: relative;
+}
+
+.sectionHash {
+  position: absolute;
+  top: -130px;
+
+  @media #{$tablet-landscape} {
+    top: -79px;
+  }
 }


### PR DESCRIPTION
This tiny PR adds missing styles to section hash in sectors-agriculture component and fix cropping sections after click on sections menu
**Before:**
![screenshot from 2019-01-31 15-20-34](https://user-images.githubusercontent.com/15097138/52065123-cfd4bf00-256d-11e9-87be-6318ab5e1874.png)

**After:**
![screenshot from 2019-01-31 15-41-37](https://user-images.githubusercontent.com/15097138/52065625-d57ed480-256e-11e9-9134-f6cbac5f4c91.png)
