### PR TITLE
Fix/agriculture feedback

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -121,14 +121,9 @@ const filterByEmissionType = createSelector(
   [getAgricultureEmissionsData, getEmissionTypeSelected],
   (data, emissionType) => {
     if (!data || !emissionType) return null;
-    return (
-      data.filter(
-        ({ emission_subcategory: { category_id } }) =>
-          `${category_id}` === emissionType.value
-      ) ||
-      data.find(
-        ({ emission_subcategory: { category_id } }) => category_id === null
-      )
+    return data.filter(
+      ({ emission_subcategory: { category_id } }) =>
+        `${category_id}` === emissionType.value
     );
   }
 );

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -17,11 +17,33 @@ import {
 import { getEmissionCountrySelected } from './ghg-metadata-selectors';
 
 const API_SCALE = 0.001; // converting from Gigagrams to Megatonnes ( 1 Gg = 0.001 Mt)
+const TOTAL_SUBCATEGORY = {
+  name: 'Total emissions',
+  category_id: 'total',
+  category_name: 'Agriculture Emissions: Total',
+  short_name: 'total_emissions_agr_18'
+};
 
 const getSourceSelection = state =>
   (state.location && state.location.search) || null;
-const getAgricultureEmissionsData = state =>
-  (state.agricultureEmissions && state.agricultureEmissions.data) || null;
+
+const getAgricultureEmissionsData = state => {
+  if (state.agricultureEmissions) {
+    return state.agricultureEmissions.data.map(e => {
+      // fills data with the missing total emissions data
+      if (e.emission_subcategory.short_name === TOTAL_SUBCATEGORY.short_name) {
+        const emission_subcategory = {
+          ...e.emission_subcategory,
+          ...TOTAL_SUBCATEGORY
+        };
+        return { ...e, emission_subcategory };
+      }
+      return e;
+    });
+  }
+  return null;
+};
+
 const getWbCountryData = state =>
   (state.wbCountryData && state.wbCountryData.data) || null;
 
@@ -57,19 +79,20 @@ export const getEmissionTypes = createSelector(
   [getAgricultureEmissionsData],
   data => {
     if (!data || !data.length) return null;
-    const totalLabel = 'Agriculture Emissions: Total';
     const emissionTypes = data.map(
       ({ emission_subcategory: { category_name, category_id } }) => ({
-        label: category_name || totalLabel,
+        label: category_name,
         value: `${category_id}`
       })
     );
     const uniqEmissionTypes = uniqBy(emissionTypes, 'value');
     const totalOption = uniqEmissionTypes.find(
-      ({ label }) => label === totalLabel
+      ({ label }) => label === TOTAL_SUBCATEGORY.category_name
     );
     const sortedEmissionTypes = sortBy(
-      uniqEmissionTypes.filter(({ label }) => label !== totalLabel),
+      uniqEmissionTypes.filter(
+        ({ label }) => label !== TOTAL_SUBCATEGORY.category_name
+      ),
       ['label']
     );
     return [totalOption, ...sortedEmissionTypes];
@@ -98,9 +121,14 @@ const filterByEmissionType = createSelector(
   [getAgricultureEmissionsData, getEmissionTypeSelected],
   (data, emissionType) => {
     if (!data || !emissionType) return null;
-    return data.filter(
-      ({ emission_subcategory: { category_id } }) =>
-        `${category_id}` === emissionType.value
+    return (
+      data.filter(
+        ({ emission_subcategory: { category_id } }) =>
+          `${category_id}` === emissionType.value
+      ) ||
+      data.find(
+        ({ emission_subcategory: { category_id } }) => category_id === null
+      )
     );
   }
 );

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
@@ -8,6 +8,7 @@ import { GREY_CHART_COLORS } from 'data/constants';
 import { format } from 'd3-format';
 
 const AGRICULTURE_COLOR = '#0677B3';
+const LUCF_SECTORS = ['Total excluding LUCF', 'Total including LUCF'];
 
 const getGhgEmissionsData = state =>
   (state.ghgEmissions && state.ghgEmissions.data) || null;
@@ -22,7 +23,7 @@ export const getPieChartData = createSelector([getGhgEmissionsData], data => {
       const lastYearEmission = emissions[emissions.length - 1];
       return { sector, location, ...lastYearEmission };
     })
-    .filter(({ value }) => value > 0); // filter for negative emission for Forestry sector
+    .filter(({ sector, value }) => value > 0 && !LUCF_SECTORS.includes(sector)); // filter for negative emission for Forestry sector and total LUCF sectors
 
   if (!sectorsLastYearEmission) return null;
   const totalEmission = sectorsLastYearEmission.reduce(

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
@@ -8,7 +8,7 @@ import { GREY_CHART_COLORS } from 'data/constants';
 import { format } from 'd3-format';
 
 const AGRICULTURE_COLOR = '#0677B3';
-const LUCF_SECTORS = ['Total excluding LUCF', 'Total including LUCF'];
+const AGGREGATED_SECTORS = ['Total excluding LUCF', 'Total including LUCF'];
 
 const getGhgEmissionsData = state =>
   (state.ghgEmissions && state.ghgEmissions.data) || null;
@@ -23,7 +23,9 @@ export const getPieChartData = createSelector([getGhgEmissionsData], data => {
       const lastYearEmission = emissions[emissions.length - 1];
       return { sector, location, ...lastYearEmission };
     })
-    .filter(({ sector, value }) => value > 0 && !LUCF_SECTORS.includes(sector)); // filter for negative emission for Forestry sector and total LUCF sectors
+    .filter(
+      ({ sector, value }) => value > 0 && !AGGREGATED_SECTORS.includes(sector)
+    ); // filter for negative emission for Forestry sector and total LUCF sectors
 
   if (!sectorsLastYearEmission) return null;
   const totalEmission = sectorsLastYearEmission.reduce(

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -91,6 +91,10 @@ export default [
     headerColor: '#0677B3',
     sections: agricultureSections
   },
+  FEATURE_AGRICULTURE && {
+    path: '/sectors/coming-soon',
+    component: Sectors
+  },
   {
     path: '/ndcs/country/:iso/full',
     component: NDCCountryFull,

--- a/app/javascript/app/routes/app-routes/sectors-routes/sectors-routes.js
+++ b/app/javascript/app/routes/app-routes/sectors-routes/sectors-routes.js
@@ -4,5 +4,10 @@ export default [
     path: '/sectors/agriculture',
     label: 'Agriculture',
     activeId
+  },
+  {
+    path: '/sectors/coming-soon',
+    label: 'Other Sectors Coming Soon',
+    activeId
   }
 ];


### PR DESCRIPTION
This PR implements three subtasks from Agriculture feedback:
[PIVOTAL](https://www.pivotaltracker.com/story/show/164426263)

**1. On Agriculture Drivers: show the name of the indicator on the legend, for instance, "Total Emissions" or something else that represents what we are seeing in the chart**
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/381191262)
![screenshot from 2019-03-07 15 43 28](https://user-images.githubusercontent.com/15097138/53968914-ca7c0e80-40ef-11e9-9c39-bbf67dbe52c8.png)

**2. On Agriculture Drivers of Emissions remove two sectors from the pie chart: "Total including LUCF" and "Total Excluding LUCF", as these would cause a double counting, so should not be there.**
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/381191243)
![ngt1r-miajq](https://user-images.githubusercontent.com/15097138/53969478-c69cbc00-40f0-11e9-82ad-881316d44bd6.gif)

 **3. On the dropdown menu for Sectors in the header, add an extra "option" that is not selectable saying "Other Sectors Coming Soon"**
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/381191179)
![screenshot from 2019-03-07 15 47 43](https://user-images.githubusercontent.com/15097138/53969402-a5d46680-40f0-11e9-937a-63ec1a2d3f4b.png)

