### PR TITLE
Fix/more ghg feedback

### DIFF
--- a/app/controllers/api/v1/locations/countries_controller.rb
+++ b/app/controllers/api/v1/locations/countries_controller.rb
@@ -3,10 +3,15 @@ module Api
     module Locations
       class CountriesController < ApiController
         def index
-          countries = Location.where(
-            location_type: 'COUNTRY',
-            show_in_cw: true
-          ).order(:wri_standard_name)
+          countries = Location.
+            where(
+              location_type: 'COUNTRY',
+              show_in_cw: true
+            ).or(
+              Location.where(
+                iso_code3: 'EU28'
+              )
+            ).order(:wri_standard_name)
 
           render json: countries,
                  each_serializer: Api::V1::LocationSerializer,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -113,7 +113,6 @@ class GhgEmissions extends PureComponent {
             options={options.regions || []}
             values={getValues(selectedOptions.regionsSelected)}
             onValueChange={selected => handleChange('regions', selected)}
-            hideResetButton
           />
           <MultiLevelDropdown
             label="Sectors / Subsectors"
@@ -121,6 +120,7 @@ class GhgEmissions extends PureComponent {
             options={options.sectors}
             values={selectedOptions.sectorsSelected || []}
             onChange={selected => handleChange('sectors', selected)}
+            clearable
             multiselect
           />
           <Multiselect

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -2,6 +2,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
 import isEmpty from 'lodash/isEmpty';
+import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaults, toPlural } from 'utils/ghg-emissions';
 import { sortLabelByAlpha } from 'utils/graphs';
@@ -272,15 +273,34 @@ const getGasConflicts = gasSelected => {
   return conflicts;
 };
 
+const getChartConflicts = (metricSelected, chartSelected) => {
+  const conflicts = [];
+
+  if (['PER_CAPITA', 'PER_GDP'].includes(metricSelected) && chartSelected.value !== 'line') {
+    const metricOption = METRIC_OPTIONS[metricSelected];
+    conflicts.push(`${metricOption.label} metric is not allowed with ${chartSelected.label} chart`);
+  }
+
+  return conflicts;
+};
+
 export const getFiltersConflicts = createSelector(
   [
     getFiltersSelected('location'),
     getFiltersSelected('gas'),
     getFiltersSelected('sector'),
     getModelSelected,
+    getMetricSelected,
     getChartTypeSelected
   ],
-  (locationSelected, gasSelected, sectorsSelected, modelSelected, chartSelected) => {
+  (
+    locationSelected,
+    gasSelected,
+    sectorsSelected,
+    modelSelected,
+    metricSelected,
+    chartSelected
+  ) => {
     let conflicts = [];
     let canChangeBreakByTo = difference(['sector', 'gas', 'regions'], [modelSelected]);
     const solutions = ['Please deselect all conflicting options'];
@@ -292,6 +312,7 @@ export const getFiltersConflicts = createSelector(
     const sectorConflicts = getOverlappingConflicts(sectorsSelected);
     const regionConflicts = getOverlappingConflicts(locationSelected);
     const gasConflicts = getGasConflicts(gasSelected);
+    const chartConflicts = getChartConflicts(metricSelected, chartSelected);
 
     if (sectorConflicts.length) {
       canChangeBreakByTo = difference(canChangeBreakByTo, ['gas', 'regions']);
@@ -315,6 +336,8 @@ export const getFiltersConflicts = createSelector(
       conflicts = conflicts.concat(regionConflicts);
     }
 
+    conflicts = conflicts.concat(chartConflicts);
+
     if (conflicts.length && isAggregatedChart) {
       solutions.push('change "Chart Type" to line chart');
     }
@@ -325,7 +348,7 @@ export const getFiltersConflicts = createSelector(
 
     return {
       conflicts,
-      solutionText: solutions.join(' or ')
+      solutionText: uniq(solutions).join(' or ')
     };
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -201,7 +201,7 @@ const getFiltersSelected = field =>
         options && (field === 'location' ? options.regions : options[toPlural(field)]);
       if (!defaults) return null;
       if (!selected || !fieldOptions || isEmpty(fieldOptions)) {
-        return defaults[field];
+        return [...defaults[field]];
       }
       let selectedFilters = [];
       if (selected) {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -5,9 +5,10 @@ import { withRouter } from 'react-router';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { handleAnalytics } from 'utils/analytics';
 import qs from 'query-string';
-import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
 import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
+import upperFirst from 'lodash/upperFirst';
 import { actions } from 'components/modal-metadata';
 
 import GhgEmissionsComponent from './ghg-emissions-component';
@@ -84,7 +85,7 @@ class GhgEmissionsContainer extends PureComponent {
 
     this.updateUrlParam({
       name: [field],
-      value: values
+      value: isEmpty(values) ? null : values
     });
 
     const selectedFilterLabels = filters.map(f => f.label);

--- a/app/javascript/app/components/multiselect/multiselect-component.jsx
+++ b/app/javascript/app/components/multiselect/multiselect-component.jsx
@@ -75,12 +75,10 @@ class Multiselect extends Component {
             styles.multiSelect,
             children ? styles.hasChildren : '',
             { [styles.mirrorX]: mirrorX },
-            { [styles.searchable]: !icon }
+            { [styles.unsearchable]: icon }
           )}
         >
-          <div className={cx(styles.values, 'values')}>
-            {this.getSelectorValue()}
-          </div>
+          <div className={cx(styles.values, 'values')}>{this.getSelectorValue()}</div>
           {loading && <Loading className={styles.loader} mini />}
           <MultiSelect
             ref={el => {
@@ -92,12 +90,7 @@ class Multiselect extends Component {
               const className = option.isSelected ? selectedClassName : '';
               return (
                 (!hideSelected || !option.isSelected) && (
-                  <div
-                    className={cx(
-                      className,
-                      option.groupId ? styles.nested : ''
-                    )}
-                  >
+                  <div className={cx(className, option.groupId ? styles.nested : '')}>
                     {option.label}
                     {option.isSelected && <span className={styles.checked} />}
                   </div>
@@ -106,10 +99,7 @@ class Multiselect extends Component {
             }}
             onValuesChange={handleChange}
             renderToggleButton={({ open }) => (
-              <Icon
-                className={open ? styles.isOpen : ''}
-                icon={icon || dropdownArrow}
-              />
+              <Icon className={open ? styles.isOpen : ''} icon={icon || dropdownArrow} />
             )}
             onSearchChange={s => this.setState({ search: s })}
             search={this.state.search}

--- a/app/javascript/app/components/multiselect/multiselect-styles.scss
+++ b/app/javascript/app/components/multiselect/multiselect-styles.scss
@@ -77,12 +77,8 @@
   }
 }
 
-:global .multi-select .react-selectize-search-field-and-selected-values .resizable-input {
+.unsearchable :global .react-selectize-search-field-and-selected-values .resizable-input {
   opacity: 0;
-}
-
-.searchable :global .react-selectize-search-field-and-selected-values .resizable-input {
-  opacity: 1;
 }
 
 .selected {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.11",
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.41.2",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.41.3",
     "css-loader": "0.28.7",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,9 +2952,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.41.2":
-  version "1.41.2"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/e4b57ccc1221f768fd8856c586eee8a92d93320d"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.41.3":
+  version "1.41.3"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/fe89f6f1c30b821c42798962556fdc890aa50cfc"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
Fixing for GHG emission module

- EU28 is a region now
- adding reset icon for regions/gases/sectors dropdowns
- fixing not visible search input, regions dropdown
- new conflict when break by GDP, or CAPITA, only line chart is allowed
- fixing some double counting issues when region has also precalculated data (WORLD, EU28) and we have to reach for all countries data as we want also expand that region if only one selected
- making sure GDP, capita calculations are right for all regions. If WB bank does not have that data, like for World we expanding the region to all underlying countries and taking that data for calculations.
 
[PIVOTAL](https://www.pivotaltracker.com/story/show/164425169)

We have to reimport locations.
```
bundle exec rake locations:import
```

Still waiting for the data or information which one AR should we remove from PIK data source file, so emissions there are doubled until we reimport the new file.

Hopefully, all is right then :see_no_evil: 