### PR TITLE
Fix problem with links after sort in NDC content table

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-component.jsx
@@ -11,13 +11,11 @@ import styles from './ndcs-table-styles.scss';
 
 class NDCTable extends PureComponent {
   getTableContent() {
-    const { loading, data, noContentMsg, titleLinks } = this.props;
+    const { loading, data, noContentMsg } = this.props;
 
     if (loading) return <Loading light className={styles.loader} />;
     if (data && data.length > 0) {
-      return (
-        <Table parseHtml titleLinks={titleLinks} data={data} rowHeight={60} />
-      );
+      return <Table parseHtml urlInData data={data} rowHeight={60} />;
     }
     return <NoContent className={styles.noContent} message={noContentMsg} />;
   }
@@ -78,8 +76,7 @@ NDCTable.propTypes = {
   data: PropTypes.array,
   handleCategoryChange: PropTypes.func.isRequired,
   handleIndicatorChange: PropTypes.func.isRequired,
-  handleSearchChange: PropTypes.func.isRequired,
-  titleLinks: PropTypes.array
+  handleSearchChange: PropTypes.func.isRequired
 };
 
 export default NDCTable;

--- a/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-table/ndcs-table-selectors.js
@@ -101,21 +101,12 @@ export const getFilteredData = createSelector(
   }
 );
 
-export const getTitleLinks = createSelector([getFilteredData], data => {
-  if (!data || isEmpty(data)) return null;
-  return data.map(d => [
-    {
-      columnName: 'country',
-      url: `/ndcs/country/${d.iso}`
-    }
-  ]);
-});
-
 export const removeIsoFromData = createSelector([getFilteredData], data => {
   if (!data || isEmpty(data)) return null;
   return data.map(d => ({
     country: d.country,
-    value: d.value
+    value: d.value,
+    urlNotShow: `/ndcs/country/${d.iso}`
   }));
 });
 
@@ -124,6 +115,5 @@ export default {
   getCategoryIndicators,
   getSelectedCategory,
   getSelectedIndicator,
-  removeIsoFromData,
-  getTitleLinks
+  removeIsoFromData
 };

--- a/app/javascript/app/components/ndcs/ndcs-table/ndcs-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-table/ndcs-table.js
@@ -13,8 +13,7 @@ import {
   getCategoryIndicators,
   getSelectedCategory,
   getSelectedIndicator,
-  removeIsoFromData,
-  getTitleLinks
+  removeIsoFromData
 } from './ndcs-table-selectors';
 
 const mapStateToProps = (state, { location }) => {
@@ -36,8 +35,7 @@ const mapStateToProps = (state, { location }) => {
     indicators: getCategoryIndicators(ndcsWithSelection),
     selectedCategory: getSelectedCategory(ndcsWithSelection),
     selectedIndicator: getSelectedIndicator(ndcsWithSelection),
-    data: removeIsoFromData(ndcsWithSelection),
-    titleLinks: getTitleLinks(ndcsWithSelection)
+    data: removeIsoFromData(ndcsWithSelection)
   };
 };
 


### PR DESCRIPTION
This small PR fixes problem with wrong order of links after data sort in `NDC content/Table`
More:  [Pivotal task](https://www.pivotaltracker.com/story/show/162235610)