### PR TITLE
Feature/agriculture emissions data for two locations

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/ghg-metadata-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/ghg-metadata-selectors.js
@@ -50,7 +50,7 @@ export const getGhgEmissionsFilter = createSelector(
   (selectedCountry, source, gas) => {
     if (!selectedCountry || !source || !gas) return null;
     return {
-      location: selectedCountry.value,
+      location: `WORLD,${selectedCountry.value}`,
       source: source.value,
       gas: gas.value
     };

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
@@ -6,6 +6,7 @@ import {
 } from 'utils/graphs';
 import { GREY_CHART_COLORS } from 'data/constants';
 import { format } from 'd3-format';
+import { getEmissionCountrySelected } from './ghg-metadata-selectors';
 
 const AGRICULTURE_COLOR = '#0677B3';
 const AGGREGATED_SECTORS = ['Total excluding LUCF', 'Total including LUCF'];
@@ -16,50 +17,67 @@ const getGhgEmissionsLoading = state =>
   (state.ghgEmissions && state.ghgEmissions.loading) || false;
 
 /** PIE-CHART SELECTORS */
-export const getPieChartData = createSelector([getGhgEmissionsData], data => {
-  if (!data || !data.length) return null;
-  const sectorsLastYearEmission = data
-    .map(({ emissions, sector, location }) => {
-      const lastYearEmission = emissions[emissions.length - 1];
-      return { sector, location, ...lastYearEmission };
-    })
-    .filter(
-      ({ sector, value }) => value > 0 && !AGGREGATED_SECTORS.includes(sector)
-    ); // filter for negative emission for Forestry sector and total LUCF sectors
+export const getGhgEmissionsDataByLocation = createSelector(
+  [getGhgEmissionsData, getEmissionCountrySelected],
+  (data, location) => {
+    if (!data || !data.length || !location) return null;
+    const emissionsData = data.filter(
+      ({ iso_code3 }) => iso_code3 === location.value
+    );
+    return emissionsData;
+  }
+);
 
-  if (!sectorsLastYearEmission) return null;
-  const totalEmission = sectorsLastYearEmission.reduce(
-    (acc, emission) => acc + emission.value,
-    0
-  );
+export const getPieChartData = createSelector(
+  [getGhgEmissionsDataByLocation],
+  data => {
+    if (!data || !data.length) return null;
+    const sectorsLastYearEmission = data
+      .map(({ emissions, sector, location }) => {
+        const lastYearEmission = emissions[emissions.length - 1];
+        return { sector, location, ...lastYearEmission };
+      })
+      .filter(
+        ({ sector, value }) => value > 0 && !AGGREGATED_SECTORS.includes(sector)
+      ); // filter for negative emission for Forestry sector and total LUCF sectors
 
-  const sectorEmissions = sectorsLastYearEmission.map(({ sector, value }) => ({
-    name: getColumnValue(sector).toLowerCase(),
-    value,
-    sector,
-    formattedValue: `${format('.2s')(value)}`,
-    formattedPercentage: `${format('.2f')(value * 100 / totalEmission)}%`,
-    percentageValue: value * 100 / totalEmission
-  }));
+    if (!sectorsLastYearEmission) return null;
+    const totalEmission = sectorsLastYearEmission.reduce(
+      (acc, emission) => acc + emission.value,
+      0
+    );
 
-  const agricultureRow = sectorEmissions.find(
-    ({ name }) => name === 'agriculture'
-  );
-  const sectorsEmissionsData = agricultureRow
-    ? [
-      agricultureRow,
-      ...sectorEmissions.filter(({ name }) => name !== 'agriculture')
-    ]
-    : sectorEmissions;
+    const sectorEmissions = sectorsLastYearEmission.map(
+      ({ sector, value }) => ({
+        name: getColumnValue(sector).toLowerCase(),
+        value,
+        sector,
+        formattedValue: `${format('.2s')(value)}`,
+        formattedPercentage: `${format('.2f')(value * 100 / totalEmission)}%`,
+        percentageValue: value * 100 / totalEmission
+      })
+    );
 
-  return {
-    year: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].year,
-    location: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].location,
-    emissionValue: agricultureRow && agricultureRow.formattedValue,
-    emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
-    data: sectorsEmissionsData
-  };
-});
+    const agricultureRow = sectorEmissions.find(
+      ({ name }) => name === 'agriculture'
+    );
+    const sectorsEmissionsData = agricultureRow
+      ? [
+        agricultureRow,
+        ...sectorEmissions.filter(({ name }) => name !== 'agriculture')
+      ]
+      : sectorEmissions;
+
+    return {
+      year: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].year,
+      location:
+        sectorsLastYearEmission[0] && sectorsLastYearEmission[0].location,
+      emissionValue: agricultureRow && agricultureRow.formattedValue,
+      emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
+      data: sectorsEmissionsData
+    };
+  }
+);
 
 const getPieChartConfig = createSelector([getPieChartData], pieChartData => {
   if (!pieChartData || !pieChartData.data || !pieChartData.data.length) {

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/pie-chart-selectors.js
@@ -9,7 +9,13 @@ import { format } from 'd3-format';
 import { getEmissionCountrySelected } from './ghg-metadata-selectors';
 
 const AGRICULTURE_COLOR = '#0677B3';
-const AGGREGATED_SECTORS = ['Total excluding LUCF', 'Total including LUCF'];
+const TOTAL_EMISSION = 'Total excluding LUCF';
+const INCLUDED_SECTORS = [
+  'Agriculture',
+  'Energy',
+  'Industrial Processes',
+  'Waste' /** , 'Land-Use Change and Forestry' */
+];
 
 const getGhgEmissionsData = state =>
   (state.ghgEmissions && state.ghgEmissions.data) || null;
@@ -32,35 +38,38 @@ export const getPieChartData = createSelector(
   [getGhgEmissionsDataByLocation],
   data => {
     if (!data || !data.length) return null;
-    const sectorsLastYearEmission = data
-      .map(({ emissions, sector, location }) => {
-        const lastYearEmission = emissions[emissions.length - 1];
-        return { sector, location, ...lastYearEmission };
-      })
-      .filter(
-        ({ sector, value }) => value > 0 && !AGGREGATED_SECTORS.includes(sector)
-      ); // filter for negative emission for Forestry sector and total LUCF sectors
+    const lastYearEmissions = data.map(({ emissions, sector, location }) => {
+      const lastYearEmission = emissions[emissions.length - 1];
+      return { sector, location, ...lastYearEmission };
+    });
 
-    if (!sectorsLastYearEmission) return null;
-    const totalEmission = sectorsLastYearEmission.reduce(
-      (acc, emission) => acc + emission.value,
-      0
-    );
+    const totalLastYearEmission = lastYearEmissions.find(
+      ({ sector }) => sector && sector === TOTAL_EMISSION
+    ).value;
 
-    const sectorEmissions = sectorsLastYearEmission.map(
-      ({ sector, value }) => ({
-        name: getColumnValue(sector).toLowerCase(),
-        value,
-        sector,
-        formattedValue: `${format('.2s')(value)}`,
-        formattedPercentage: `${format('.2f')(value * 100 / totalEmission)}%`,
-        percentageValue: value * 100 / totalEmission
-      })
-    );
+    const filteredEmissions = lastYearEmissions.filter(
+      ({ sector, value }) => value > 0 && INCLUDED_SECTORS.includes(sector)
+    ); // filter for negative emission for Forestry sector and total LUCF sectors
+
+    if (!filteredEmissions) return null;
+
+    const sectorEmissions = filteredEmissions.map(({ sector, value }) => ({
+      name: getColumnValue(sector).toLowerCase(),
+      value,
+      sector,
+      formattedValue: `${format('.2s')(value)}`,
+      formattedPercentage: `${format('.2f')(
+        value * 100 / totalLastYearEmission
+      )}%`,
+      percentageValue: value * 100 / totalLastYearEmission
+    }));
 
     const agricultureRow = sectorEmissions.find(
       ({ name }) => name === 'agriculture'
     );
+
+    if (!agricultureRow) return null;
+
     const sectorsEmissionsData = agricultureRow
       ? [
         agricultureRow,
@@ -69,9 +78,8 @@ export const getPieChartData = createSelector(
       : sectorEmissions;
 
     return {
-      year: sectorsLastYearEmission[0] && sectorsLastYearEmission[0].year,
-      location:
-        sectorsLastYearEmission[0] && sectorsLastYearEmission[0].location,
+      year: filteredEmissions[0] && filteredEmissions[0].year,
+      location: filteredEmissions[0] && filteredEmissions[0].location,
       emissionValue: agricultureRow && agricultureRow.formattedValue,
       emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
       data: sectorsEmissionsData

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -67,7 +67,18 @@ export const DEFAULT_EMISSIONS_SELECTIONS = {
   }
 };
 
-export const TOP_EMITTERS = ['CHN', 'USA', 'EU28', 'IND', 'RUS', 'JPN', 'BRA', 'IDN', 'CAN', 'MEX'];
+export const TOP_EMITTERS = [
+  'CHN',
+  'USA',
+  'EU28',
+  'IND',
+  'RUS',
+  'JPN',
+  'BRA',
+  'IDN',
+  'CAN',
+  'MEX'
+];
 
 export const CHART_COLORS = [
   '#00B4D2',
@@ -102,22 +113,14 @@ export const CHART_COLORS_EXTENDED = [
 ];
 
 export const OTHER_COLOR = '#b1b1b1';
+
 export const GREY_CHART_COLORS = [
   '#68696B',
-  '#757678',
-  '#808184',
   '#818285',
-  '#8e8f91',
-  '#999B9E',
-  '#959697',
-  '#a4a5a6',
-  '#ACACB7',
-  '#b3b4b5',
-  '#c2c3c3',
-  '#d1d2d2',
-  '#e0e1e1',
-  '#E3E5EA',
-  '#eff0f0'
+  '#999B9D',
+  '#ACAEB8',
+  '#C3C4CD',
+  '#E2E4EA'
 ];
 
 export const COUNTRY_COMPARE_COLORS = ['#113750', '#00B4D2', '#D2187C'];
@@ -247,7 +250,12 @@ export const USERS_PROFESIONAL_SECTORS = [
 
 export const ALL_SELECTED = 'All Selected';
 export const ALL_SELECTED_OPTION = { label: ALL_SELECTED, value: ALL_SELECTED };
-export const NO_ALL_SELECTED_COLUMNS = ['breakBy', 'chartType', 'sources', 'regions'];
+export const NO_ALL_SELECTED_COLUMNS = [
+  'breakBy',
+  'chartType',
+  'sources',
+  'regions'
+];
 
 export const METRIC_OPTIONS = {
   ABSOLUTE_VALUE: { label: 'Absolute value', value: 'ABSOLUTE_VALUE' },

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
@@ -35,7 +35,7 @@ class SectorsAgriculture extends PureComponent {
             <div className="grid-column-item">
               <Intro
                 title="Agriculture"
-                description={`Agriculture is the second-largest contributor to global greenhouse gas emissions ${percentageEmissionText}. This page shows you where emissions come from (including direct and indirect emissions), what actions countries have proposed in their NDCs and resources for more action.`}
+                description={`Agriculture is the second-largest contributor to global greenhouse gas emissions${percentageEmissionText}. This page shows you where emissions come from (including direct and indirect emissions), what actions countries have proposed in their NDCs and resources for more action.`}
               />
             </div>
           </div>

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
@@ -20,8 +20,14 @@ class SectorsAgriculture extends PureComponent {
       anchorLinks,
       setActiveSection,
       location,
-      history
+      history,
+      percentageEmission
     } = this.props;
+    const percentageEmissionText =
+      (percentageEmission &&
+        `, producing ${percentageEmission} of all emissions`) ||
+      '';
+
     return (
       <div>
         <Header route={route}>
@@ -29,9 +35,7 @@ class SectorsAgriculture extends PureComponent {
             <div className="grid-column-item">
               <Intro
                 title="Agriculture"
-                description={
-                  'Agriculture is the second-largest contributor to global greenhouse gas emissions. This page shows you where emissions come from (including direct and indirect emissions), what actions countries have proposed in their NDCs and resources for more action.'
-                }
+                description={`Agriculture is the second-largest contributor to global greenhouse gas emissions ${percentageEmissionText}. This page shows you where emissions come from (including direct and indirect emissions), what actions countries have proposed in their NDCs and resources for more action.`}
               />
             </div>
           </div>
@@ -73,7 +77,12 @@ SectorsAgriculture.propTypes = {
   location: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   anchorLinks: PropTypes.array.isRequired,
-  setActiveSection: PropTypes.func.isRequired
+  setActiveSection: PropTypes.func.isRequired,
+  percentageEmission: PropTypes.string
+};
+
+SectorsAgriculture.defaultProps = {
+  percentageEmission: ''
 };
 
 export default SectorsAgriculture;

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture.js
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture.js
@@ -1,7 +1,10 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { actions } from 'components/anchor-nav';
-import { getAnchorLinks } from './sectors-agricuture-selectors';
+import {
+  getAnchorLinks,
+  getWorldwidePercentageAgricultureEmission
+} from './sectors-agricuture-selectors';
 import Component from './sectors-agriculture-component';
 
 const mapStateToProps = (state, { route, location, history }) => {
@@ -9,7 +12,8 @@ const mapStateToProps = (state, { route, location, history }) => {
   return {
     location,
     history,
-    anchorLinks: getAnchorLinks(routeData)
+    anchorLinks: getAnchorLinks(routeData),
+    percentageEmission: getWorldwidePercentageAgricultureEmission(state)
   };
 };
 

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
@@ -1,6 +1,13 @@
 import { createSelector } from 'reselect';
+import { format } from 'd3-format';
 
 const getSections = routeData => routeData.route.sections || null;
+
+const getGhgEmissionsData = state =>
+  (state.emissions && state.emissions.data) || null;
+
+const AGRICULTURE_SECTOR = 'Agriculture';
+const TOTAL_SECTOR = 'Total excluding LUCF';
 
 export const getAnchorLinks = createSelector([getSections], sections =>
   sections.filter(route => route.anchor).map(route => ({
@@ -11,6 +18,43 @@ export const getAnchorLinks = createSelector([getSections], sections =>
   }))
 );
 
-export default {
-  getAnchorLinks
-};
+const getWorldwideGhgEmissionsData = createSelector(
+  [getGhgEmissionsData],
+  data => {
+    if (!data || !data.length) return null;
+    const emissionsData = data.filter(({ iso_code3 }) => iso_code3 === 'WORLD');
+    return emissionsData;
+  }
+);
+
+export const getWorldwidePercentageAgricultureEmission = createSelector(
+  [getWorldwideGhgEmissionsData],
+  data => {
+    if (!data || !data.length) return null;
+    const agricultureEmissions = data.find(
+      ({ sector }) => sector && sector === AGRICULTURE_SECTOR
+    );
+    const totalEmission = data.find(
+      ({ sector }) => sector && sector === TOTAL_SECTOR
+    );
+
+    if (
+      !agricultureEmissions ||
+      !agricultureEmissions.emissions ||
+      !totalEmission ||
+      !totalEmission.emissions
+    ) { return null; }
+    const { emissions } = agricultureEmissions;
+    const lastYear = Math.max(...emissions.map(({ year }) => year));
+    const lastYearAgricultureEmission = emissions.find(
+      ({ year }) => year === lastYear
+    );
+    const lastYearTotalEmission = totalEmission.emissions.find(
+      ({ year }) => year === lastYear
+    );
+
+    return `${format('.2f')(
+      lastYearAgricultureEmission.value * 100 / lastYearTotalEmission.value
+    )}%`;
+  }
+);

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
@@ -7,7 +7,7 @@ const getGhgEmissionsData = state =>
   (state.emissions && state.emissions.data) || null;
 
 const AGRICULTURE_SECTOR = 'Agriculture';
-const TOTAL_SECTOR = 'Total including LUCF';
+const TOTAL_SECTOR = 'Total excluding LUCF';
 
 export const getAnchorLinks = createSelector([getSections], sections =>
   sections.filter(route => route.anchor).map(route => ({

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
@@ -7,7 +7,7 @@ const getGhgEmissionsData = state =>
   (state.emissions && state.emissions.data) || null;
 
 const AGRICULTURE_SECTOR = 'Agriculture';
-const TOTAL_SECTOR = 'Total excluding LUCF';
+const TOTAL_SECTOR = 'Total including LUCF';
 
 export const getAnchorLinks = createSelector([getSections], sections =>
   sections.filter(route => route.anchor).map(route => ({
@@ -43,7 +43,9 @@ export const getWorldwidePercentageAgricultureEmission = createSelector(
       !agricultureEmissions.emissions ||
       !totalEmission ||
       !totalEmission.emissions
-    ) { return null; }
+    ) {
+      return null;
+    }
     const { emissions } = agricultureEmissions;
     const lastYear = Math.max(...emissions.map(({ year }) => year));
     const lastYearAgricultureEmission = emissions.find(


### PR DESCRIPTION
This PR adds a percentage value of agriculture emission to the agriculture description text:
![Screenshot from 2019-04-01 14 57 11](https://user-images.githubusercontent.com/15097138/55333085-7b2ac300-548e-11e9-8851-2605e434539f.png)
 and solves a problem with an incorrect calculation of values in emissions pie chart (before the total value was a sum of values for all sectors, now it is value from `Total excluding LUCF`)
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/382166986#comment_689524174) | [PIVOTAL](https://www.pivotaltracker.com/story/show/164824979)

**IMPORTANT:** Now in the piechart I'm showing only data for sectors  'Agriculture', 'Energy', 'Industrial Processes', and 'Waste' because after adding all those values together they are equal with the `Total excluding LUCF` value. Also in my calculation, I used `Total excluding LUCF` instead of `Total including LUCF` value because it's not possible to show negative value on the pie chart, and we have to be consistent between percentage value in agriculture section description and pie chart. Please check if this makes sense to you.