### PR TITLE
Pass category and sector params to data explorer link in NDCS actions section

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-component.jsx
@@ -11,7 +11,7 @@ import Icon from 'components/icon';
 import accordionArrow from 'assets/icons/accordion-arrow.svg';
 import Loading from 'components/loading';
 import ModalMetadata from 'components/modal-metadata';
-
+import DataExplorerFilters from 'providers/data-explorer-provider';
 import tooltipTheme from 'styles/themes/map-tooltip/map-tooltip.scss';
 import styles from './ndcs-map-styles.scss';
 
@@ -115,6 +115,7 @@ const NDCMap = ({
           />
         )}
         <ModalMetadata />
+        <DataExplorerFilters section={'ndc-content'} />
       </div>
     )}
   </TabletLandscape>

--- a/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map.js
@@ -28,14 +28,15 @@ const actions = { ...fetchActions, ...modalActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data, loading } = state.ndcs;
-  const { countries } = state;
+  const { countries, dataExplorer } = state;
   const search = qs.parse(location.search);
   const ndcsWithSelection = {
     ...data,
     countries: countries.data,
     categorySelected: search.category,
     indicatorSelected: search.indicator,
-    search
+    search,
+    dataExplorer
   };
   return {
     loading,

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -170,7 +170,14 @@ export const DATA_EXPLORER_TO_MODULES_PARAMS = {
       idLabel: 'number'
     }
   },
-  'ndc-content': {},
+  'ndc-content': {
+    sectors: {
+      key: 'sectors'
+    },
+    categories: {
+      key: 'category'
+    }
+  },
   'emission-pathways': {
     locations: {
       key: 'currentLocation',


### PR DESCRIPTION
This PR updates params of the link to the data explorer page (download link in `Agriculture/Countries’ Actions in their NDCs`)
[PIVOTAL](https://www.pivotaltracker.com/story/show/165347377) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/385208850#comment_692470717)

~~**IMPORTANT:** I found a small issue, after redirection from `agriculture page` to the `data explorer`, query params for `sector` and `category` are updating correctly, also the data, but dropdown filters are empty, as default. It looks like data explorer issue, I'll fix it in another PR.~~
Tomek solved it [HERE](https://github.com/Vizzuality/climate-watch/pull/824)