### PR TITLE
Fix position of 'Explore here' link in Latest Updates section

### DIFF
--- a/app/javascript/app/components/tile/tile-component.jsx
+++ b/app/javascript/app/components/tile/tile-component.jsx
@@ -13,11 +13,11 @@ const Tile = ({ category, date, description, link }) => (
     rel="noopener noreferrer"
   >
     <div className={styles.container}>
-      <div className={styles.details}>
-        <span>{category}</span>
-        <span>{date}</span>
-      </div>
       <div className={styles.content}>
+        <div className={styles.details}>
+          <span>{category}</span>
+          <span>{date}</span>
+        </div>
         <Truncate
           className={styles.description}
           lines={4}
@@ -26,11 +26,11 @@ const Tile = ({ category, date, description, link }) => (
         >
           {description}
         </Truncate>
-        <span className={styles.link}>
-          Explore here
-          <Icon icon={arrowTailRight} />
-        </span>
       </div>
+      <span className={styles.link}>
+        Explore here
+        <Icon icon={arrowTailRight} />
+      </span>
     </div>
   </a>
 );

--- a/app/javascript/app/components/tile/tile-styles.scss
+++ b/app/javascript/app/components/tile/tile-styles.scss
@@ -46,7 +46,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 15px 26px 30px 15px;
+  padding: 15px 26px 25px 15px;
+  justify-content: space-between;
   position: absolute;
   width: 100%;
 }
@@ -65,18 +66,17 @@
 .content {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  justify-content: space-between;
-  margin-left: 4px;
 }
 
 .description {
   font-size: $font-size-large;
+  margin-left: 4px;
 }
 
 .link {
   display: flex;
   align-items: flex-end;
+  margin-left: 4px;
   justify-content: space-between;
   width: 140px;
 


### PR DESCRIPTION
This small PR fixes a position of `Explore here` link in `Latest updates` section:

**BEFORE:**
![Screenshot from 2019-03-18 16 48 53](https://user-images.githubusercontent.com/15097138/54549865-e2327d00-49a2-11e9-8b6a-421b1c2a2bb7.png)

**AFTER:**
![Screenshot from 2019-03-18 17 24 24](https://user-images.githubusercontent.com/15097138/54549870-e3fc4080-49a2-11e9-942f-a89b48a79c09.png)
