### PR TITLE
Feature/consumption default selection

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data.js
@@ -3,15 +3,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import qs from 'query-string';
-import isArray from 'lodash/isArray';
 import { getLocationParamUpdated } from 'utils/navigation';
 import Component from './meat-data-component';
-import {
-  meatData,
-  CATEGORY_KEY,
-  BREAK_BY_KEY,
-  COUNTRIES_KEY
-} from './meat-data-selectors';
+import { meatData, CATEGORY_KEY, BREAK_BY_KEY } from './meat-data-selectors';
 
 const mapStateToProps = (state, { location }) => {
   const search = qs.parse(location.search);
@@ -39,13 +33,9 @@ class MeatDataContainer extends PureComponent {
     this.updateUrlParam({ name: BREAK_BY_KEY, value: option.value });
 
   handleLegendChange = selected => {
-    let values;
-    if (isArray(selected)) {
-      values = selected.map(v => v.value).join(',');
-    } else {
-      values = selected.value;
-    }
-    this.updateUrlParam({ name: COUNTRIES_KEY, value: values });
+    const others = selected.filter(v => v.value === 'others');
+    const value = others.length && others[0].value;
+    this.updateUrlParam({ name: 'tradeChart', value });
   };
 
   render() {

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/tooltip/tooltip-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/tooltip/tooltip-component.jsx
@@ -51,10 +51,12 @@ const Tooltip = ({ content, config }) => {
         {renderTag(countryName, countryColor)}
         {renderFormattedValue(countryValue)}
       </p>
-      <p className={styles.info}>
-        {renderTag(othersName, othersColor)}
-        {renderFormattedValue(otherCountriesValue)}
-      </p>
+      {otherCountriesValue && (
+        <p className={styles.info}>
+          {renderTag(othersName, othersColor)}
+          {renderFormattedValue(otherCountriesValue)}
+        </p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR updates `Agriculture > Countries context > By Country > Consumption chart` default selection (now only the selected country is displayed. User should add `other countries` through legend `+` button ).
It also fixes an existing bug when changing country after interacting with chart legend.

[Pivotal](https://www.pivotaltracker.com/story/show/164532447)