### PR TITLE
Show ABOUT nav with nested menu

### DIFF
--- a/app/javascript/app/routes/app-routes/about-nested-routes/about-nested-routes.js
+++ b/app/javascript/app/routes/app-routes/about-nested-routes/about-nested-routes.js
@@ -1,0 +1,29 @@
+const activeId = 'about';
+
+export default [
+  {
+    path: '/about',
+    label: 'About Climate Watch',
+    activeId
+  },
+  {
+    path: '/about/partners',
+    label: 'Climate Watch Partners',
+    activeId
+  },
+  {
+    path: '/about/contact',
+    label: 'Sign Up for Updates',
+    activeId
+  },
+  {
+    path: '/about/permissions',
+    label: 'Permissions & Licensing',
+    activeId
+  },
+  {
+    path: '/about/faq/general_questions',
+    label: 'FAQ',
+    activeId
+  }
+];

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -31,7 +31,8 @@ import NDCCompareRoutes from './NDCCompare-routes';
 import NDCSContentRoutes from './NDCSContent-routes';
 import MyCwRoutes from './my-cw-routes';
 import DataExplorerRoutes from './data-explorer-routes';
-import aboutRoutes from './about-routes';
+import AboutRoutes from './about-routes';
+import AboutNestedRoutes from './about-nested-routes';
 import emissionPathwaysRoutes from './emission-pathways-routes';
 import emissionPathwaysModelRoutes from './emission-pathways-model-routes';
 import sectorsRoutes from './sectors-routes';
@@ -198,11 +199,15 @@ export default [
   {
     path: '/about',
     component: About,
-    nav: true,
     label: 'ABOUT',
     headerImage: 'about',
     headerColor: '#113750',
-    routes: aboutRoutes
+    routes: AboutRoutes
+  },
+  {
+    nav: true,
+    label: 'ABOUT',
+    routes: AboutNestedRoutes
   },
   {
     path: '/error-page',


### PR DESCRIPTION
WRI wanted to make the FAQ more easily discoverable, so we thought that we could update the About entry on the navbar to be a nested navigation.

This PR adds an extra file that includes the routes to be nested under that option. I have tried to follow similar pattern to what we have for the NDCs, though for the about the core routes are in a separate file, unlike the NDCs. But hope this is OK!