### PR TITLE
Feature/ghg module download chart csv

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -6,7 +6,7 @@ $min-height: 500px;
   @include columns((12, 12));
 
   @media #{$tablet-landscape} {
-    @include columns((9.9, 2));
+    @include columns((9.4, 2.5));
   }
 
   .colEnd {

--- a/app/javascript/app/utils/csv.js
+++ b/app/javascript/app/utils/csv.js
@@ -1,0 +1,25 @@
+export function encodeAsCSVContent(data, sortOrder) {
+  let csvContent = 'data:text/csv;charset=utf-8,';
+
+  const escapeForCSV = value => (value && String(value).includes(',') ? `"${value}"` : value);
+
+  const headers = Object.keys(data[0]).sort(sortOrder);
+  const rows = [headers.join(',')];
+
+  data.forEach(row => {
+    rows.push(headers.map(header => escapeForCSV(row[header])).join(','));
+  });
+
+  csvContent += rows.join('\r\n');
+  return encodeURI(csvContent);
+}
+
+export function invokeCSVDownload(csvContentEncoded) {
+  const link = document.createElement('a');
+  link.setAttribute('href', csvContentEncoded);
+  link.setAttribute('download', 'ghg-emissions.csv');
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link); // Required for FF
+  link.click();
+  document.body.removeChild(link);
+}

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -207,20 +207,31 @@ export function precentageTwoPlacesRound(percentage) {
   return Math.round(percentage * 10) / 10;
 }
 
+export function orderByColumns(columnOrder) {
+  const indexOf = col => (columnOrder.indexOf(col) > -1 ? columnOrder.indexOf(col) : Infinity);
+  return (a, b) => indexOf(a) - indexOf(b);
+}
+
+export function stripHTML(text) {
+  return text.replace(/<(?:.|\n)*?>/gm, '');
+}
+
 export default {
   arrayToSentence,
   compareIndexByKey,
   deburrUpper,
-  isCountryIncluded,
-  importAllImagesFromFolder,
-  truncateDecimals,
-  isMicrosoftBrowser,
-  toStartCase,
-  wordWrap,
-  parseLinkHeader,
-  replaceAll,
   findEqual,
+  importAllImagesFromFolder,
   isANumber,
+  isCountryIncluded,
+  isMicrosoftBrowser,
   noEmptyValues,
-  precentageTwoPlacesRound
+  orderByColumns,
+  parseLinkHeader,
+  precentageTwoPlacesRound,
+  replaceAll,
+  stripHTML,
+  toStartCase,
+  truncateDecimals,
+  wordWrap
 };

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -42,7 +42,7 @@ module.exports = merge(sharedConfig, {
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
     watchOptions: {
-      ignored: /node_modules/
+      ignored: /node_modules([\\]+|\/)+(?!cw-components)/
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.11",
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.49.1",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.49.2",
     "css-loader": "0.28.7",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,9 +2952,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.49.1":
-  version "1.49.1"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/5778efce0ba9758aff8a06f7e83f5ebc4889807d"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.49.2":
+  version "1.49.2"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/d1a827df67ff63892d157a5a0148e02c1c46f1c0"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
- Download GHG chart's table data as CSV [story](https://www.pivotaltracker.com/story/show/165343036)
- updating cw-components to not show the Energy sector as a parent sector without any children for PIK datasource (Data Explorer)