### PR TITLE
Scroll to top after click on country on NDC map

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map.js
@@ -79,12 +79,15 @@ class NDCMapContainer extends PureComponent {
     const { isoCountries } = this.props;
     const iso = geography.properties && geography.properties.id;
     if (iso && isCountryIncluded(isoCountries, iso)) {
-      this.props.history.push(`/ndcs/country/${iso}/sectoral-information`);
+      this.props.history.push(
+        `/ndcs/country/${iso}/sectoral-information?section=sectoral_mitigation_plans`
+      );
       handleAnalytics(
         'Agriculture Profile - Countries Actions',
         'Use map to find country',
         geography.properties.name
       );
+      window.scrollTo(0, 0);
     }
   };
 


### PR DESCRIPTION
This PR fixes page behavior after clicking on a country on NDC actions; now a click opens `Sectoral Mitigation Plans` section and scroll page to the top.
[PIVOTAL](https://www.pivotaltracker.com/story/show/165347330) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/385208201)