### PR TITLE
Change description text in Agriculture/Drivers of emissions

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/drivers-of-emissions-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/drivers-of-emissions-component.jsx
@@ -21,7 +21,7 @@ class DriversOfEmissions extends PureComponent {
         <p>
           Agriculture is one of the most rapidly growing sectors and accounts
           for a significant portion of emissions in developing countries. GHG
-          emissions from agriculture consist of non-CO<sub>2</sub> gases
+          emissions from agriculture consist mainly of non-CO<sub>2</sub> gases
           produced by crop and livestock production and management activities.
         </p>
         <p>


### PR DESCRIPTION
This PR changes the text of description in Agriculture/Drivers of Emissions to:

“....GHG emissions from agriculture consist **mainly** of non-CO2 gases produced by crop and livestock production and management activities.”  

[PIVOTAL](https://www.pivotaltracker.com/story/show/165849693) | [BASECAMP - the first point](https://basecamp.com/1756858/projects/13795275/todos/387609143) 