### PR TITLE
Fix passing year and and update switch option after click on map in C…

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
@@ -6,8 +6,9 @@ import qs from 'query-string';
 import { format } from 'd3-format';
 import { isCountryIncluded } from 'app/utils';
 import { handleAnalytics } from 'utils/analytics';
-import { countriesContexts } from './context-by-indicator-selectors';
+import { getLocationParamUpdated } from 'utils/navigation';
 
+import { countriesContexts } from './context-by-indicator-selectors';
 import Component from './context-by-indicator-component';
 
 const mapStateToProps = (state, { location, countries }) => {
@@ -54,18 +55,25 @@ class ContextByIndicatorContainer extends PureComponent {
   };
 
   handleCountryClick = geography => {
-    const { isoCountries, history } = this.props;
+    const { isoCountries, indicatorSelectedYear } = this.props;
     const iso = geography.properties && geography.properties.id;
     if (iso && isCountryIncluded(isoCountries, iso)) {
-      history.push(
-        `/sectors/agriculture?contextBy=country&contextMapIndicator=total_fertilizers&country=${iso}#understand-countries-contexts`
-      );
+      this.updateUrlParam([
+        { name: 'contextBy', value: 'country' },
+        { name: 'country', value: iso },
+        { name: 'countryYear', value: indicatorSelectedYear.value }
+      ]);
       handleAnalytics(
         'Agriculture Profile - Countries Context',
         'Use map to find country',
         geography.properties.name
       );
     }
+  };
+
+  updateUrlParam = (params, clear) => {
+    const { history, location } = this.props;
+    history.push(getLocationParamUpdated(location, params, clear));
   };
 
   render() {
@@ -84,7 +92,9 @@ ContextByIndicatorContainer.propTypes = {
   selectedIndicator: PropTypes.shape({}),
   mapData: PropTypes.arrayOf(PropTypes.shape({})),
   isoCountries: PropTypes.arrayOf(PropTypes.string),
-  history: PropTypes.shape({})
+  history: PropTypes.shape({}),
+  indicatorSelectedYear: PropTypes.shape({}),
+  location: PropTypes.shape({})
 };
 
 export default withRouter(

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-component.jsx
@@ -29,7 +29,6 @@ const SwitchOptionsComponents = {
 class CountriesContext extends PureComponent {
   render() {
     const { query, selectedCountry, handleSwitchClick, loading } = this.props;
-
     const switchOption = (query && query.contextBy) || 'indicator';
 
     const Component = SwitchOptionsComponents[switchOption];
@@ -47,6 +46,7 @@ class CountriesContext extends PureComponent {
             </p>
             <div className={styles.switchWrapper}>
               <Switch
+                key={`explore-by-${switchOption}`}
                 options={tabs}
                 selectedOption={switchOption}
                 onClick={handleSwitchClick}


### PR DESCRIPTION
This PR fixes a bug after clicking on a country in map component in Countries' Context section.
Now, a selected year from `Explore by indicator` is this same as a year in `Explore by country`, also an active option on switch component is changing to `Explore by country`.
[PIVOTAL](https://www.pivotaltracker.com/story/show/164824992)
![c1viv-xx2ku](https://user-images.githubusercontent.com/15097138/54932676-1cf06400-4f13-11e9-92b4-4ff9b29f3f53.gif)
