### PR TITLE
Feature/enable water withdrawal chart

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
@@ -80,12 +80,12 @@ const indicatorCardsComponent = ({ cards, selectedYear }) => (
             {card.legend && renderLegend(card, selectedYear)}
             {card.chartData &&
             card.chartData.some(l => l.value) && (
-            <div className={styles.chart}>
+                <div className={styles.chart}>
                   <PieChart
-                data={card.chartData}
-                width={150}
-                config={card.chartConfig}
-              />
+                    data={card.chartData}
+                    width={150}
+                    config={card.chartConfig}
+                  />
                 </div>
               )}
             {card.rank && (

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
@@ -27,7 +27,9 @@ const renderLegend = (card, year) => {
     </div>
   ) : (
     <NoContent
-      message={card.noDataMessage || `No data for ${card.countryName} in ${year.value}`}
+      message={
+        card.noDataMessage || `No data for ${card.countryName} in ${year.value}`
+      }
       className={styles.noContent}
       minHeight={100}
     />
@@ -76,15 +78,16 @@ const indicatorCardsComponent = ({ cards, selectedYear }) => (
           />
           <div className={styles.cardContent}>
             {card.legend && renderLegend(card, selectedYear)}
-            {card.chartData && card.chartData.some(l => l.value) && (
-              <div className={styles.chart}>
-                <PieChart
-                  data={card.chartData}
-                  width={150}
-                  config={card.chartConfig}
-                />
-              </div>
-            )}
+            {card.chartData &&
+            card.chartData.some(l => l.value) && (
+            <div className={styles.chart}>
+                  <PieChart
+                data={card.chartData}
+                width={150}
+                config={card.chartConfig}
+              />
+                </div>
+              )}
             {card.rank && (
               <div
                 className={cx(styles.textHtmlWrapper, styles.rank)}

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
@@ -14,7 +14,7 @@ const cardTheme = {
 };
 
 const renderLegend = (card, year) => {
-  const hasData = card.legend.some(l => l.value != null) || card.chartConfig;
+  const hasData = card.chartData.some(l => l.value);
   return hasData ? (
     <div className={cx(styles.textHtmlWrapper, styles.legend)}>
       {card.legend.map(i => (
@@ -27,7 +27,7 @@ const renderLegend = (card, year) => {
     </div>
   ) : (
     <NoContent
-      message={`No water withdrawal data for ${card.countryName} in ${year.value}`}
+      message={card.noDataMessage || `No data for ${card.countryName} in ${year.value}`}
       className={styles.noContent}
       minHeight={100}
     />
@@ -76,7 +76,7 @@ const indicatorCardsComponent = ({ cards, selectedYear }) => (
           />
           <div className={styles.cardContent}>
             {card.legend && renderLegend(card, selectedYear)}
-            {card.chartConfig && (
+            {card.chartData && card.chartData.some(l => l.value) && (
               <div className={styles.chart}>
                 <PieChart
                   data={card.chartData}

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-styles.scss
@@ -79,8 +79,7 @@
     }
 
     .rank {
-      position: absolute;
-      bottom: 10px;
+      margin: 10px 0;
     }
   }
 
@@ -165,6 +164,11 @@
       .chart,
       .legend {
         width: 50%;
+      }
+
+      .rank {
+        position: absolute;
+        bottom: 10px;
       }
     }
 

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
@@ -193,7 +193,10 @@ const getCardsData = createSelector(
       title: 'Water withdrawal and water stress',
       chartConfig: getChartConfig(
         [
-          { label: 'Agricultural activities', slug: 'agricultureWaterWithdrawal' },
+          {
+            label: 'Agricultural activities',
+            slug: 'agricultureWaterWithdrawal'
+          },
           { label: 'Non-agricultural activities', slug: 'totalWaterWithdrawal' }
         ],
         y.label,
@@ -202,9 +205,11 @@ const getCardsData = createSelector(
         '%'
       ),
       chartData: [
-        { name: 'totalWaterWithdrawal', value: yearData.water_withdrawal && 100.00 - yearData.water_withdrawal },
+        {
+          name: 'totalWaterWithdrawal',
+          value: yearData.water_withdrawal && 100.0 - yearData.water_withdrawal
+        },
         { name: 'agricultureWaterWithdrawal', value: yearData.water_withdrawal }
-
       ],
       legend: [
         {
@@ -220,7 +225,8 @@ const getCardsData = createSelector(
       rank: yearData.water_withdrawal_rank
         ? `<p>Water stress country ranking <span>${yearData.water_withdrawal_rank}</span> of 156</p>`
         : '',
-      text: '<p>Globally, 70 percent of all freshwater withdrawn from rivers, lakes and aquifers was used for agriculture. In many regions, baseline water stress coincides with regions  of key crop production, increasing water stress and future risks.</p>',
+      text:
+        '<p>Globally, 70 percent of all freshwater withdrawn from rivers, lakes and aquifers was used for agriculture. In many regions, baseline water stress coincides with regions  of key crop production, increasing water stress and future risks.</p>',
       noDataMessage: `No water withdrawal data for ${c.label} in ${y.value}`
     };
 

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
@@ -195,9 +195,9 @@ const getCardsData = createSelector(
         [
           {
             label: 'Agricultural activities',
-            slug: 'agricultureWaterWithdrawal'
+            slug: 'agricultureActivities'
           },
-          { label: 'Non-agricultural activities', slug: 'totalWaterWithdrawal' }
+          { label: 'Non-agricultural activities', slug: 'nonAgricultureActivities' }
         ],
         y.label,
         'percentage',
@@ -206,10 +206,10 @@ const getCardsData = createSelector(
       ),
       chartData: [
         {
-          name: 'totalWaterWithdrawal',
-          value: yearData.water_withdrawal && 100.0 - yearData.water_withdrawal
+          name: 'nonAgricultureActivities',
+          value: yearData.water_withdrawal && 100 - yearData.water_withdrawal
         },
-        { name: 'agricultureWaterWithdrawal', value: yearData.water_withdrawal }
+        { name: 'agricultureActivities', value: yearData.water_withdrawal }
       ],
       legend: [
         {

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-contexts-selectors.js
@@ -14,7 +14,7 @@ const legendHtmlDot = (text, color, value, unit) =>
   `<p><span style="background-color: ${color}; width: 10px; height: 10px; display: inline-block; border-radius: 10px; margin-right: 10px;" ></span>${text}</p><p style="color: ${color};">${value ||
     '---'} ${unit}<p/>`;
 
-const getChartConfig = (labels, year, unit, colors) => ({
+const getChartConfig = (labels, year, unit, colors, suffix) => ({
   outerRadius: 55,
   innerRadius: 25,
   hideLegend: true,
@@ -27,7 +27,8 @@ const getChartConfig = (labels, year, unit, colors) => ({
   axes: {
     yLeft: {
       unit,
-      label: year
+      label: year,
+      suffix
     }
   },
   theme: {
@@ -130,7 +131,8 @@ const getCardsData = createSelector(
       text: `<p> Agriculture is a source of livelihood for more than 2 billion people around the world. In <span>${y.value}</span>, <span>${precentageTwoPlacesRound(
         yearData.employment_agri_total
       ) ||
-        '---'}%</span> of <span>${c.label}'s</span> population was employed in the agriculture sector.`
+        '---'}%</span> of <span>${c.label}'s</span> population was employed in the agriculture sector.`,
+      noDataMessage: `No population data for ${c.label} on ${y.value}`
     };
 
     const GDP = {
@@ -183,16 +185,33 @@ const getCardsData = createSelector(
         }
       ],
       text:
-        '<p><span>Agriculture</span> makes up a significant portion of the economic output of many developing countries and economic growth in the sector can often reduce poverty and increase food security. </p>'
+        '<p><span>Agriculture</span> makes up a significant portion of the economic output of many developing countries and economic growth in the sector can often reduce poverty and increase food security. </p>',
+      noDataMessage: `No GDP data for ${c.label} in ${y.value}`
     };
+
     const water = {
       title: 'Water withdrawal and water stress',
+      chartConfig: getChartConfig(
+        [
+          { label: 'Agricultural activities', slug: 'agricultureWaterWithdrawal' },
+          { label: 'Non-agricultural activities', slug: 'totalWaterWithdrawal' }
+        ],
+        y.label,
+        'percentage',
+        ['#0677B3', '#CACCD0'],
+        '%'
+      ),
+      chartData: [
+        { name: 'totalWaterWithdrawal', value: yearData.water_withdrawal && 100.00 - yearData.water_withdrawal },
+        { name: 'agricultureWaterWithdrawal', value: yearData.water_withdrawal }
+
+      ],
       legend: [
         {
           text: legendHtmlDot(
             'Agricultural activities',
             '#0677B3',
-            yearData.water_withdrawal,
+            format('.2')(yearData.water_withdrawal),
             '%'
           )
         }
@@ -201,10 +220,10 @@ const getCardsData = createSelector(
       rank: yearData.water_withdrawal_rank
         ? `<p>Water stress country ranking <span>${yearData.water_withdrawal_rank}</span> of 156</p>`
         : '',
-      text: contextsData.water_withdrawal
-        ? '<p>Globally, 70 percent of all freshwater withdrawn from rivers, lakes and aquifers was used for agriculture. In many regions, baseline water stress coincides with regions  of key crop production, increasing water stress and future risks.</p>'
-        : ''
+      text: '<p>Globally, 70 percent of all freshwater withdrawn from rivers, lakes and aquifers was used for agriculture. In many regions, baseline water stress coincides with regions  of key crop production, increasing water stress and future risks.</p>',
+      noDataMessage: `No water withdrawal data for ${c.label} in ${y.value}`
     };
+
     const fertilizer = {
       chartConfig: getChartConfig(
         [
@@ -239,7 +258,8 @@ const getCardsData = createSelector(
       ],
       title: 'Fertilizer and pesticide use',
       text:
-        '<p>The use of synthetic nitrogen fertilizer is a large contributor to emissions in agriculture, owing to the potent greenhouse gas N2O. Heavy pesticide use can lead to harmful impacts on the environment.</p>'
+        '<p>The use of synthetic nitrogen fertilizer is a large contributor to emissions in agriculture, owing to the potent greenhouse gas N2O. Heavy pesticide use can lead to harmful impacts on the environment.</p>',
+      noDataMessage: `No fertilizer and pesticide use data for ${c.label} in ${y.value}`
     };
 
     return [GDP, socioeconomic, water, fertilizer];

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
@@ -51,11 +51,10 @@ export const getPieChartData = createSelector([getGhgEmissionsData], data => {
       ...sectorEmissions.filter(({ name }) => name !== 'agriculture')
     ]
     : sectorEmissions;
-  const { location, year } = sectorsLastYearEmission[0];
 
   return {
-    year,
-    location,
+    year: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].year,
+    location: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].location,
     emissionValue: agricultureRow && agricultureRow.formattedValue,
     emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
     data: sectorsEmissionsData


### PR DESCRIPTION
[PIVOTAL](https://www.pivotaltracker.com/story/show/164824983)

This PR:
- enables water withdrawal chart in Agriculture profile:
![Screenshot from 2019-03-22 15 55 41](https://user-images.githubusercontent.com/15097138/54835916-094ac080-4cbb-11e9-93c3-a1874375784c.png)
- adds custom `no data` messages for each chart:
![Screenshot from 2019-03-22 15 54 29](https://user-images.githubusercontent.com/15097138/54835979-2e3f3380-4cbb-11e9-858d-b1cbd0fde364.png)
- fixes bug with navigation from Agriculture to GHG Emissions chart and back
