### PR TITLE
Fix/ghg feedback tasks

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-providers.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-providers.js
@@ -1,7 +1,5 @@
 import { createSelector } from 'reselect';
 import uniq from 'lodash/uniq';
-import isEqual from 'lodash/isEqual';
-import { ALL_SELECTED_OPTION } from 'data/constants';
 import { getOptionsSelected } from './ghg-emissions-selectors-filters';
 
 export const getProviderFilters = createSelector(
@@ -15,10 +13,7 @@ export const getProviderFilters = createSelector(
       regionsSelected
     } = selectedOptions;
 
-    const parseValues = selected =>
-      (isEqual(selected, [ALL_SELECTED_OPTION])
-        ? null
-        : uniq(selected.map(s => s.value)).join());
+    const parseValues = selected => uniq(selected.map(s => s.value)).join();
     const regionCountriesSelected = [];
     regionsSelected.forEach(r => {
       if (r.members) regionCountriesSelected.push(r.members);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -99,11 +99,13 @@ class GhgEmissionsContainer extends PureComponent {
 
   handleInfoClick = () => {
     const { selected } = this.props;
-    const { source } = selected.sourceSelected;
+    let { label: source } = selected.sourcesSelected || {};
     if (source) {
+      if (source.startsWith('UNFCCC')) source = 'UNFCCC';
+      const slugs = `historical_emissions_${source}`;
       this.props.setModalMetadata({
         category: 'Historical Emissions',
-        slugs: source,
+        slugs,
         open: true
       });
     }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -9,7 +9,6 @@ import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
 import isArray from 'lodash/isArray';
 import isEqual from 'lodash/isEqual';
-import { ALL_SELECTED, NO_ALL_SELECTED_COLUMNS } from 'data/constants';
 import { actions } from 'components/modal-metadata';
 
 import GhgEmissionsComponent from './ghg-emissions-component';
@@ -73,18 +72,7 @@ class GhgEmissionsContainer extends PureComponent {
       filters
     );
     if (isArray(updatedFilters)) {
-      if (
-        !NO_ALL_SELECTED_COLUMNS.includes(field) &&
-        (updatedFilters.length === 0 ||
-          updatedFilters[updatedFilters.length - 1].label === ALL_SELECTED)
-      ) {
-        values = ALL_SELECTED;
-      } else {
-        values = updatedFilters
-          .filter(v => v && v.value !== ALL_SELECTED)
-          .map(v => v.value)
-          .join(',');
-      }
+      values = updatedFilters.map(v => v.value).join(',');
     } else {
       values = updatedFilters.value;
     }


### PR DESCRIPTION
- Default to ALL GHG when gases dropdown is cleared
- Fix metadata info button (Show UNFCCC metadata for both UNFCCC options)

Note: The subscript not showing in gases is a conflict with React Truncate component but I didn't have time to solve it. Maybe we could find an alternative but it has to have 'truncation' of several lines