### PR TITLE
Show zero on y-axis of agriculture emissions chart

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -112,6 +112,7 @@ class ChartLine extends PureComponent {
     const LineChartMargin = espGraph
       ? { top: 50, right: 0, left: marginOffset, bottom: 0 }
       : { top: 10, right: 0, left: -10, bottom: 0 };
+
     const yAxisLabel = (
       <Label
         position="top"
@@ -143,7 +144,7 @@ class ChartLine extends PureComponent {
           <YAxis
             axisLine={false}
             tickLine={false}
-            scale="linear"
+            scale="auto"
             type="number"
             tick={
               <CustomizedYAxisTick
@@ -152,7 +153,7 @@ class ChartLine extends PureComponent {
                 unit={espGraph && unit}
               />
             }
-            domain={(domain && domain.y) || ['auto', 'auto']}
+            domain={(domain && domain.y) || [0, 'auto']}
             interval={'preserveStartEnd'}
           >
             {espGraph && yAxisLabel}

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
@@ -62,14 +62,13 @@ class HistoricalEmissionsGraph extends PureComponent {
   };
 
   renderEmissionsChart = () => {
-    const { config, data, domain, filters, filtersSelected, loading } = this.props;
+    const { config, data, filters, filtersSelected, loading } = this.props;
     return (
       <Chart
         className={styles.chartWrapper}
         type="line"
         config={config}
         data={data}
-        domain={domain}
         dataOptions={filters}
         dataSelected={filtersSelected}
         height={430}
@@ -82,7 +81,11 @@ class HistoricalEmissionsGraph extends PureComponent {
   };
 
   renderExploreButtonGroup = () => {
-    const { exploreEmissionsConfig, emissionsCountry, handleInfoClick } = this.props;
+    const {
+      exploreEmissionsConfig,
+      emissionsCountry,
+      handleInfoClick
+    } = this.props;
     const buttonGroupConfig = [
       {
         type: 'info',
@@ -135,7 +138,9 @@ class HistoricalEmissionsGraph extends PureComponent {
         <RegionsProvider />
         <CountriesProvider />
         <WbCountryDataProvider />
-        <AgricultureEmissionsProvider isoCode3={emissionsCountry && emissionsCountry.value} />
+        <AgricultureEmissionsProvider
+          isoCode3={emissionsCountry && emissionsCountry.value}
+        />
       </div>
     );
   }
@@ -149,7 +154,6 @@ HistoricalEmissionsGraph.propTypes = {
   config: PropTypes.object,
   exploreEmissionsConfig: PropTypes.object.isRequired,
   data: PropTypes.array,
-  domain: PropTypes.object,
   filters: PropTypes.array,
   filtersSelected: PropTypes.array,
   locations: PropTypes.array,
@@ -166,7 +170,6 @@ HistoricalEmissionsGraph.defaultProps = {
   handleMetricTypeChange: () => {},
   handleInfoClick: () => {},
   config: null,
-  domain: null,
   data: [],
   filters: [],
   filtersSelected: [],

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
@@ -7,7 +7,6 @@ import {
 import {
   getChartData,
   getChartConfig,
-  getChartDomain,
   getFilterOptions,
   getFiltersSelected,
   getEmissionTypes,
@@ -33,7 +32,6 @@ export const getAllData = createStructuredSelector({
   data: getChartData,
   loading: getAgricultureEmissionsLoading,
   config: getChartConfig,
-  domain: getChartDomain,
   filters: getFilterOptions,
   filtersSelected: getFiltersSelected,
   locations: getLocationsOptions,

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -216,11 +216,6 @@ export const getChartData = createSelector(
   }
 );
 
-export const getChartDomain = createSelector([getChartData], data => {
-  if (!data) return null;
-  return { x: ['auto', 'auto'], y: ['auto', 'auto'] };
-});
-
 let colorThemeCache = {};
 
 export const getChartConfig = createSelector(


### PR DESCRIPTION
This PR enables showing zero on the y-axis of agriculture emissions chart:
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/387609542) | [PIVOTAL](https://www.pivotaltracker.com/story/show/165850297)

![Screenshot from 2019-05-07 10 52 22](https://user-images.githubusercontent.com/15097138/57291015-86d55f00-70b6-11e9-9adf-0a4a770becf2.png)
