### PR TITLE
Fix country actions counter

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-selectors.js
@@ -75,7 +75,7 @@ export const getCountriesCountWithProposedActions = createSelector(
       )
     );
 
-    return flatten([...new Set(countriesWithActionsSpecified)]).length;
+    return [...new Set(flatten(countriesWithActionsSpecified))].length;
   }
 );
 


### PR DESCRIPTION
This PR fixes country counter in description of "Countries’ Actions in their NDCs" section.
[BASECAMP - (NDC: error in text intro)](https://basecamp.com/1756858/projects/13795275/todos/381192437) | [PIVOTAL](https://www.pivotaltracker.com/story/show/164426263)

We have an array of two arrays, and we wanted to have one merged array with unique values, but instead we were getting merged array with duplicated values:
![screenshot from 2019-03-08 16 08 29](https://user-images.githubusercontent.com/15097138/54040092-73903b00-41bc-11e9-96a6-24c1fa59041e.png)
