### PR TITLE
Feature/agriculture emissions backend units

### DIFF
--- a/app/controllers/api/v1/data/agriculture_profile/emissions_controller.rb
+++ b/app/controllers/api/v1/data/agriculture_profile/emissions_controller.rb
@@ -9,7 +9,16 @@ module Api
             render json: emissions,
                    adapter: :json,
                    each_serializer: Api::V1::Data::AgricultureProfile::EmissionSerializer,
-                   root: :data
+                   root: :data,
+                   meta: meta
+          end
+
+          private
+
+          def meta
+            {
+              emission_locations_with_data: ::AgricultureProfile::Emission.all_locations_iso_codes
+            }
           end
         end
       end

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -6,11 +6,11 @@ import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaults, toPlural } from 'utils/ghg-emissions';
 import { sortLabelByAlpha } from 'utils/graphs';
-import { GAS_AGGREGATES, TOP_EMITTERS_OPTION, METRIC_OPTIONS } from 'data/constants';
+import { GAS_AGGREGATES, TOP_EMITTERS_OPTION, CALCULATION_OPTIONS } from 'data/constants';
 import { getMeta, getRegions, getSources, getSelection } from './ghg-emissions-selectors-get';
 
 const DEFAULTS = {
-  breakBy: `regions-${METRIC_OPTIONS.ABSOLUTE_VALUE.value}`
+  breakBy: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
 };
 
 const getOptionSelectedFunction = filter => (options, selected) => {
@@ -42,15 +42,15 @@ const getSourceSelected = createSelector(
 const BREAK_BY_OPTIONS = [
   {
     label: 'Regions-Totals',
-    value: `regions-${METRIC_OPTIONS.ABSOLUTE_VALUE.value}`
+    value: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
   },
   {
     label: 'Regions-Per Capita',
-    value: `regions-${METRIC_OPTIONS.PER_CAPITA.value}`
+    value: `regions-${CALCULATION_OPTIONS.PER_CAPITA.value}`
   },
   {
     label: 'Regions-Per GDP',
-    value: `regions-${METRIC_OPTIONS.PER_GDP.value}`
+    value: `regions-${CALCULATION_OPTIONS.PER_GDP.value}`
   },
   {
     label: 'Sectors',
@@ -276,7 +276,7 @@ const getChartConflicts = (metricSelected, chartSelected) => {
   const conflicts = [];
 
   if (['PER_CAPITA', 'PER_GDP'].includes(metricSelected) && chartSelected.value !== 'line') {
-    const metricOption = METRIC_OPTIONS[metricSelected];
+    const metricOption = CALCULATION_OPTIONS[metricSelected];
     conflicts.push(`${metricOption.label} metric is not allowed with ${chartSelected.label} chart`);
   }
 

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/card-pie-chart-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/card-pie-chart-component.jsx
@@ -7,6 +7,15 @@ import EmissionsProvider from 'providers/emissions-provider';
 import styles from './card-pie-chart-styles.scss';
 import Tooltip from './tooltip/tooltip';
 
+const renderEmissionValue = value => (
+  <span
+    // eslint-disable-next-line react/no-danger
+    dangerouslySetInnerHTML={{
+      __html: value
+    }}
+  />
+);
+
 class CardPieChart extends PureComponent {
   renderAgricultureLabel = () => {
     const { pieChartData } = this.props;
@@ -27,10 +36,7 @@ class CardPieChart extends PureComponent {
             color={color}
           />
           <span className={styles.labelValue} style={{ color }}>
-            {`${emissionPercentage} (${emissionValue} `}
-            <span>
-              MtCO<sub>2</sub>)
-            </span>
+            {emissionPercentage} ({renderEmissionValue(emissionValue)})
           </span>
         </div>
       </div>
@@ -42,24 +48,14 @@ class CardPieChart extends PureComponent {
     const data = pieChartData ? pieChartData.data : [];
     const config = pieChartData && pieChartData.config;
     return (
-      <PieChart
-        data={data}
-        width="100%"
-        height={250}
-        config={config}
-        customTooltip={<Tooltip />}
-      />
+      <PieChart data={data} width="100%" height={250} config={config} customTooltip={<Tooltip />} />
     );
   };
 
   renderLoading = () => {
     const { pieChartData } = this.props;
     const loading = pieChartData && pieChartData.loading;
-    return loading ? (
-      <Loading height="100%" />
-    ) : (
-      <NoContent message="No data available" />
-    );
+    return loading ? <Loading height="100%" /> : <NoContent message="No data available" />;
   };
 
   render() {
@@ -79,19 +75,13 @@ class CardPieChart extends PureComponent {
       <div>
         <Card
           theme={cardTheme}
-          subtitle={
-            pieChartData ? `${location} agriculture emissions in ${year}` : ''
-          }
+          subtitle={pieChartData ? `${location} agriculture emissions in ${year}` : ''}
         >
           {pieChartData && emissionValue ? (
             <div className={styles.cardContent}>
               <p className={styles.description}>
-                <span>{location}</span> in <span>{year}</span>, the Agriculture
-                sector contributed to{' '}
-                <span>
-                  {emissionValue} MtCO<sub>2</sub>e
-                </span>{' '}
-                GHG emissions, which represented{' '}
+                <span>{location}</span> in <span>{year}</span>, the Agriculture sector contributed
+                to {renderEmissionValue(emissionValue)} GHG emissions, which represented{' '}
                 <span>{emissionPercentage}</span> of all emissions.
               </p>
               <TabletLandscape>

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/pie-chart-selectors.js
@@ -1,10 +1,6 @@
 import { createSelector } from 'reselect';
-import {
-  getTooltipConfig,
-  getColumnValue,
-  getPieChartThemeConfig
-} from 'utils/graphs';
-import { GREY_CHART_COLORS } from 'data/constants';
+import { getTooltipConfig, getColumnValue, getPieChartThemeConfig } from 'utils/graphs';
+import { GREY_CHART_COLORS, UNITS } from 'data/constants';
 import { format } from 'd3-format';
 import getIsoCode from './location-selectors';
 
@@ -17,10 +13,8 @@ const INCLUDED_SECTORS = [
   'Waste' /** , 'Land-Use Change and Forestry' */
 ];
 
-const getGhgEmissionsData = state =>
-  (state.emissions && state.emissions.data) || null;
-const getGhgEmissionsLoading = state =>
-  (state.emissions && state.emissions.loading) || false;
+const getGhgEmissionsData = state => (state.emissions && state.emissions.data) || null;
+const getGhgEmissionsLoading = state => (state.emissions && state.emissions.loading) || false;
 
 const getGhgEmissionsDataByLocation = createSelector(
   [getGhgEmissionsData, getIsoCode],
@@ -31,58 +25,57 @@ const getGhgEmissionsDataByLocation = createSelector(
   }
 );
 
-export const getPieChartData = createSelector(
-  [getGhgEmissionsDataByLocation],
-  data => {
-    if (!data || !data.length) return null;
-    const lastYearEmissions = data.map(({ emissions, sector, location }) => {
-      const lastYearEmission = emissions[emissions.length - 1];
-      return { sector, location, ...lastYearEmission };
-    });
+const API_SCALE = 1000000; // GHG emission data MtCO2e, we convert to tCO2e
 
-    const totalLastYearEmission = lastYearEmissions.find(
-      ({ sector }) => sector && sector === TOTAL_EMISSION
-    );
+export const getPieChartData = createSelector([getGhgEmissionsDataByLocation], data => {
+  if (!data || !data.length) return null;
+  const lastYearEmissions = data.map(({ emissions, sector, location }) => {
+    const lastYearEmission = emissions[emissions.length - 1];
+    return { sector, location, ...lastYearEmission };
+  });
 
-    const filteredEmissions = lastYearEmissions.filter(
-      ({ sector, value }) => value > 0 && INCLUDED_SECTORS.includes(sector)
-    ); // filter for negative emission for Forestry sector and total LUCF sectors
+  const totalLastYearEmission = lastYearEmissions.find(
+    ({ sector }) => sector && sector === TOTAL_EMISSION
+  );
 
-    if (!filteredEmissions || !totalLastYearEmission) return null;
+  const filteredEmissions = lastYearEmissions.filter(
+    ({ sector, value }) => value > 0 && INCLUDED_SECTORS.includes(sector)
+  ); // filter for negative emission for Forestry sector and total LUCF sectors
 
-    const sectorEmissions = filteredEmissions.map(({ sector, value }) => ({
-      name: getColumnValue(sector).toLowerCase(),
-      value,
-      sector,
-      formattedValue: `${format('.2s')(value)}`,
-      formattedPercentage: `${format('.2f')(
-        value * 100 / totalLastYearEmission.value
-      )}%`,
-      percentageValue: value * 100 / totalLastYearEmission.value
-    }));
+  if (!filteredEmissions || !totalLastYearEmission) return null;
 
-    const agricultureRow = sectorEmissions.find(
-      ({ name }) => name === 'agriculture'
-    );
+  const formatEmissionValue = value => {
+    const formatted = `${format('.2s')(value * API_SCALE)}t${UNITS.CO2e}`;
+    const onlyNumber = parseFloat(formatted);
+    const rest = formatted.replace(onlyNumber, '');
+    return `${onlyNumber} ${rest}`;
+  };
 
-    if (!agricultureRow) return null;
+  const sectorEmissions = filteredEmissions.map(({ sector, value }) => ({
+    name: getColumnValue(sector).toLowerCase(),
+    value,
+    sector,
+    formattedValue: formatEmissionValue(value),
+    formattedPercentage: `${format('.2f')(value * 100 / totalLastYearEmission.value)}%`,
+    percentageValue: value * 100 / totalLastYearEmission.value
+  }));
 
-    const sectorsEmissionsData = agricultureRow
-      ? [
-        agricultureRow,
-        ...sectorEmissions.filter(({ name }) => name !== 'agriculture')
-      ]
-      : sectorEmissions;
-    const x = {
-      year: filteredEmissions[0] && filteredEmissions[0].year,
-      location: filteredEmissions[0] && filteredEmissions[0].location,
-      emissionValue: agricultureRow && agricultureRow.formattedValue,
-      emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
-      data: sectorsEmissionsData
-    };
-    return x;
-  }
-);
+  const agricultureRow = sectorEmissions.find(({ name }) => name === 'agriculture');
+
+  if (!agricultureRow) return null;
+
+  const sectorsEmissionsData = agricultureRow
+    ? [agricultureRow, ...sectorEmissions.filter(({ name }) => name !== 'agriculture')]
+    : sectorEmissions;
+  const x = {
+    year: filteredEmissions[0] && filteredEmissions[0].year,
+    location: filteredEmissions[0] && filteredEmissions[0].location,
+    emissionValue: agricultureRow && agricultureRow.formattedValue,
+    emissionPercentage: agricultureRow && agricultureRow.formattedPercentage,
+    data: sectorsEmissionsData
+  };
+  return x;
+});
 
 const getPieChartConfig = createSelector([getPieChartData], pieChartData => {
   if (!pieChartData || !pieChartData.data || !pieChartData.data.length) {
@@ -119,13 +112,7 @@ export const getPieChartPayload = createSelector(
   [getPieChartData, getPieChartConfig, getGhgEmissionsLoading],
   (pieChartData, config, loading) => {
     if (!pieChartData || !config) return null;
-    const {
-      location,
-      year,
-      emissionValue,
-      emissionPercentage,
-      data
-    } = pieChartData;
+    const { location, year, emissionValue, emissionPercentage, data } = pieChartData;
     const color = AGRICULTURE_COLOR;
 
     return {

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/tooltip/tooltip.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/tooltip/tooltip.jsx
@@ -5,15 +5,19 @@ import { has } from 'lodash';
 import styles from './tooltip-styles.scss';
 
 const Tooltip = ({ content }) => {
-  const color = has(content, 'payload[0].payload.fill')
-    ? content.payload[0].payload.fill
-    : '';
-  const payload =
-    has(content, 'payload[0].payload.payload') &&
-    content.payload[0].payload.payload;
+  const color = has(content, 'payload[0].payload.fill') ? content.payload[0].payload.fill : '';
+  const payload = has(content, 'payload[0].payload.payload') && content.payload[0].payload.payload;
   const sector = payload ? payload.sector : '';
   const formattedValue = payload ? payload.formattedValue : '';
   const formattedPercentage = payload ? payload.formattedPercentage : '';
+  const renderEmissionValue = value => (
+    <span
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: value
+      }}
+    />
+  );
 
   return (
     <div className={styles.tooltip}>
@@ -27,10 +31,7 @@ const Tooltip = ({ content }) => {
         color={color}
       />
       <span className={styles.value}>
-        {`${formattedPercentage} (${formattedValue} `}
-        <span>
-          MtCO<sub>2</sub>
-        </span>)
+        {formattedPercentage} ({renderEmissionValue(formattedValue)})
       </span>
     </div>
   );

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
@@ -1,14 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ExploreButtonGroup from 'components/sectors-agriculture/drivers-of-emissions/explore-group/explore-group';
-import Chart from 'components/charts/chart';
-import Dropdown from 'components/dropdown';
+import { Chart, Dropdown } from 'cw-components';
 import RegionsProvider from 'providers/regions-provider/regions-provider';
 import CountriesProvider from 'providers/countries-provider/countries-provider';
 import AgricultureEmissionsProvider from 'providers/agriculture-emissions-provider/agriculture-emissions-provider';
 import WbCountryDataProvider from 'providers/wb-country-data-provider';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
-import { METRIC_OPTIONS } from 'data/constants';
 
 import styles from './historical-emissions-graph-styles.scss';
 import CardPieChart from '../card-pie-chart/card-pie-chart';
@@ -84,9 +82,9 @@ class HistoricalEmissionsGraph extends PureComponent {
         dataOptions={filters}
         dataSelected={filtersSelected}
         height={430}
-        dot={false}
-        forceFixedFormatDecimals={3}
-        espGraph
+        dots={false}
+        lineType="linear"
+        showUnit
         loading={loading && !data}
       />
     );

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
@@ -23,9 +23,10 @@ class HistoricalEmissionsGraph extends PureComponent {
       handleEmissionTypeChange,
       handleMetricTypeChange,
       emissionType,
-      emissionMetric
+      emissionMetric,
+      emissionMetrics
     } = this.props;
-    const metricOptions = Object.values(METRIC_OPTIONS).map(option => option);
+
     const locationGroups = [
       {
         groupId: 'regions',
@@ -62,7 +63,7 @@ class HistoricalEmissionsGraph extends PureComponent {
           key="metric"
           label="Break by metric"
           className={styles.dropdown}
-          options={metricOptions}
+          options={emissionMetrics}
           onValueChange={handleMetricTypeChange}
           value={emissionMetric}
           hideResetButton
@@ -166,7 +167,8 @@ HistoricalEmissionsGraph.propTypes = {
   emissionTypes: PropTypes.array,
   emissionType: PropTypes.object,
   loading: PropTypes.bool,
-  emissionMetric: PropTypes.object
+  emissionMetric: PropTypes.object,
+  emissionMetrics: PropTypes.array
 };
 
 HistoricalEmissionsGraph.defaultProps = {
@@ -183,7 +185,8 @@ HistoricalEmissionsGraph.defaultProps = {
   emissionTypes: [],
   emissionType: null,
   loading: false,
-  emissionMetric: null
+  emissionMetric: null,
+  emissionMetrics: []
 };
 
 export default HistoricalEmissionsGraph;

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
@@ -11,7 +11,8 @@ import {
   getFiltersSelected,
   getEmissionTypes,
   getEmissionTypeSelected,
-  getMetricSelected
+  getMetricSelected,
+  getMetricOptions
 } from './historical-emissions-graph-selectors/line-chart-selectors';
 
 const getAgricultureEmissionsLoading = state =>
@@ -39,5 +40,6 @@ export const getAllData = createStructuredSelector({
   exploreEmissionsConfig: getExploreEmissionsButtonConfig,
   emissionTypes: getEmissionTypes,
   emissionType: getEmissionTypeSelected,
-  emissionMetric: getMetricSelected
+  emissionMetric: getMetricSelected,
+  emissionMetrics: getMetricOptions
 });

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -1,37 +1,23 @@
 import { createSelector } from 'reselect';
 import qs from 'query-string';
-import {
-  uniqBy,
-  sortBy,
-  isEmpty,
-  intersection,
-  flatten,
-  groupBy
-} from 'lodash';
-import {
-  getYColumnValue,
-  getThemeConfig,
-  getTooltipConfig,
-  setChartColors,
-  getMetricRatio
-} from 'utils/graphs';
+import { uniqBy, sortBy, isEmpty, intersection, flatten, groupBy } from 'lodash';
+import { getYColumnValue, getThemeConfig, getTooltipConfig, setChartColors } from 'utils/graphs';
 import {
   AGRICULTURE_TOTAL_EMISSIONS,
   CHART_COLORS,
   CHART_COLORS_EXTENDED,
   DEFAULT_AXES_CONFIG,
-  METRIC_OPTIONS
+  CALCULATION_OPTIONS,
+  UNITS
 } from 'data/constants';
 import { getEmissionCountrySelected } from './location-selectors';
 
-const getSourceSelection = state =>
-  (state.location && state.location.search) || null;
+const getSourceSelection = state => (state.location && state.location.search) || null;
 
 const getAgricultureEmissionsData = state =>
   (state.agricultureEmissions && state.agricultureEmissions.data) || null;
 
-const getWbCountryData = state =>
-  (state.wbCountryData && state.wbCountryData.data) || null;
+const getWbCountryData = state => (state.wbCountryData && state.wbCountryData.data) || null;
 
 const getCountryMetricData = createSelector(
   [getWbCountryData, getEmissionCountrySelected],
@@ -44,8 +30,7 @@ const getCountryMetricData = createSelector(
         metricData[d.year] = { gdp: d.gdp, population: d.population };
       });
     } else {
-      const members =
-        country.members && country.members.map(isoCode3 => data[isoCode3]);
+      const members = country.members && country.members.map(isoCode3 => data[isoCode3]);
       if (!members) return {};
       const membersByYear = groupBy(flatten(members), 'year');
       const years = Object.keys(membersByYear);
@@ -72,73 +57,57 @@ const getCountryMetricData = createSelector(
   }
 );
 
-export const getEmissionTypes = createSelector(
-  [getAgricultureEmissionsData],
-  data => {
-    if (!data || !data.length) return null;
-    const emissionTypes = data.map(
-      ({ emission_subcategory: { category_name, category_id } }) => ({
-        label: category_name,
-        value: `${category_id}`
-      })
-    );
-    const uniqEmissionTypes = uniqBy(emissionTypes, 'value');
-    const totalOption = uniqEmissionTypes.find(
-      ({ label }) => label === AGRICULTURE_TOTAL_EMISSIONS.category_name
-    );
-    const sortedEmissionTypes = sortBy(
-      uniqEmissionTypes.filter(
-        ({ label }) => label !== AGRICULTURE_TOTAL_EMISSIONS.category_name
-      ),
-      ['label']
-    );
-    return [totalOption, ...sortedEmissionTypes];
-  }
-);
+export const getEmissionTypes = createSelector([getAgricultureEmissionsData], data => {
+  if (!data || !data.length) return null;
+  const emissionTypes = data.map(({ emission_subcategory: { category_name, category_id } }) => ({
+    label: category_name,
+    value: `${category_id}`
+  }));
+  const uniqEmissionTypes = uniqBy(emissionTypes, 'value');
+  const totalOption = uniqEmissionTypes.find(
+    ({ label }) => label === AGRICULTURE_TOTAL_EMISSIONS.category_name
+  );
+  const sortedEmissionTypes = sortBy(
+    uniqEmissionTypes.filter(({ label }) => label !== AGRICULTURE_TOTAL_EMISSIONS.category_name),
+    ['label']
+  );
+  return [totalOption, ...sortedEmissionTypes];
+});
 
 export const getEmissionTypeSelected = createSelector(
   [getSourceSelection, getEmissionTypes],
   (selectedEmissionOption, emissionTypes) => {
     if (!emissionTypes) return null;
     if (!selectedEmissionOption) {
-      const defaultEmissionType = emissionTypes.find(
-        ({ value }) => value === 1
-      );
+      const defaultEmissionType = emissionTypes.find(({ value }) => value === 1);
       return defaultEmissionType || emissionTypes[0];
     }
     const { emissionType } = qs.parse(selectedEmissionOption);
-    const selectedEmissionType = emissionTypes.find(
-      ({ value }) => value === emissionType
-    );
+    const selectedEmissionType = emissionTypes.find(({ value }) => value === emissionType);
     return selectedEmissionType || emissionTypes[0];
   }
 );
 
-export const getMetricOptions = createSelector(
-  getEmissionTypeSelected,
-  emissionType => {
-    const allMetrics = Object.values(METRIC_OPTIONS);
+export const getMetricOptions = createSelector(getEmissionTypeSelected, emissionType => {
+  const allMetrics = Object.values(CALCULATION_OPTIONS);
 
-    if (!emissionType) return allMetrics;
+  if (!emissionType) return allMetrics;
 
-    if (emissionType && emissionType.label === 'Agriculture emissions intensity') {
-      return [METRIC_OPTIONS.ABSOLUTE_VALUE];
-    }
-
-    return allMetrics;
+  if (emissionType && emissionType.label === 'Agriculture emissions intensity') {
+    return [CALCULATION_OPTIONS.ABSOLUTE_VALUE];
   }
-);
+
+  return allMetrics;
+});
 
 export const getMetricSelected = createSelector(
   [getSourceSelection, getMetricOptions],
   (sourceSelection, metricOptions) => {
-    if (!sourceSelection) return METRIC_OPTIONS.ABSOLUTE_VALUE;
+    if (!sourceSelection) return CALCULATION_OPTIONS.ABSOLUTE_VALUE;
 
     const { emissionMetric } = qs.parse(sourceSelection);
-    const selectedEmissionMetric = metricOptions.find(
-      ({ value }) => value === emissionMetric
-    );
-    return selectedEmissionMetric || METRIC_OPTIONS.ABSOLUTE_VALUE;
+    const selectedEmissionMetric = metricOptions.find(({ value }) => value === emissionMetric);
+    return selectedEmissionMetric || CALCULATION_OPTIONS.ABSOLUTE_VALUE;
   }
 );
 
@@ -147,20 +116,29 @@ const filterByEmissionType = createSelector(
   (data, emissionType) => {
     if (!data || !emissionType) return null;
     return data.filter(
-      ({ emission_subcategory: { category_id } }) =>
-        `${category_id}` === emissionType.value
+      ({ emission_subcategory: { category_id } }) => `${category_id}` === emissionType.value
     );
   }
 );
 
-const getEmissionCategoryUnit = createSelector(
-  [filterByEmissionType],
-  (data) => {
-    if (!data || !data.length) return null;
+const getEmissionCategoryUnit = createSelector([filterByEmissionType], data => {
+  if (!data || !data.length) return null;
 
-    return data[0].emission_subcategory.category_unit;
-  }
-);
+  return data[0].emission_subcategory.category_unit;
+});
+
+const getScale = createSelector(getEmissionCategoryUnit, unit => {
+  if (!unit) return null;
+  // gigagrams to tonnes 1Gg = 1000 tonnes
+  if (unit.includes('gigagrams')) return 1000;
+  return 1;
+});
+
+const getUnit = createSelector(getEmissionCategoryUnit, unit => {
+  if (!unit) return null;
+  if (unit.includes('gigagrams')) return UNITS.CO2e;
+  return unit;
+});
 
 export const getFilterOptions = createSelector([filterByEmissionType], data => {
   if (!data || !data.length) return null;
@@ -182,11 +160,8 @@ export const getFiltersSelected = createSelector(
     if (!search) return filters;
     const { filter } = qs.parse(search);
     const filtersValues = filters.map(({ value }) => value);
-    const subCategoriesSelected =
-      (filter && filter.split(',')) || filtersValues;
-    const filtersSelected = filters.filter(({ value }) =>
-      subCategoriesSelected.includes(value)
-    );
+    const subCategoriesSelected = (filter && filter.split(',')) || filtersValues;
+    const filtersSelected = filters.filter(({ value }) => subCategoriesSelected.includes(value));
     return filtersSelected;
   }
 );
@@ -197,30 +172,38 @@ const filterDataBySelectedIndicator = createSelector(
     if (!data) return null;
     if (!filtersSelected) return data;
     const labels = filtersSelected.map(({ label }) => label);
-    const result = data.filter(({ emission_subcategory: { name } }) =>
-      labels.includes(name)
-    );
+    const result = data.filter(({ emission_subcategory: { name } }) => labels.includes(name));
     return result;
   }
 );
 
+export const getMetricRatio = (selected, calculationData, x) => {
+  if (!calculationData || !calculationData[x]) return 1;
+  if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
+    // GDP is in dollars and we want to display it in million dollars
+    return calculationData[x].gdp / 1000000;
+  }
+  if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
+    return calculationData[x].population;
+  }
+  return 1;
+};
+
 export const getChartData = createSelector(
-  [filterDataBySelectedIndicator, getCountryMetricData, getMetricSelected],
-  (data, countryMetric, metricSelected) => {
+  [filterDataBySelectedIndicator, getCountryMetricData, getMetricSelected, getScale],
+  (data, countryMetric, metricSelected, scale) => {
     if (!data || !data.length || !countryMetric || !metricSelected) return null;
     if (
-      metricSelected.value !== METRIC_OPTIONS.ABSOLUTE_VALUE.value &&
+      metricSelected.value !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value &&
       isEmpty(countryMetric)
     ) {
       return null;
     } // set null when country/region doesn't have a metric data
 
     let xValues = Object.keys(data[0].values).map(key => parseInt(key, 10));
-    if (metricSelected.value !== METRIC_OPTIONS.ABSOLUTE_VALUE.value) {
+    if (metricSelected.value !== CALCULATION_OPTIONS.ABSOLUTE_VALUE.value) {
       // get array of common years for data and for metric
-      const metricValues = Object.keys(countryMetric).map(key =>
-        parseInt(key, 10)
-      );
+      const metricValues = Object.keys(countryMetric).map(key => parseInt(key, 10));
       xValues = intersection(xValues, metricValues);
     }
     const dataParsed = xValues.map(x => {
@@ -228,14 +211,8 @@ export const getChartData = createSelector(
       data.forEach(d => {
         const yKey = getYColumnValue(d.emission_subcategory.name);
         const yData = d.values[x];
-        const calculationRatio = getMetricRatio(
-          metricSelected.value,
-          countryMetric,
-          x
-        );
-        yItems[yKey] = yData
-          ? parseFloat(yData) / calculationRatio
-          : undefined;
+        const calculationRatio = getMetricRatio(metricSelected.value, countryMetric, x);
+        yItems[yKey] = yData ? parseFloat(yData) * (scale / calculationRatio) : undefined;
       });
       return { x, ...yItems };
     });
@@ -252,29 +229,35 @@ export const getChartData = createSelector(
 
 let colorThemeCache = {};
 
+const getUnitForSelectedMetric = (unit, metric) => {
+  if (metric === CALCULATION_OPTIONS.PER_CAPITA.value) {
+    return `${unit} per Capita`;
+  }
+  if (metric === CALCULATION_OPTIONS.PER_GDP.value) {
+    return `${unit} per million $ GDP`;
+  }
+
+  return unit;
+};
+
 export const getChartConfig = createSelector(
-  [getChartData, getFiltersSelected, getMetricSelected, getEmissionCategoryUnit],
-  (data, yColumns, metricSelected, apiUnit) => {
-    if (!data || !yColumns || !metricSelected || !apiUnit) return null;
-    const chartColors = setChartColors(
-      yColumns.length,
-      CHART_COLORS,
-      CHART_COLORS_EXTENDED
-    );
+  [getChartData, getFiltersSelected, getMetricSelected, getUnit],
+  (data, yColumns, metricSelected, unit) => {
+    if (!data || !yColumns || !metricSelected || !unit) return null;
+    const chartColors = setChartColors(yColumns.length, CHART_COLORS, CHART_COLORS_EXTENDED);
     const theme = getThemeConfig(yColumns, chartColors);
     colorThemeCache = { ...theme, ...colorThemeCache };
     const tooltip = getTooltipConfig(yColumns);
-    let unit = apiUnit;
-    if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
-      unit = `${unit} per Capita`;
-    }
-    if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {
-      unit = `${unit} per million $ GDP`;
-    }
+    const unitForMetric = getUnitForSelectedMetric(unit, metricSelected.value);
+
     return {
       axes: {
         ...DEFAULT_AXES_CONFIG,
-        yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit }
+        yLeft: {
+          ...DEFAULT_AXES_CONFIG.yLeft,
+          unit: unitForMetric,
+          suffix: unit === UNITS.CO2e ? 't' : null
+        }
       },
       theme: colorThemeCache,
       tooltip,

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -33,19 +33,6 @@ const getAgricultureEmissionsData = state =>
 const getWbCountryData = state =>
   (state.wbCountryData && state.wbCountryData.data) || null;
 
-export const getMetricSelected = createSelector(
-  [getSourceSelection],
-  sourceSelection => {
-    if (!sourceSelection) return METRIC_OPTIONS.ABSOLUTE_VALUE;
-    const { emissionMetric } = qs.parse(sourceSelection);
-    const metricOptions = Object.values(METRIC_OPTIONS).map(option => option);
-    const selectedEmissionMetric = metricOptions.find(
-      ({ value }) => value === emissionMetric
-    );
-    return selectedEmissionMetric || METRIC_OPTIONS.ABSOLUTE_VALUE;
-  }
-);
-
 const getCountryMetricData = createSelector(
   [getWbCountryData, getEmissionCountrySelected],
   (data, country) => {
@@ -124,6 +111,34 @@ export const getEmissionTypeSelected = createSelector(
       ({ value }) => value === emissionType
     );
     return selectedEmissionType || emissionTypes[0];
+  }
+);
+
+export const getMetricOptions = createSelector(
+  getEmissionTypeSelected,
+  emissionType => {
+    const allMetrics = Object.values(METRIC_OPTIONS);
+
+    if (!emissionType) return allMetrics;
+
+    if (emissionType && emissionType.label === 'Agriculture emissions intensity') {
+      return [METRIC_OPTIONS.ABSOLUTE_VALUE];
+    }
+
+    return allMetrics;
+  }
+);
+
+export const getMetricSelected = createSelector(
+  [getSourceSelection, getMetricOptions],
+  (sourceSelection, metricOptions) => {
+    if (!sourceSelection) return METRIC_OPTIONS.ABSOLUTE_VALUE;
+
+    const { emissionMetric } = qs.parse(sourceSelection);
+    const selectedEmissionMetric = metricOptions.find(
+      ({ value }) => value === emissionMetric
+    );
+    return selectedEmissionMetric || METRIC_OPTIONS.ABSOLUTE_VALUE;
   }
 );
 

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/line-chart-selectors.js
@@ -64,11 +64,9 @@ export const getEmissionTypes = createSelector([getAgricultureEmissionsData], da
     value: `${category_id}`
   }));
   const uniqEmissionTypes = uniqBy(emissionTypes, 'value');
-  const totalOption = uniqEmissionTypes.find(
-    ({ label }) => label === AGRICULTURE_TOTAL_EMISSIONS.category_name
-  );
+  const totalOption = uniqEmissionTypes.find(({ label }) => label === AGRICULTURE_TOTAL_EMISSIONS);
   const sortedEmissionTypes = sortBy(
-    uniqEmissionTypes.filter(({ label }) => label !== AGRICULTURE_TOTAL_EMISSIONS.category_name),
+    uniqEmissionTypes.filter(({ label }) => label !== AGRICULTURE_TOTAL_EMISSIONS),
     ['label']
   );
   return [totalOption, ...sortedEmissionTypes];

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
@@ -1,9 +1,12 @@
 import { createSelector } from 'reselect';
+import get from 'lodash/get';
 import qs from 'query-string';
 
 const getCountries = state => state.countries || null;
 const getRegions = state => state.regions || null;
 const getSourceSelection = state => (state.location && state.location.search) || null;
+const getLocationsWithData = state =>
+  get(state, 'agricultureEmissions.meta.emission_locations_with_data', null);
 
 /**  LOCATIONS SELECTORS */
 const getCountriesOptions = createSelector([getCountries], countries => {
@@ -25,14 +28,26 @@ const getRegionsOptions = createSelector([getRegions], regions => {
   }));
 });
 
-export const getLocationsOptions = createSelector(
+const getLocationsOptionsUnfiltered = createSelector(
   [getCountriesOptions, getRegionsOptions],
-  (countries, regions) =>
-    (!countries || !countries.length || !regions || !regions.length ? [] : [...countries, ...regions])
+  (countries, regions) => {
+    if (!countries || !regions) return [];
+
+    return [...countries, ...regions];
+  }
+);
+
+export const getLocationsOptions = createSelector(
+  [getLocationsOptionsUnfiltered, getLocationsWithData],
+  (locations, locationsWithData) => {
+    if (!locations || !locationsWithData) return [];
+
+    return locations.filter(l => locationsWithData.includes(l.value));
+  }
 );
 
 export const getEmissionCountrySelected = createSelector(
-  [getSourceSelection, getLocationsOptions],
+  [getSourceSelection, getLocationsOptionsUnfiltered],
   (selectedEmissionOption, countriesOptions) => {
     if (!countriesOptions) return null;
     const defaultCountry = countriesOptions.find(({ value }) => value === 'WORLD');

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -336,13 +336,7 @@ export const WRI_WEBSITE = 'https://www.wri.org/';
 export const WRI_CLIMATE_BLOG = 'https://www.wri.org/blog-tags/9654';
 export const RW_WEBSITE = 'https://resourcewatch.org/';
 
-export const AGRICULTURE_TOTAL_EMISSIONS = {
-  name: 'Total emissions',
-  category_id: 'total',
-  category_name: 'Agriculture Emissions: Total',
-  category_unit: 'CO2eq gigagrams',
-  short_name: 'total_emissions_agr_18'
-};
+export const AGRICULTURE_TOTAL_EMISSIONS = 'Agriculture Emissions: Total';
 
 export const AGRICULTURE_INDICATORS_NAMES = {
   total_pesticides_use: 'Pesticides consumption',

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -361,6 +361,13 @@ export const WRI_WEBSITE = 'https://www.wri.org/';
 export const WRI_CLIMATE_BLOG = 'https://www.wri.org/blog-tags/9654';
 export const RW_WEBSITE = 'https://resourcewatch.org/';
 
+export const AGRICULTURE_TOTAL_EMISSIONS = {
+  name: 'Total emissions',
+  category_id: 'total',
+  category_name: 'Agriculture Emissions: Total',
+  short_name: 'total_emissions_agr_18'
+};
+
 export const AGRICULTURE_INDICATORS_NAMES = {
   total_pesticides_use: 'Pesticides consumption',
   total_fertilizers: 'Fertilizers consumption',

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -67,18 +67,7 @@ export const DEFAULT_EMISSIONS_SELECTIONS = {
   }
 };
 
-export const TOP_EMITTERS = [
-  'CHN',
-  'USA',
-  'EU28',
-  'IND',
-  'RUS',
-  'JPN',
-  'BRA',
-  'IDN',
-  'CAN',
-  'MEX'
-];
+export const TOP_EMITTERS = ['CHN', 'USA', 'EU28', 'IND', 'RUS', 'JPN', 'BRA', 'IDN', 'CAN', 'MEX'];
 
 export const CHART_COLORS = [
   '#00B4D2',
@@ -183,14 +172,7 @@ export const NEW_CHART_COLORS_EXTENDED = [
   '#CCCDCF'
 ];
 
-export const GREY_CHART_COLORS = [
-  '#68696B',
-  '#818285',
-  '#999B9D',
-  '#ACAEB8',
-  '#C3C4CD',
-  '#E2E4EA'
-];
+export const GREY_CHART_COLORS = ['#68696B', '#818285', '#999B9D', '#ACAEB8', '#C3C4CD', '#E2E4EA'];
 
 export const COUNTRY_COMPARE_COLORS = ['#113750', '#00B4D2', '#D2187C'];
 
@@ -323,12 +305,7 @@ export const USERS_PROFESIONAL_SECTORS = [
 
 export const ALL_SELECTED = 'All Selected';
 export const ALL_SELECTED_OPTION = { label: ALL_SELECTED, value: ALL_SELECTED };
-export const NO_ALL_SELECTED_COLUMNS = [
-  'breakBy',
-  'chartType',
-  'sources',
-  'regions'
-];
+export const NO_ALL_SELECTED_COLUMNS = ['breakBy', 'chartType', 'sources', 'regions'];
 
 export const METRIC_OPTIONS = {
   ABSOLUTE_VALUE: { label: 'Absolute value', value: 'ABSOLUTE_VALUE' },
@@ -365,6 +342,7 @@ export const AGRICULTURE_TOTAL_EMISSIONS = {
   name: 'Total emissions',
   category_id: 'total',
   category_name: 'Agriculture Emissions: Total',
+  category_unit: 'CO2eq gigagrams',
   short_name: 'total_emissions_agr_18'
 };
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -176,6 +176,10 @@ export const GREY_CHART_COLORS = ['#68696B', '#818285', '#999B9D', '#ACAEB8', '#
 
 export const COUNTRY_COMPARE_COLORS = ['#113750', '#00B4D2', '#D2187C'];
 
+export const UNITS = {
+  CO2e: 'CO<sub>2</sub>e'
+};
+
 export const DEFAULT_AXES_CONFIG = {
   xBottom: {
     name: 'Year',
@@ -184,7 +188,7 @@ export const DEFAULT_AXES_CONFIG = {
   },
   yLeft: {
     name: 'Emissions',
-    unit: 'CO<sub>2</sub>e',
+    unit: UNITS.CO2e,
     format: 'number'
   }
 };
@@ -306,12 +310,6 @@ export const USERS_PROFESIONAL_SECTORS = [
 export const ALL_SELECTED = 'All Selected';
 export const ALL_SELECTED_OPTION = { label: ALL_SELECTED, value: ALL_SELECTED };
 export const NO_ALL_SELECTED_COLUMNS = ['breakBy', 'chartType', 'sources', 'regions'];
-
-export const METRIC_OPTIONS = {
-  ABSOLUTE_VALUE: { label: 'Absolute value', value: 'ABSOLUTE_VALUE' },
-  PER_CAPITA: { label: 'per Capita', value: 'PER_CAPITA' },
-  PER_GDP: { label: 'per GDP', value: 'PER_GDP' }
-};
 
 export const TOP_EMITTERS_OPTION = {
   iso: 'TOP',

--- a/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
+++ b/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
@@ -1,24 +1,9 @@
-import { AGRICULTURE_TOTAL_EMISSIONS } from 'data/constants';
-
 export const initialState = {
   loading: false,
   loaded: false,
   data: [],
   error: false
 };
-
-const appendMissingTotalEmissionsProps = d => {
-  if (d.emission_subcategory.short_name === AGRICULTURE_TOTAL_EMISSIONS.short_name) {
-    const emission_subcategory = {
-      ...d.emission_subcategory,
-      ...AGRICULTURE_TOTAL_EMISSIONS
-    };
-    return { ...d, emission_subcategory };
-  }
-  return d;
-};
-
-const transformData = data => data.map(appendMissingTotalEmissionsProps);
 
 const setLoading = (loading, state) => ({ ...state, loading });
 const setLoaded = (loaded, state) => ({ ...state, loaded });
@@ -27,6 +12,6 @@ const setError = (state, error) => ({ ...state, error });
 export default {
   fetchAgricultureEmissionsInit: state => setLoading(true, state),
   fetchAgricultureEmissionsReady: (state, { payload: { data } }) =>
-    setLoaded(true, setLoading(false, { ...state, data: transformData(data) })),
+    setLoaded(true, setLoading(false, { ...state, data })),
   fetchAgricultureEmissionsFail: state => setLoading(setError(state, true), false)
 };

--- a/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
+++ b/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
@@ -1,9 +1,24 @@
+import { AGRICULTURE_TOTAL_EMISSIONS } from 'data/constants';
+
 export const initialState = {
   loading: false,
   loaded: false,
   data: [],
   error: false
 };
+
+const transformData = (data) => (
+  data.map(d => {
+    if (d.emission_subcategory.short_name === AGRICULTURE_TOTAL_EMISSIONS.short_name) {
+      const emission_subcategory = {
+        ...d.emission_subcategory,
+        ...AGRICULTURE_TOTAL_EMISSIONS
+      };
+      return { ...d, emission_subcategory };
+    }
+    return d;
+  })
+);
 
 const setLoading = (loading, state) => ({ ...state, loading });
 const setLoaded = (loaded, state) => ({ ...state, loaded });
@@ -12,7 +27,7 @@ const setError = (state, error) => ({ ...state, error });
 export default {
   fetchAgricultureEmissionsInit: state => setLoading(true, state),
   fetchAgricultureEmissionsReady: (state, { payload: { data } }) =>
-    setLoaded(true, setLoading(false, { ...state, data })),
+    setLoaded(true, setLoading(false, { ...state, data: transformData(data) })),
   fetchAgricultureEmissionsFail: state =>
     setLoading(setError(state, true), false)
 };

--- a/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
+++ b/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
@@ -2,6 +2,7 @@ export const initialState = {
   loading: false,
   loaded: false,
   data: [],
+  meta: {},
   error: false
 };
 
@@ -11,7 +12,7 @@ const setError = (state, error) => ({ ...state, error });
 
 export default {
   fetchAgricultureEmissionsInit: state => setLoading(true, state),
-  fetchAgricultureEmissionsReady: (state, { payload: { data } }) =>
-    setLoaded(true, setLoading(false, { ...state, data })),
+  fetchAgricultureEmissionsReady: (state, { payload: { data, meta } }) =>
+    setLoaded(true, setLoading(false, { ...state, data, meta })),
   fetchAgricultureEmissionsFail: state => setLoading(setError(state, true), false)
 };

--- a/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
+++ b/app/javascript/app/providers/agriculture-emissions-provider/agriculture-emissions-provider-reducers.js
@@ -7,18 +7,18 @@ export const initialState = {
   error: false
 };
 
-const transformData = (data) => (
-  data.map(d => {
-    if (d.emission_subcategory.short_name === AGRICULTURE_TOTAL_EMISSIONS.short_name) {
-      const emission_subcategory = {
-        ...d.emission_subcategory,
-        ...AGRICULTURE_TOTAL_EMISSIONS
-      };
-      return { ...d, emission_subcategory };
-    }
-    return d;
-  })
-);
+const appendMissingTotalEmissionsProps = d => {
+  if (d.emission_subcategory.short_name === AGRICULTURE_TOTAL_EMISSIONS.short_name) {
+    const emission_subcategory = {
+      ...d.emission_subcategory,
+      ...AGRICULTURE_TOTAL_EMISSIONS
+    };
+    return { ...d, emission_subcategory };
+  }
+  return d;
+};
+
+const transformData = data => data.map(appendMissingTotalEmissionsProps);
 
 const setLoading = (loading, state) => ({ ...state, loading });
 const setLoaded = (loaded, state) => ({ ...state, loaded });
@@ -28,6 +28,5 @@ export default {
   fetchAgricultureEmissionsInit: state => setLoading(true, state),
   fetchAgricultureEmissionsReady: (state, { payload: { data } }) =>
     setLoaded(true, setLoading(false, { ...state, data: transformData(data) })),
-  fetchAgricultureEmissionsFail: state =>
-    setLoading(setError(state, true), false)
+  fetchAgricultureEmissionsFail: state => setLoading(setError(state, true), false)
 };

--- a/app/javascript/app/utils/ghg-emissions.js
+++ b/app/javascript/app/utils/ghg-emissions.js
@@ -1,4 +1,4 @@
-import { DEFAULT_EMISSIONS_SELECTIONS, DATA_SCALE, CALCULATION_OPTIONS } from 'data/constants';
+import { DEFAULT_EMISSIONS_SELECTIONS, CALCULATION_OPTIONS } from 'data/constants';
 
 export const getGhgEmissionDefaults = (source, meta) => {
   const sourceName = source.name || source.label;
@@ -17,7 +17,7 @@ export const calculatedRatio = (selected, calculationData, x) => {
   if (!calculationData || !calculationData[x]) return 1;
   if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
     // GDP is in dollars and we want to display it in million dollars
-    return calculationData[x][0].gdp / DATA_SCALE;
+    return calculationData[x][0].gdp / 1000000;
   }
   if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
     return calculationData[x][0].population;

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -10,7 +10,7 @@ import map from 'lodash/map';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import isEmpty from 'lodash/isEmpty';
-import { OTHER_COLOR, METRIC_OPTIONS } from 'data/constants';
+import { OTHER_COLOR } from 'data/constants';
 
 export const parseRegions = regions =>
   regions.map(region => ({
@@ -27,9 +27,7 @@ export const sortLabelByAlpha = array =>
 
 const flatmap = (res, v) => Object.assign(res, v);
 export const extractValues = data => key =>
-  data.map(d =>
-    map(d, (v, k) => ({ [k]: d[k][key] || v })).reduce(flatmap, {})
-  );
+  data.map(d => map(d, (v, k) => ({ [k]: d[k][key] || v })).reduce(flatmap, {}));
 
 export const getColumns = data =>
   Object.keys(data[0]).map(d => ({ label: data[0][d].label, value: d }));
@@ -58,16 +56,10 @@ export const groupDataByScenario = (data, scenarios) =>
 export const sortEmissionsByValue = array =>
   array.sort((a, b) => {
     if (!a.emissions.length || !b.emissions.length) return 0;
-    if (
-      a.emissions[a.emissions.length - 1].value >
-      b.emissions[a.emissions.length - 1].value
-    ) {
+    if (a.emissions[a.emissions.length - 1].value > b.emissions[a.emissions.length - 1].value) {
       return -1;
     }
-    if (
-      a.emissions[a.emissions.length - 1].value <
-      b.emissions[a.emissions.length - 1].value
-    ) {
+    if (a.emissions[a.emissions.length - 1].value < b.emissions[a.emissions.length - 1].value) {
       return 1;
     }
     return 0;
@@ -119,8 +111,7 @@ export const getPieChartThemeConfig = (columns, colors) => {
   const theme = {};
   columns.forEach((column, i) => {
     const index = column.index || i;
-    const correctedIndex =
-      index < colors.length ? index : index - colors.length;
+    const correctedIndex = index < colors.length ? index : index - colors.length;
     theme[column.value] = {
       label: column.label,
       stroke: colors[correctedIndex],
@@ -141,8 +132,7 @@ export const getTooltipConfig = columns => {
 export const setChartColors = (chartElementsLength, palette, extendedPalette) =>
   (chartElementsLength < 11 ? palette : extendedPalette);
 
-export const getColorPalette = (colorRange, quantity) =>
-  chroma.scale(colorRange).colors(quantity);
+export const getColorPalette = (colorRange, quantity) => chroma.scale(colorRange).colors(quantity);
 
 export const darkenColor = color => chroma(color).darken();
 
@@ -159,12 +149,7 @@ export function setXAxisDomain() {
   return ['auto', 'auto'];
 }
 
-export function getCustomTicks(
-  columns,
-  data,
-  tickNumber = 8,
-  decimals = false
-) {
+export function getCustomTicks(columns, data, tickNumber = 8, decimals = false) {
   const totalValues = [];
   const yValues = columns.y.map(c => data.map(d => d[[c.value]]));
   const getSign = value => (value > 0 ? 'positive' : 'negative');
@@ -189,17 +174,3 @@ export function getCustomTicks(
     ticks: getNiceTickValues([minValue, maxValue], tickNumber, decimals)
   };
 }
-
-export const getMetricRatio = (selected, calculationData, x) => {
-  if (!calculationData || !calculationData[x]) return 1;
-  if (selected === METRIC_OPTIONS.PER_GDP.value) {
-    // GDP is in dollars and we want to display it in million dollars
-    // emissions is in MtC02e and we want to display it in tCO2e (1MtC02e = 1000000 tC02e)
-    return calculationData[x].gdp / (1000000 * 1000000);
-  }
-  if (selected === METRIC_OPTIONS.PER_CAPITA.value) {
-    // emissions is in MtC02e and we want to display it in tCO2e (1MtC02e = 1000000 tC02e)
-    return calculationData[x].population / 1000000;
-  }
-  return 1;
-};

--- a/app/models/agriculture_profile/emission.rb
+++ b/app/models/agriculture_profile/emission.rb
@@ -15,5 +15,9 @@ module AgricultureProfile
       emissions = emissions.by_location_iso(params[:iso_code3]) if params[:iso_code3]
       emissions
     end
+
+    def self.all_locations_iso_codes
+      all.joins(:location).distinct.pluck('locations.iso_code3')
+    end
   end
 end

--- a/app/serializers/api/v1/data/agriculture_profile/emission_subcategory_serializer.rb
+++ b/app/serializers/api/v1/data/agriculture_profile/emission_subcategory_serializer.rb
@@ -11,6 +11,7 @@ module Api
           attribute :indicator_name
           attribute :category_name
           attribute :category_id
+          attribute :category_unit
 
           def category_name
             object.emission_category&.name
@@ -18,6 +19,10 @@ module Api
 
           def category_id
             object.emission_category_id
+          end
+
+          def category_unit
+            object.emission_category&.unit
           end
         end
       end

--- a/docs/data_explorer.md
+++ b/docs/data_explorer.md
@@ -540,11 +540,17 @@ Link: </api/v1/data/ndc_content/indicators>; rel="meta indicators", </api/v1/dat
             "emission_subcategory": {
                 "name": "Manure Management",
                 "short_name": "total_emissions_agr_2",
-                "indicator_name": "Total Emissions in agriculture"
+                "indicator_name": "Total Emissions in agriculture",
+                "category_id": 100,
+                "category_name": "Total Emissions",
+                "category unit": "CO2eq gigagrams"
             }
         }
         ...
-   ]
+   ],
+   "meta": {
+     "emission_locations_with_data": ["ITA", "HUN", "COL", "IRQ"...]
+   }
 ```
 
 ### Country Contexts


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/166433680)
[Pivotal story 2](https://www.pivotaltracker.com/story/show/166433712)

- Disable/hide the "Per Capita" and "Per GDP" break by metric for the Emissions option: "Agriculture emissions intensity" (see attached screenshot).
- Display the correct units for different options. GHG units converted to tCO2e (unification with GHG module)
- standardize unit between the pie chart and the line chart

![image](https://user-images.githubusercontent.com/1286444/59284755-18fbf480-8c6d-11e9-85a4-9b3a25efe36d.png)

We have to reimport agriculture emission data, and metadata, because I've added Total emission category to the Legend file as on the picture below.

![image](https://user-images.githubusercontent.com/1286444/59284621-d33f2c00-8c6c-11e9-9cc1-21a384933da4.png)


```
bundle exec rake agriculture_profile:import_metadata
bundle exec rake agriculture_profile:import_emissions
```

[Pivotal story 3](https://www.pivotaltracker.com/story/show/166433747)
- hiding locations for which we don't have any emission data
