### PR TITLE
Remove 'htmlFor' attribute from checkbox-input-component label

### DIFF
--- a/app/javascript/app/components/check-input/check-input-component.jsx
+++ b/app/javascript/app/components/check-input/check-input-component.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-for */
 import React from 'react';
 import { themr } from 'react-css-themr';
 import PropTypes from 'prop-types';
@@ -14,7 +15,6 @@ const CheckInputComponent = props => {
     theme,
     toggleFirst,
     disabled,
-    id,
     errorText
   } = props;
   return (
@@ -24,14 +24,12 @@ const CheckInputComponent = props => {
           [styles.toggleFirst]: toggleFirst,
           [styles.disabled]: disabled
         })}
-        htmlFor={id}
       >
         <input
           className={theme.checkbox}
           type="checkbox"
           checked={!disabled && checked}
           onChange={onChange}
-          id={id}
           disabled={disabled}
         />
         <span className={theme.label}>{label}</span>
@@ -55,7 +53,6 @@ CheckInputComponent.propTypes = {
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   toggleFirst: PropTypes.bool,
-  id: PropTypes.string,
   theme: PropTypes.object
 };
 


### PR DESCRIPTION
This PR fixes the checkobox-input component in data explorer modal. The issue was connected with `htmlFor` property of label tag, after removing this attribute problem has been solved.
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/383868040) | [PIVOTAL](https://www.pivotaltracker.com/story/show/165120547)