### PR TITLE
Feature/change max height of dropdowns

### DIFF
--- a/app/javascript/app/components/dropdown/dropdown-styles.scss
+++ b/app/javascript/app/components/dropdown/dropdown-styles.scss
@@ -74,6 +74,10 @@
 .dropdownDisclaimerWrapper {
   display: flex;
   align-items: center;
+
+  :global .dropdown-menu {
+    max-height: 300px !important;
+  }
 }
 
 .disclaimer {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.11",
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.49.2",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.51.0",
     "css-loader": "0.28.7",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2957,9 +2957,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.49.2":
-  version "1.49.2"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/d1a827df67ff63892d157a5a0148e02c1c46f1c0"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.51.0":
+  version "1.51.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/21a55a373ceef67752dae33e63d2925d42cc4985"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
This PR increases max-height of menu for dropdowns, multi-select and multi-level dropdowns to 300px.
**IMPORTANT:** Before start run `yarn install` to update CW Components to the latest version 1.51.0