### PR TITLE
Set filters menu as sticky menu for explore by country section

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country-styles.scss
@@ -8,64 +8,23 @@
   margin-bottom: $gutter-padding;
 }
 
-.intro {
-  @include columns((6 , 5));
-
-  margin-bottom: 40px;
-
-  > *:last-child {
-    @include column-offset(1, $gutters: true);
-  }
-}
-
-.header {
-  color: $theme-color;
-  font-weight: $font-weight;
-  margin-bottom: 12px;
-}
-
-.introText {
-  color: $theme-color;
-}
-
-.switchWrapper {
-  display: flex;
-  justify-content: flex-end;
-  height: 40px;
-}
-
-.switchOption {
-  display: flex;
-  align-items: center;
-  font-weight: $font-weight-bold;
-  font-size: $font-size-xs;
-  line-height: $font-size-sm;
-  letter-spacing: 1px;
-}
-
-.switchSelected {
-  background-color: $theme-color;
-}
-
 .actionsContainer {
   align-items: flex-end;
+  background-color: $white;
   margin-bottom: 20px;
+  position: sticky;
+  top: 108px;
+  z-index: 1;
 }
 
 .filtersGroup {
   @include columns(12);
 
+  padding-top: 16px;
+
   > * {
     @include xy-gutters(30px, $gutter-position: 'bottom');
   }
-}
-
-.dataContainer {
-  display: flex;
-  flex-direction: column;
-  height: 45px;
-  padding-top: 5px;
-  justify-content: space-around;
 }
 
 .btnGroup {
@@ -77,6 +36,8 @@
 @media #{$tablet-portrait} {
   .filtersGroup {
     @include columns((6,6));
+
+    padding-top: 20px;
   }
 }
 
@@ -91,5 +52,11 @@
 
   .actionsContainer {
     @include columns((10, 2));
+  }
+}
+
+@media #{$desktop} {
+  .actionsContainer {
+    top: 49px;
   }
 }

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
@@ -94,6 +94,8 @@
 .filtersGroup {
   @include columns(12);
 
+  margin-top: 20px;
+
   > * {
     @include xy-gutters(30px, $gutter-position: 'bottom');
   }

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-styles.scss
@@ -9,7 +9,7 @@
 }
 
 .intro {
-  margin-bottom: 40px;
+  margin-bottom: 20px;
 
   > * {
     margin-bottom: 20px;


### PR DESCRIPTION
This PR makes a filters menu `sticky` and removes unused CSS classes
[PIVOTAL](https://www.pivotaltracker.com/story/show/165120435) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/384456914)

![e8ymx-kh91t](https://user-images.githubusercontent.com/15097138/55720980-12959600-59fa-11e9-8f4b-4395bc270b30.gif)
