### PR TITLE
Fix/data explorer filter sector and gases for selected data source

### DIFF
--- a/app/controllers/api/v1/data/historical_emissions/data_sources_controller.rb
+++ b/app/controllers/api/v1/data/historical_emissions/data_sources_controller.rb
@@ -4,10 +4,16 @@ module Api
       module HistoricalEmissions
         class DataSourcesController < ApiController
           def index
-            render json: ::HistoricalEmissions::DataSource.all,
+            render json: data_sources,
                    adapter: :json,
                    each_serializer: Api::V1::Data::HistoricalEmissions::DataSourceSerializer,
                    root: :data
+          end
+
+          private
+
+          def data_sources
+            Api::V1::Data::HistoricalEmissions::DataSourceWithRelatedRecordsSearch.new.call
           end
         end
       end

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Dropdown from 'components/dropdown';
-import { MultiLevelDropdown } from 'cw-components';
-import MultiSelect from 'components/multiselect';
+import { MultiLevelDropdown, Multiselect } from 'cw-components';
 import { deburrCapitalize } from 'app/utils';
 import {
   MULTIPLE_LEVEL_SECTION_FIELDS,
@@ -81,9 +80,6 @@ class DataExplorerFilters extends PureComponent {
     const fieldFilters = filters.map(field => {
       if (multipleSection(field)) {
         const isMulti = multipleSection(field).multiselect;
-        const valueProp = {};
-        const values = selectedOptions ? selectedOptions[field] : null;
-        valueProp[`value${isMulti ? 's' : ''}`] = isMulti ? values || [] : values && values[0];
         const getSelectedValue = option => {
           if (isArray(option)) {
             return option.length > 0 && last(option).value === ALL_SELECTED
@@ -102,7 +98,7 @@ class DataExplorerFilters extends PureComponent {
             label={deburrCapitalize(field)}
             placeholder={`Filter by ${deburrCapitalize(field)}`}
             options={getOptions(filterOptions, field)}
-            {...valueProp}
+            values={(selectedOptions && selectedOptions[field]) || []}
             disabled={isDisabled(field)}
             onChange={option => {
               handleFiltersChange({ [field]: getSelectedValue(option) });
@@ -116,7 +112,7 @@ class DataExplorerFilters extends PureComponent {
         const fieldInfo = GROUPED_OR_MULTI_SELECT_FIELDS[section].find(f => f.key === field);
         const label = fieldInfo.label || fieldInfo.key;
         return (
-          <MultiSelect
+          <Multiselect
             key={fieldInfo.key}
             label={deburrCapitalize(label)}
             selectedLabel={activeFilterLabel[field]}
@@ -125,7 +121,7 @@ class DataExplorerFilters extends PureComponent {
             options={getOptions(filterOptions, field, true)}
             groups={fieldInfo.groups}
             disabled={isDisabled(field)}
-            onMultiValueChange={selected => {
+            onValueChange={selected => {
               handleFiltersChange({ [field]: selected });
               handleChangeSelectorAnalytics();
             }}

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -139,13 +139,7 @@ export const DATA_EXPLORER_DEPENDENCIES = {
     scenarios: ['models', 'locations'],
     categories: ['scenarios', 'models', 'locations'],
     subcategories: ['categories', 'scenarios', 'models', 'locations'],
-    indicators: [
-      'subcategories',
-      'categories',
-      'scenarios',
-      'models',
-      'locations'
-    ]
+    indicators: ['subcategories', 'categories', 'scenarios', 'models', 'locations']
   }
 };
 
@@ -247,9 +241,16 @@ export const FILTERED_FIELDS = {
   'historical-emissions': {
     sectors: [
       {
-        parent: 'source',
-        parentId: 'dataSourceId',
-        id: 'data_source_id'
+        parent: 'data-sources',
+        parentId: 'sector_ids',
+        id: 'id'
+      }
+    ],
+    gases: [
+      {
+        parent: 'data-sources',
+        parentId: 'gas_ids',
+        id: 'id'
       }
     ]
   },

--- a/app/serializers/api/v1/data/historical_emissions/data_source_serializer.rb
+++ b/app/serializers/api/v1/data/historical_emissions/data_source_serializer.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     module Data
       module HistoricalEmissions
-        class DataSourceSerializer < ActiveModel::Serializer
-          attributes :id, :name, :display_name
+        class DataSourceSerializer < HashSerializer
+          attributes :id, :name, :display_name, :location_ids, :sector_ids, :gas_ids
         end
       end
     end

--- a/app/serializers/hash_serializer.rb
+++ b/app/serializers/hash_serializer.rb
@@ -1,0 +1,5 @@
+class HashSerializer < ActiveModel::Serializer
+  def read_attribute_for_serialization(attr)
+    object[attr]
+  end
+end

--- a/app/services/api/v1/data/historical_emissions/data_source_with_related_records_search.rb
+++ b/app/services/api/v1/data/historical_emissions/data_source_with_related_records_search.rb
@@ -1,0 +1,39 @@
+module Api
+  module V1
+    module Data
+      module HistoricalEmissions
+        class DataSourceWithRelatedRecordsSearch
+          def call
+            data_sources.map do |source|
+              source.
+                slice(:id, :name, :display_name, :metadata_dataset).
+                merge(related_records[source.id] || {})
+            end
+          end
+
+          private
+
+          def data_sources
+            ::HistoricalEmissions::DataSource.all
+          end
+
+          def related_records
+            @related_records ||= ::HistoricalEmissions::Record.
+              select(
+                <<-SQL
+              data_source_id,
+              ARRAY_AGG(DISTINCT sector_id) AS sector_ids,
+              ARRAY_AGG(DISTINCT gas_id) AS gas_ids,
+              ARRAY_AGG(DISTINCT location_id) AS location_ids
+            SQL
+              ).
+              group('data_source_id').
+              as_json.
+              map { |h| [h['data_source_id'], h.symbolize_keys.except(:id)] }.
+              to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -91,7 +91,11 @@ Link: </api/v1/data/historical_emissions/data_sources>; rel="meta data_sources",
    "data":[
       {
          "id":number,
-         "name":"string e.g. CAIT"
+         "name":"string e.g. CAIT",
+         "display_name":"string e.g. CAIT",
+         "gas_ids":[1,2,3],
+         "sector_ids":[1,2,3],
+         "location_ids":[1,2,3]
       }
    ]
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.11",
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.48.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.49.1",
     "css-loader": "0.28.7",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,9 +2952,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.48.0":
-  version "1.48.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6cf608ffdcfbd9b364e3c6d52fc17dc36b83d061"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.49.1":
+  version "1.49.1"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/5778efce0ba9758aff8a06f7e83f5ebc4889807d"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
Data explorer was lacking the frontend filter of sectors and gases for the selected data source.

As the data explorer is using its own endpoints and I didn't want to mess with the logic of filtering filters which was already there or use other endpoints to get related gases and sources for the data source, so I decided to add related records ids (locations, gases, sectors) to data source data explorer metadata endpoint `api/v1/data/historical_emissions/data_sources`.

[Pivotal](https://www.pivotaltracker.com/story/show/165343045)