### PR TITLE
Feature/default years

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
@@ -51,6 +51,18 @@ class ContextByIndicatorComponent extends Component {
     ReactTooltip.rebuild();
   }
 
+  renderYearLabel = option => {
+    const { yearsWithData } = this.props;
+    const hasData = yearsWithData.find(y => y.value === option.value);
+    return (
+      <div
+        style={{ color: `${hasData ? '#113750' : '#b1b1c1'}`, padding: '10px' }}
+      >
+        {option.label}
+      </div>
+    );
+  };
+
   render() {
     const {
       indicators,
@@ -67,6 +79,7 @@ class ContextByIndicatorComponent extends Component {
       handleCountryEnter,
       handleCountryClick
     } = this.props;
+
     return (
       <TabletLandscape>
         {isTablet => (
@@ -84,6 +97,7 @@ class ContextByIndicatorComponent extends Component {
                   label={'Year'}
                   value={indicatorSelectedYear}
                   options={indicatorsYears}
+                  renderOption={this.renderYearLabel}
                   onValueChange={updateIndicatorYearFilter}
                   hideResetButton
                 />
@@ -178,6 +192,7 @@ ContextByIndicatorComponent.propTypes = {
   indicators: PropTypes.arrayOf(PropTypes.shape({})),
   topTenCountries: PropTypes.arrayOf(PropTypes.shape({})),
   indicatorsYears: PropTypes.arrayOf(PropTypes.shape({})),
+  yearsWithData: PropTypes.arrayOf(PropTypes.shape({})),
   selectedIndicator: PropTypes.shape({}),
   indicatorSelectedYear: PropTypes.shape({}),
   countryData: PropTypes.shape({}),

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
@@ -1,6 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { getColorByIndex } from 'utils/map';
-import { isEmpty, orderBy } from 'lodash';
+import { isEmpty, orderBy, flatten } from 'lodash';
 import { format } from 'd3-format';
 import worldPaths from 'app/data/world-50m-paths';
 import {
@@ -81,11 +81,30 @@ const getYears = createSelector(getAgricultureData, data => {
   }));
 });
 
+const getYearsWithData = createSelector(
+  [getSelectedIndicator, getYears, getAgricultureData],
+  (indicator, years, data) => {
+    if (!years || !years || !data) return null;
+    years.map(y => data.filter(d => d.year === y).some(f => f[indicator]));
+    const yearsWithData = years.map(y =>
+      data.filter(d => d.year === parseInt(y.value, 10))
+    );
+    const yearsWithSelectedIndicatorData = flatten(yearsWithData)
+      .filter(y => y[indicator.value])
+      .map(d => d.year);
+    const uniqueYears = [...new Set(yearsWithSelectedIndicatorData)];
+    return uniqueYears.map(y => ({
+      label: y.toString(),
+      value: y.toString()
+    }));
+  }
+);
+
 export const getSelectedYear = createSelector(
-  [getYears, getSearch],
-  (years, search) => {
-    if (isEmpty(years)) return null;
-    if (search && !search.indicatorYear) return years[0];
+  [getYears, getYearsWithData, getSearch],
+  (years, yearsWithData, search) => {
+    if (isEmpty(years) || isEmpty(years)) return null;
+    if (search && !search.indicatorYear) return yearsWithData[0];
     return years.find(y => y.value === search.indicatorYear);
   }
 );

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
@@ -81,7 +81,7 @@ const getYears = createSelector(getAgricultureData, data => {
   }));
 });
 
-const getYearsWithData = createSelector(
+export const getYearsWithData = createSelector(
   [getSelectedIndicator, getYears, getAgricultureData],
   (indicator, years, data) => {
     if (!years || !years || !data) return null;
@@ -245,6 +245,7 @@ export const countriesContexts = createStructuredSelector({
   indicators: getIndicatorsParsed,
   selectedIndicator: getSelectedIndicator,
   indicatorsYears: getYears,
+  yearsWithData: getYearsWithData,
   indicatorSelectedYear: getSelectedYear,
   paths: getPathsWithStyles,
   legend: getMapLegend,


### PR DESCRIPTION
This PR updates `Agriculture > Countries contexts > Explore by indicator` default year selection to the first year in which there's data for the selected indicator.
It also updates styles for years options on years dropdown. Only years with data are rendered with `theme-color` the years with no data are greyed out.

![Kapture 2019-03-18 at 14 43 25](https://user-images.githubusercontent.com/6906348/54534242-3d0caa00-498c-11e9-8ece-471dea54e1e2.gif)
