### PR TITLE
[Agriculture] - Add calculation of metrics data for Regions

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
@@ -19,7 +19,8 @@ const getRegionsOptions = createSelector([getRegions], regions => {
   if (!regions) return null;
   return regions.map(d => ({
     label: d.wri_standard_name,
-    value: d.iso_code3
+    value: d.iso_code3,
+    members: d.members && d.members.map(({ iso_code3 }) => iso_code3)
   }));
 });
 


### PR DESCRIPTION
This PR enables calculation of metrics data (population and GDP) for Regions e.g. WORLD, by adding up members country metrics, like in GHG emissions chart.
[PIVOTAL](https://www.pivotaltracker.com/story/show/165852070) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/387609800)
![4si7y-9yd3n](https://user-images.githubusercontent.com/15097138/57314993-95d60480-70ea-11e9-96c5-80ccb382ba1d.gif)
