### PR TITLE
ghg_table: change unit for absolute_value

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -447,8 +447,11 @@ export const getTableData = createSelector(
   (data, metric, model, yColumnOptions) => {
     if (!data || !model || !data.length || !yColumnOptions) return null;
 
-    const formatValue = value => value && Number(value.toFixed(2));
-    const unit = `t${getUnit(metric)}`;
+    const isAbsoluteValue = metric === 'ABSOLUTE_VALUE';
+    const scale = isAbsoluteValue ? 1000000 : 1; // to convert tCO2e to MtCO2e if not gdp or population metric
+    const scaleString = isAbsoluteValue ? 'Mt' : 't';
+    const formatValue = value => value && Number((value / scale).toFixed(2));
+    const unit = `${scaleString}${getUnit(metric)}`;
 
     const pivot = yColumnOptions.map(c => ({
       [GHG_TABLE_HEADER[model]]: c.label,


### PR DESCRIPTION
The unit for absolute value should be MtCO2e.

[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/388193880#comment_698619153) - still no response from the client but it was easy to do it with the proposed way.