### PR TITLE
Rename option text GDP to Absolute in Countries Context

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-selectors.js
@@ -11,7 +11,7 @@ import {
 const TRADE_IMPORT = 'Import';
 const TRADE_EXPORT = 'Export';
 
-const GDP_FILTER = 'GDP';
+const TOTAL_FILTER = 'total';
 const PER_CAPITA_FILTER = 'per_capita';
 
 export const CATEGORY_KEY = 'meatCategory';
@@ -101,7 +101,7 @@ const getCategoriesOptions = createSelector(
 );
 
 const getBreakByOptions = createSelector(() => [
-  { label: 'GDP', value: GDP_FILTER },
+  { label: 'Absolute', value: TOTAL_FILTER },
   { label: 'Per capita', value: PER_CAPITA_FILTER }
 ]);
 
@@ -119,7 +119,7 @@ const getDefaults = createSelector(
     if (!categoriesOptions || !breakByOptions || !dataOptions) return null;
 
     return {
-      [BREAK_BY_KEY]: breakByOptions.find(o => o.value === GDP_FILTER),
+      [BREAK_BY_KEY]: breakByOptions.find(o => o.value === TOTAL_FILTER),
       [CATEGORY_KEY]: categoriesOptions && categoriesOptions[0],
       [COUNTRIES_KEY]: dataOptions.filter(o => o.value !== 'others')
     };


### PR DESCRIPTION
This PR changes label text of the one of options in `Countries' Context/ Production, Consumption and Trade chart / Break by filter` from GDP to Absolute.
[PIVOTAL](https://www.pivotaltracker.com/story/show/165530606) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/384102042)

![Screenshot from 2019-04-23 13 03 11](https://user-images.githubusercontent.com/15097138/56579490-2f1ff980-65c8-11e9-87a8-ff6360f7ab15.png)