### PR TITLE
new defaults for PIK data, gwp could be null

### DIFF
--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -51,8 +51,8 @@ export const DEFAULT_EMISSIONS_SELECTIONS = {
     location: 'WORLD'
   },
   PIK: {
-    gas: 'All GHG',
-    sector: 'Total including LULUCF',
+    gas: 'KYOTOGHG',
+    sector: 'Total excluding LULUCF',
     location: 'WORLD'
   },
   UNFCCC_AI: {

--- a/app/serializers/api/v1/historical_emissions/record_serializer.rb
+++ b/app/serializers/api/v1/historical_emissions/record_serializer.rb
@@ -31,7 +31,7 @@ module Api
         end
 
         def gwp
-          object.gwp.name
+          object.gwp&.name
         end
 
         def emissions


### PR DESCRIPTION
Small changes to make the new PIK data file working.

New file and changed metadata_sectors were uploaded to AWS staging.

```
bundle exec rake historical_emissions:import
```