### PR TITLE
Fix/future pathways tabs second chance

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
@@ -156,17 +156,13 @@ class EmissionPathwayGraphContainer extends PureComponent {
 
   handleClearSelection = () => {
     const { search } = this.props;
-    const { model, ...rest } = search;
-    const params = Object.keys(rest).map(k => (
-      { name: k, value: rest[k] }
-    ));
+    const { model, scenario, ...rest } = search;
+    const params = Object.keys(rest).map(k => ({ name: k, value: rest[k] }));
     this.updateUrlParam(params, true);
   };
 
   updateUrlParam(params, clear) {
     const { history, location } = this.props;
-    console.log('replacing this params', params)
-    console.log('clearing', true)
     history.replace(getLocationParamUpdated(location, params, clear));
   }
 

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph.js
@@ -155,15 +155,18 @@ class EmissionPathwayGraphContainer extends PureComponent {
   };
 
   handleClearSelection = () => {
-    const { location } = this.props.filtersSelected;
-    this.updateUrlParam(
-      { name: 'currentLocation', value: location.value },
-      true
-    );
+    const { search } = this.props;
+    const { model, ...rest } = search;
+    const params = Object.keys(rest).map(k => (
+      { name: k, value: rest[k] }
+    ));
+    this.updateUrlParam(params, true);
   };
 
   updateUrlParam(params, clear) {
     const { history, location } = this.props;
+    console.log('replacing this params', params)
+    console.log('clearing', true)
     history.replace(getLocationParamUpdated(location, params, clear));
   }
 

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -8,12 +8,9 @@ export function getLocationParamUpdated(location, params = [], clear = false) {
   const search = getSearch(location);
   const newFilters = {};
   const paramsArray = isArray(params) ? params : [params];
-  console.log('Search', search)
-  console.log('paramsArray', paramsArray)
   paramsArray.forEach(param => {
     newFilters[param.name] = param.value;
   });
-  console.log('newFilters', newFilters, clear)
   const newSearch = clear
     ? { ...newFilters }
     : {

--- a/app/javascript/app/utils/navigation.js
+++ b/app/javascript/app/utils/navigation.js
@@ -8,9 +8,12 @@ export function getLocationParamUpdated(location, params = [], clear = false) {
   const search = getSearch(location);
   const newFilters = {};
   const paramsArray = isArray(params) ? params : [params];
+  console.log('Search', search)
+  console.log('paramsArray', paramsArray)
   paramsArray.forEach(param => {
     newFilters[param.name] = param.value;
   });
+  console.log('newFilters', newFilters, clear)
   const newSearch = clear
     ? { ...newFilters }
     : {


### PR DESCRIPTION
This PR updates `clearSelection` button behaviour to avoid the page going back to `Historical Emissions` tab.
[Pivotal task](https://www.pivotaltracker.com/story/show/163941397)

![kapture 2019-02-18 at 12 32 10](https://user-images.githubusercontent.com/6906348/52948248-3c76f880-3379-11e9-81da-fa1268a89bc2.gif)

P.S: While debugging found out that currently, as we are not displaying subcategory on `Agriculture` dropdowns, user experience could be a bit misleading because the same `indicator` name (eg. `CO2`) could belong to different `subcategories` hence having different `indicator` values (numbers) so data does not displays in the chart.
I'm opening a ticket on pivotal to discuss possible fixes.
https://www.pivotaltracker.com/story/show/164046823