### PR TITLE
Agriculture: hook up metadata into button groups info buttons

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country-component.jsx
@@ -11,89 +11,95 @@ import MeatData from './meat-data';
 
 import styles from './context-by-country-styles.scss';
 
-const buttonGroupConfig = [
-  {
-    type: 'info',
-    onClick: () => {
-      // TODO: Implement info button click
-    }
-  },
-  {
-    type: 'share',
-    analyticsGraphName: 'Country/Ghg-emissions',
-    positionRight: true
-  },
-  {
-    type: 'download',
-    section: 'ghg-emissions'
-  },
-  {
-    type: 'addToUser'
-  }
-];
-
 const ContextByCountryComponent = ({
   cards,
   countries,
   selectedCountry,
   years,
   selectedYear,
-  // handleInfoBtnClick,
+  handleInfoClick,
   updateCountryFilter,
   updateCountryYearFilter
-}) => (
-  <TabletLandscape>
-    {isTablet => (
-      <React.Fragment>
-        <div className={styles.actionsContainer}>
-          <div className={styles.filtersGroup}>
-            {countries && (
-              <Dropdown
-                label={'Country'}
-                value={selectedCountry}
-                options={countries}
-                onValueChange={updateCountryFilter}
-                hideResetButton
-              />
+}) => {
+  const buttonGroupConfig = [
+    {
+      type: 'info',
+      onClick: handleInfoClick
+    },
+    {
+      type: 'share',
+      analyticsGraphName: 'Country/Ghg-emissions',
+      positionRight: true
+    },
+    {
+      type: 'download',
+      section: 'ghg-emissions'
+    },
+    {
+      type: 'addToUser'
+    }
+  ];
+
+  return (
+    <TabletLandscape>
+      {isTablet => (
+        <React.Fragment>
+          <div className={styles.actionsContainer}>
+            <div className={styles.filtersGroup}>
+              {countries && (
+                <Dropdown
+                  label={'Country'}
+                  value={selectedCountry}
+                  options={countries}
+                  onValueChange={updateCountryFilter}
+                  hideResetButton
+                />
+              )}
+              {
+                !isEmpty(years) &&
+                selectedYear && (
+                  <Dropdown
+                    label={'Year'}
+                    value={selectedYear}
+                    options={years}
+                    onValueChange={updateCountryYearFilter}
+                    hideResetButton
+                  />
+                )
+              }
+            </div>
+            {isTablet && (
+              <ButtonGroup className={styles.btnGroup} buttonsConfig={buttonGroupConfig} />
             )}
-            {!isEmpty(years) &&
-             selectedYear && (
-               <Dropdown
-                 label={'Year'}
-                 value={selectedYear}
-                 options={years}
-                 onValueChange={updateCountryYearFilter}
-                 hideResetButton
-               />
-             )}
           </div>
-          {isTablet && (
+          {!isEmpty(years) ? (
+            <div>
+              {
+                selectedCountry &&
+                selectedYear && (
+                  <React.Fragment>
+                    <IndicatorCards selectedYear={selectedYear} cards={cards} />
+                    <LandArea />
+                    <MeatData />
+                  </React.Fragment>
+                )
+              }
+            </div>
+          ) : (
+            <NoContent
+              message={`No data for ${selectedCountry.label}, please select another country`}
+              className={styles.noContent}
+              minHeight={300}
+            />
+          )}
+          {!isTablet && (
             <ButtonGroup className={styles.btnGroup} buttonsConfig={buttonGroupConfig} />
           )}
-        </div>
-        {!isEmpty(years) ? (
-          <div>
-            {selectedCountry &&
-             selectedYear && (
-               <React.Fragment>
-                 <IndicatorCards selectedYear={selectedYear} cards={cards} />
-                 <LandArea />
-                 <MeatData />
-               </React.Fragment>
-            )}
-          </div>
-        ) : (
-          <NoContent
-            message={`No data for ${selectedCountry.label}, please select another country`}
-            className={styles.noContent}
-            minHeight={300}
-          />
-        )}
-        {!isTablet && <ButtonGroup className={styles.btnGroup} buttonsConfig={buttonGroupConfig} />}
-      </React.Fragment>
-    )}
-  </TabletLandscape>
-);
+        </React.Fragment>
+      )}
+    </TabletLandscape>
+  );
+};
 
 ContextByCountryComponent.propTypes = {
   countries: PropTypes.arrayOf(PropTypes.shape({})),
@@ -108,8 +114,8 @@ ContextByCountryComponent.propTypes = {
   }),
   cards: PropTypes.arrayOf(PropTypes.shape({})),
   updateCountryYearFilter: PropTypes.func.isRequired,
-  updateCountryFilter: PropTypes.func.isRequired
-  // handleInfoBtnClick: PropTypes.func.isRequired
+  updateCountryFilter: PropTypes.func.isRequired,
+  handleInfoClick: PropTypes.func.isRequired
 };
 
 export default ContextByCountryComponent;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/context-by-country.js
@@ -1,3 +1,37 @@
+import { PureComponent, createElement } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { actions } from 'components/modal-metadata';
 import Component from './context-by-country-component';
 
-export default Component;
+class ContextByCountryContainer extends PureComponent {
+  handleInfoClick = () => {
+    this.props.setModalMetadata({
+      customTitle: 'Data Sources',
+      category: 'Agriculture - Context by Country',
+      slugs: [
+        'FAOSTAT_3',
+        'FAOSTAT_4',
+        'FAOSTAT_5',
+        'WBD',
+        'OECD-FAO',
+        'Aqueduct_Country_River_Basin_Rankings'
+      ],
+      open: true
+    });
+  };
+
+  render() {
+    return createElement(Component, {
+      ...this.props,
+      handleInfoClick: this.handleInfoClick
+    });
+  }
+}
+
+ContextByCountryContainer.propTypes = {
+  setModalMetadata: PropTypes.func
+};
+
+export default connect(null, actions)(ContextByCountryContainer);

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-component.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { Card, Icon, PieChart } from 'cw-components';
+import { Card, PieChart } from 'cw-components';
 import NoContent from 'components/no-content';
-import infoIcon from 'assets/icons/info';
 
 import styles from './indicator-card-styles.scss';
 
@@ -27,9 +26,7 @@ const renderLegend = (card, year) => {
     </div>
   ) : (
     <NoContent
-      message={
-        card.noDataMessage || `No data for ${card.countryName} in ${year.value}`
-      }
+      message={card.noDataMessage || `No data for ${card.countryName} in ${year.value}`}
       className={styles.noContent}
       minHeight={100}
     />
@@ -78,16 +75,14 @@ const indicatorCardsComponent = ({ cards, selectedYear }) => (
           />
           <div className={styles.cardContent}>
             {card.legend && renderLegend(card, selectedYear)}
-            {card.chartData &&
-            card.chartData.some(l => l.value) && (
+            {
+              card.chartData &&
+              card.chartData.some(l => l.value) && (
                 <div className={styles.chart}>
-                  <PieChart
-                    data={card.chartData}
-                    width={150}
-                    config={card.chartConfig}
-                  />
+                  <PieChart data={card.chartData} width={150} config={card.chartConfig} />
                 </div>
-              )}
+              )
+            }
             {card.rank && (
               <div
                 className={cx(styles.textHtmlWrapper, styles.rank)}
@@ -96,11 +91,6 @@ const indicatorCardsComponent = ({ cards, selectedYear }) => (
             )}
             {card.population && renderPopulationBarChart(card, selectedYear)}
           </div>
-          <Icon
-            icon={infoIcon}
-            theme={{ icon: styles.cardInfoIcon }}
-            onClick={undefined}
-          />
           <div className={styles.yearData}>
             <span>{selectedYear && selectedYear.value}</span> data
           </div>

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/indicator-card/indicator-card-styles.scss
@@ -51,13 +51,6 @@
     }
   }
 
-  .cardInfoIcon {
-    position: absolute;
-    fill: $manatee;
-    right: 30px;
-    top: 20px;
-  }
-
   .cardContent {
     display: flex;
     flex-direction: column;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/land-area/land-area-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/land-area/land-area-component.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LandAreaProvider from 'providers/agriculture-land-area-provider';
-import { SunburstChart, Card, Tag, Icon } from 'cw-components';
-import infoIcon from 'assets/icons/info';
+import { SunburstChart, Card, Tag } from 'cw-components';
 import Tooltip from './tooltip';
 
 import styles from './land-area-styles.scss';
@@ -28,29 +27,18 @@ const LandArea = ({
   chartData,
   chartColors,
   chartConfig,
-  firstLevelLegend,
-  handleInfoBtnClick
+  firstLevelLegend
 }) => (
   <div className={styles.container}>
     {chartData && (
-      <Card
-        key={'Share in Land Area'}
-        title={'Share in Land Area'}
-        theme={cardTheme}
-      >
+      <Card key={'Share in Land Area'} title={'Share in Land Area'} theme={cardTheme}>
         <div className={styles.cardContainer}>
           <div className={styles.header}>
             <div className={styles.title}>
-              Land used for agricultural production often uses a significant
-              portion of total land in a country and expanding agricultural land
-              can drive deforestation and emissions growth. See the total
-              percentage of land used for agriculture.
+              Land used for agricultural production often uses a significant portion of total land
+              in a country and expanding agricultural land can drive deforestation and emissions
+              growth. See the total percentage of land used for agriculture.
             </div>
-            <Icon
-              icon={infoIcon}
-              theme={{ icon: styles.cardInfoIcon }}
-              onClick={handleInfoBtnClick}
-            />
           </div>
           <div className={styles.chartContainer}>
             <div className={styles.legend}>
@@ -68,10 +56,11 @@ const LandArea = ({
                 ))}
             </div>
             <div className={styles.chart}>
-              {chartData &&
-              chartColors &&
-              chartConfig && (
-              <SunburstChart
+              {
+                chartData &&
+                chartColors &&
+                chartConfig && (
+                  <SunburstChart
                     data={chartData}
                     customTooltip={<Tooltip />}
                     width={250}
@@ -79,7 +68,8 @@ const LandArea = ({
                     colors={chartColors}
                     config={chartConfig}
                   />
-                )}
+                )
+              }
             </div>
           </div>
         </div>
@@ -88,12 +78,12 @@ const LandArea = ({
         </div>
       </Card>
     )}
-    {selectedCountry &&
-    selectedYear && (
-    <LandAreaProvider
-          params={{ country: selectedCountry.value, year: selectedYear.value }}
-        />
-      )}
+    {
+      selectedCountry &&
+      selectedYear && (
+        <LandAreaProvider params={{ country: selectedCountry.value, year: selectedYear.value }} />
+      )
+    }
   </div>
 );
 
@@ -103,8 +93,7 @@ LandArea.propTypes = {
   chartData: PropTypes.array,
   chartColors: PropTypes.object,
   chartConfig: PropTypes.object,
-  firstLevelLegend: PropTypes.array,
-  handleInfoBtnClick: PropTypes.func
+  firstLevelLegend: PropTypes.array
 };
 
 export default LandArea;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/land-area/land-area-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/land-area/land-area-styles.scss
@@ -52,10 +52,6 @@
   justify-content: space-between;
 }
 
-.cardInfoIcon {
-  fill: $manatee;
-}
-
 .card {
   height: 100%;
   width: 100%;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-component.jsx
@@ -6,9 +6,8 @@ import MeatProductionProvider from 'providers/agriculture-meat-production-provid
 import MeatWorldProductionProvider from 'providers/agriculture-world-meat-production-provider';
 import MeatTradeProvider from 'providers/agriculture-meat-trade-provider';
 import MeatWorldTradeProvider from 'providers/agriculture-world-meat-trade-provider';
-import { Card, Icon, Chart, Dropdown } from 'cw-components';
+import { Card, Chart, Dropdown } from 'cw-components';
 import NoContent from 'components/no-content';
-import infoIcon from 'assets/icons/info';
 import Tooltip from './tooltip';
 
 import styles from './meat-data-styles.scss';
@@ -33,8 +32,7 @@ const MeatData = ({
   domain,
   updateCategoryFilter,
   updateBreakByFilter,
-  handleLegendChange,
-  handleInfoBtnClick
+  handleLegendChange
 }) => {
   const params = selectedCountry &&
   selectedYear && { country: selectedCountry.value, year: selectedYear.value };
@@ -49,17 +47,11 @@ const MeatData = ({
           <div className={styles.cardContainer}>
             <div className={styles.header}>
               <div className={styles.title}>
-                Beef, sheep, and other animals are resource and greenhouse
-                gas-intensive to produce and have a higher carbon footprint than
-                non-animal foods. However, products are traded globally and
-                consumption in other countries is driving the demand and
+                Beef, sheep, and other animals are resource and greenhouse gas-intensive to produce
+                and have a higher carbon footprint than non-animal foods. However, products are
+                traded globally and consumption in other countries is driving the demand and
                 emissions growth.
               </div>
-              <Icon
-                icon={infoIcon}
-                theme={{ icon: styles.cardInfoIcon }}
-                onClick={handleInfoBtnClick}
-              />
             </div>
             <div className={styles.actionsContainer}>
               {categories && (
@@ -139,7 +131,6 @@ MeatData.propTypes = {
   breakByOptions: PropTypes.array,
   selectedCategory: PropTypes.object,
   selectedBreakBy: PropTypes.object,
-  handleInfoBtnClick: PropTypes.func,
   dataSelected: PropTypes.array,
   dataOptions: PropTypes.array,
   domain: PropTypes.object,

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data-styles.scss
@@ -50,10 +50,6 @@
   margin-bottom: 35px;
 }
 
-.cardInfoIcon {
-  fill: $manatee;
-}
-
 .card {
   height: 100%;
   width: 100%;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-country/meat-data/meat-data.js
@@ -22,15 +22,10 @@ class MeatDataContainer extends PureComponent {
     history.replace(getLocationParamUpdated(location, params));
   };
 
-  handleInfoBtnClick = () => {
-    // TODO: Implement info button click
-  };
-
   updateCategoryFilter = category =>
     this.updateUrlParam({ name: CATEGORY_KEY, value: category.value });
 
-  updateBreakByFilter = option =>
-    this.updateUrlParam({ name: BREAK_BY_KEY, value: option.value });
+  updateBreakByFilter = option => this.updateUrlParam({ name: BREAK_BY_KEY, value: option.value });
 
   handleLegendChange = selected => {
     const others = selected.filter(v => v.value === 'others');

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
@@ -25,27 +25,6 @@ const getTooltip = (country, tooltipTxt, { label }) => (
   </Link>
 );
 
-const buttonGroupConfig = [
-  {
-    type: 'info',
-    onClick: () => {
-      // TODO: Implement info button click
-    }
-  },
-  {
-    type: 'share',
-    analyticsGraphName: 'Country/Ghg-emissions',
-    positionRight: true
-  },
-  {
-    type: 'download',
-    section: 'ghg-emissions'
-  },
-  {
-    type: 'addToUser'
-  }
-];
-
 class ContextByIndicatorComponent extends Component {
   componentDidUpdate() {
     ReactTooltip.rebuild();
@@ -55,9 +34,7 @@ class ContextByIndicatorComponent extends Component {
     const { yearsWithData } = this.props;
     const hasData = yearsWithData.find(y => y.value === option.value);
     return (
-      <div
-        style={{ color: `${hasData ? '#113750' : '#b1b1c1'}`, padding: '10px' }}
-      >
+      <div style={{ color: `${hasData ? '#113750' : '#b1b1c1'}`, padding: '10px' }}>
         {option.label}
       </div>
     );
@@ -77,8 +54,28 @@ class ContextByIndicatorComponent extends Component {
       updateIndicatorFilter,
       updateIndicatorYearFilter,
       handleCountryEnter,
-      handleCountryClick
+      handleCountryClick,
+      handleInfoClick
     } = this.props;
+
+    const buttonGroupConfig = [
+      {
+        type: 'info',
+        onClick: handleInfoClick
+      },
+      {
+        type: 'share',
+        analyticsGraphName: 'Country/Ghg-emissions',
+        positionRight: true
+      },
+      {
+        type: 'download',
+        section: 'ghg-emissions'
+      },
+      {
+        type: 'addToUser'
+      }
+    ];
 
     return (
       <TabletLandscape>
@@ -103,10 +100,7 @@ class ContextByIndicatorComponent extends Component {
                 />
               </div>
               {isTablet && (
-                <ButtonGroup
-                  className={styles.btnGroup}
-                  buttonsConfig={buttonGroupConfig}
-                />
+                <ButtonGroup className={styles.btnGroup} buttonsConfig={buttonGroupConfig} />
               )}
             </div>
             <div className={styles.visualizationsContainer}>
@@ -119,11 +113,7 @@ class ContextByIndicatorComponent extends Component {
                   onCountryFocus={undefined}
                   dragEnable={false}
                 />
-                <MapLegend
-                  mapColors={MAP_COLORS}
-                  buckets={legend}
-                  className={styles.legend}
-                />
+                <MapLegend mapColors={MAP_COLORS} buckets={legend} className={styles.legend} />
               </div>
               {topTenCountries && (
                 <div className={styles.topTenSection}>
@@ -153,10 +143,7 @@ class ContextByIndicatorComponent extends Component {
                           </li>
                         ))}
                       </ul>
-                      <ReactTooltip
-                        className={styles.tooltipContainer}
-                        id="cc-chart-tooltip"
-                      />
+                      <ReactTooltip className={styles.tooltipContainer} id="cc-chart-tooltip" />
                     </React.Fragment>
                   ) : (
                     <div
@@ -167,10 +154,7 @@ class ContextByIndicatorComponent extends Component {
               )}
             </div>
             {!isTablet && (
-              <ButtonGroup
-                className={styles.btnGroup}
-                buttonsConfig={buttonGroupConfig}
-              />
+              <ButtonGroup className={styles.btnGroup} buttonsConfig={buttonGroupConfig} />
             )}
             {countryData && (
               <ReactTooltip
@@ -202,7 +186,8 @@ ContextByIndicatorComponent.propTypes = {
   updateIndicatorFilter: PropTypes.func.isRequired,
   updateIndicatorYearFilter: PropTypes.func.isRequired,
   handleCountryEnter: PropTypes.func.isRequired,
-  handleCountryClick: PropTypes.func.isRequired
+  handleCountryClick: PropTypes.func.isRequired,
+  handleInfoClick: PropTypes.func.isRequired
 };
 
 export default ContextByIndicatorComponent;

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
@@ -7,6 +7,7 @@ import { format } from 'd3-format';
 import { isCountryIncluded } from 'app/utils';
 import { handleAnalytics } from 'utils/analytics';
 import { getLocationParamUpdated } from 'utils/navigation';
+import { actions } from 'components/modal-metadata';
 
 import { countriesContexts } from './context-by-indicator-selectors';
 import Component from './context-by-indicator-component';
@@ -42,10 +43,7 @@ class ContextByIndicatorContainer extends PureComponent {
 
     const countryData = mapData.find(c => c.iso === geometryIdHover);
 
-    return (
-      countryData &&
-      this.indicatorValueFormat(countryData.value, selectedIndicator.unit)
-    );
+    return countryData && this.indicatorValueFormat(countryData.value, selectedIndicator.unit);
   }
 
   handleCountryEnter = geography => {
@@ -71,6 +69,15 @@ class ContextByIndicatorContainer extends PureComponent {
     }
   };
 
+  handleInfoClick = () => {
+    this.props.setModalMetadata({
+      customTitle: 'Data Sources',
+      category: 'Agriculture - Context by Indicator',
+      slugs: ['FAOSTAT_2', 'FAOSTAT_3', 'WBD', 'Aqueduct_Country_River_Basin_Rankings'],
+      open: true
+    });
+  };
+
   updateUrlParam = (params, clear) => {
     const { history, location } = this.props;
     history.push(getLocationParamUpdated(location, params, clear));
@@ -83,6 +90,7 @@ class ContextByIndicatorContainer extends PureComponent {
       tooltipTxt,
       handleCountryEnter: this.handleCountryEnter,
       handleCountryClick: this.handleCountryClick,
+      handleInfoClick: this.handleInfoClick,
       countryData: this.state.country
     });
   }
@@ -94,9 +102,8 @@ ContextByIndicatorContainer.propTypes = {
   isoCountries: PropTypes.arrayOf(PropTypes.string),
   history: PropTypes.shape({}),
   indicatorSelectedYear: PropTypes.shape({}),
-  location: PropTypes.shape({})
+  location: PropTypes.shape({}),
+  setModalMetadata: PropTypes.func
 };
 
-export default withRouter(
-  connect(mapStateToProps, null)(ContextByIndicatorContainer)
-);
+export default withRouter(connect(mapStateToProps, actions)(ContextByIndicatorContainer));

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-context.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-context.js
@@ -26,10 +26,6 @@ class CountriesContextsContainer extends PureComponent {
     history.replace(getLocationParamUpdated(location, params));
   };
 
-  handleInfoBtnClick = () => {
-    // TODO: Implement info button click
-  };
-
   updateCountryFilter = ({ value }) => this.updateUrlParam({ name: 'country', value });
 
   updateCountryYearFilter = ({ value }) => this.updateUrlParam({ name: 'countryYear', value });
@@ -52,7 +48,6 @@ class CountriesContextsContainer extends PureComponent {
         updateIndicatorYearFilter={this.updateIndicatorYearFilter}
         updateIndicatorFilter={this.updateIndicatorFilter}
         handleSwitchClick={this.handleSwitchClick}
-        handleInfoBtnClick={this.handleInfoBtnClick}
       />
     );
   }

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
@@ -62,14 +62,7 @@ class HistoricalEmissionsGraph extends PureComponent {
   };
 
   renderEmissionsChart = () => {
-    const {
-      config,
-      data,
-      domain,
-      filters,
-      filtersSelected,
-      loading
-    } = this.props;
+    const { config, data, domain, filters, filtersSelected, loading } = this.props;
     return (
       <Chart
         className={styles.chartWrapper}
@@ -89,9 +82,12 @@ class HistoricalEmissionsGraph extends PureComponent {
   };
 
   renderExploreButtonGroup = () => {
-    const { exploreEmissionsConfig, emissionsCountry } = this.props;
+    const { exploreEmissionsConfig, emissionsCountry, handleInfoClick } = this.props;
     const buttonGroupConfig = [
-      { type: 'info' },
+      {
+        type: 'info',
+        onClick: handleInfoClick
+      },
       {
         type: 'share',
         shareUrl: `/embed/agriculture-emission?emissionsCountry=${emissionsCountry &&
@@ -139,9 +135,7 @@ class HistoricalEmissionsGraph extends PureComponent {
         <RegionsProvider />
         <CountriesProvider />
         <WbCountryDataProvider />
-        <AgricultureEmissionsProvider
-          isoCode3={emissionsCountry && emissionsCountry.value}
-        />
+        <AgricultureEmissionsProvider isoCode3={emissionsCountry && emissionsCountry.value} />
       </div>
     );
   }
@@ -151,6 +145,7 @@ HistoricalEmissionsGraph.propTypes = {
   handleCountryChange: PropTypes.func,
   handleEmissionTypeChange: PropTypes.func,
   handleMetricTypeChange: PropTypes.func,
+  handleInfoClick: PropTypes.func,
   config: PropTypes.object,
   exploreEmissionsConfig: PropTypes.object.isRequired,
   data: PropTypes.array,
@@ -169,6 +164,7 @@ HistoricalEmissionsGraph.defaultProps = {
   handleCountryChange: () => {},
   handleEmissionTypeChange: () => {},
   handleMetricTypeChange: () => {},
+  handleInfoClick: () => {},
   config: null,
   domain: null,
   data: [],

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph.js
@@ -18,14 +18,19 @@ class HistoricalEmissionsGraph extends PureComponent {
   };
 
   handleEmissionTypeChange = ({ value }) => {
-    this.updateUrlParam([
-      { name: 'emissionType', value },
-      { name: 'filter', value: '' }
-    ]);
+    this.updateUrlParam([{ name: 'emissionType', value }, { name: 'filter', value: '' }]);
   };
 
   handleMetricTypeChange = ({ value }) => {
     this.updateUrlParam([{ name: 'emissionMetric', value }]);
+  };
+
+  handleInfoClick = () => {
+    this.props.setModalMetadata({
+      category: 'Agriculture - Historical Emissions',
+      slugs: 'FAOSTAT_1',
+      open: true
+    });
   };
 
   render() {
@@ -33,14 +38,16 @@ class HistoricalEmissionsGraph extends PureComponent {
       ...this.props,
       handleCountryChange: this.handleCountryChange,
       handleEmissionTypeChange: this.handleEmissionTypeChange,
-      handleMetricTypeChange: this.handleMetricTypeChange
+      handleMetricTypeChange: this.handleMetricTypeChange,
+      handleInfoClick: this.handleInfoClick
     });
   }
 }
 
 HistoricalEmissionsGraph.propTypes = {
   history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired
+  location: PropTypes.object.isRequired,
+  setModalMetadata: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, { location }) => {
@@ -63,6 +70,4 @@ const mapStateToProps = (state, { location }) => {
   return { ...getTargetsData };
 };
 
-export default withRouter(
-  connect(mapStateToProps, actions)(HistoricalEmissionsGraph)
-);
+export default withRouter(connect(mapStateToProps, actions)(HistoricalEmissionsGraph));

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
@@ -4,6 +4,7 @@ import Waypoint from 'react-waypoint';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import AnchorNav from 'components/anchor-nav';
+import ModalMetadata from 'components/modal-metadata';
 import Sticky from 'react-stickynode';
 import cx from 'classnames';
 import { updateUrlHash } from 'utils/navigation';
@@ -24,9 +25,7 @@ class SectorsAgriculture extends PureComponent {
       percentageEmission
     } = this.props;
     const percentageEmissionText =
-      (percentageEmission &&
-        `, producing ${percentageEmission} of all emissions`) ||
-      '';
+      (percentageEmission && `, producing ${percentageEmission} of all emissions`) || '';
 
     return (
       <div>
@@ -64,6 +63,7 @@ class SectorsAgriculture extends PureComponent {
               <div className={styles.sectionComponent}>
                 <div id={section.hash} className={styles.sectionHash} />
                 <section.component />
+                <ModalMetadata />
               </div>
             </Waypoint>
           ))}


### PR DESCRIPTION
First, reimport metadata

```
bundle exec rake wri_metadata:import
```


Here is a quick map of data sources to the data we have across Agriculture pages 

FAOSTAT_1 - Emissions
FAOSTAT_2 - Value-added Agriculture
FAOSTAT_3 - Pesticides and Fertilizers
FAOSTAT_4 - Land use
FAOSTAT_5 - Production and trade import/export
FAOSTAT_6 - Looks like this one is not used
WBD - Employment
OECD-FAO- - Meat consumption
Aqueduct_Country_River_Basin_Rankings - Water withdrawal

Categories used for Google Analytics event:
- Agriculture - Context by Country
- Agriculture - Context by Indicator
- Agriculture - Historical Emissions