### PR TITLE
Add slug column to indc_labels table and aknowledge it in importer

### DIFF
--- a/app/serializers/api/v1/indc/label_serializer.rb
+++ b/app/serializers/api/v1/indc/label_serializer.rb
@@ -3,6 +3,7 @@ module Api
     module Indc
       class LabelSerializer < ActiveModel::Serializer
         attribute :value, key: :name
+        attribute :slug
         attribute :index
       end
     end

--- a/app/serializers/api/v1/indc/value_serializer.rb
+++ b/app/serializers/api/v1/indc/value_serializer.rb
@@ -4,6 +4,7 @@ module Api
       class ValueSerializer < ActiveModel::Serializer
         attribute :value
         attribute :label_id, if: -> { object.label_id }
+        attribute :label_slug, if: -> { object.label&.slug }
         attribute :sector_id, if: -> { object.sector_id }
       end
     end

--- a/db/migrate/20190725143552_add_slug_to_indc_labels.rb
+++ b/db/migrate/20190725143552_add_slug_to_indc_labels.rb
@@ -1,0 +1,5 @@
+class AddSlugToIndcLabels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :indc_labels, :slug, :string, default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,22 +5,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: emissions_filter_by_year_range(jsonb, integer, integer); Type: FUNCTION; Schema: public; Owner: -
@@ -515,53 +502,6 @@ ALTER SEQUENCE public.agriculture_profile_metadata_id_seq OWNED BY public.agricu
 
 
 --
--- Name: agriculture_profile_metadata_sources; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.agriculture_profile_metadata_sources (
-    id bigint NOT NULL,
-    dataset character varying,
-    title character varying,
-    technical_title character varying,
-    source_organization character varying,
-    learn_more character varying,
-    summary text,
-    description text,
-    cautions text,
-    geographic_coverage character varying,
-    date_of_content character varying,
-    frequency_of_updates character varying,
-    summary_of_licenses character varying,
-    terms_of_service_link character varying,
-    citation character varying,
-    published_language character varying,
-    published_title character varying,
-    other character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: agriculture_profile_metadata_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.agriculture_profile_metadata_sources_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: agriculture_profile_metadata_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.agriculture_profile_metadata_sources_id_seq OWNED BY public.agriculture_profile_metadata_sources.id;
-
-
---
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1048,7 +988,8 @@ CREATE TABLE public.indc_labels (
     value text NOT NULL,
     index integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    slug character varying
 );
 
 
@@ -2194,13 +2135,6 @@ ALTER TABLE ONLY public.agriculture_profile_metadata ALTER COLUMN id SET DEFAULT
 
 
 --
--- Name: agriculture_profile_metadata_sources id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agriculture_profile_metadata_sources ALTER COLUMN id SET DEFAULT nextval('public.agriculture_profile_metadata_sources_id_seq'::regclass);
-
-
---
 -- Name: datasets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2675,14 +2609,6 @@ ALTER TABLE ONLY public.agriculture_profile_meat_trades
 
 ALTER TABLE ONLY public.agriculture_profile_metadata
     ADD CONSTRAINT agriculture_profile_metadata_pkey PRIMARY KEY (id);
-
-
---
--- Name: agriculture_profile_metadata_sources agriculture_profile_metadata_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agriculture_profile_metadata_sources
-    ADD CONSTRAINT agriculture_profile_metadata_sources_pkey PRIMARY KEY (id);
 
 
 --
@@ -4220,6 +4146,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181205151353'),
 ('20181205152900'),
 ('20181205161151'),
+('20181218161317'),
+('20181218161621'),
 ('20181218163254'),
 ('20181219173718'),
 ('20181220093604'),
@@ -4228,7 +4156,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181227144108'),
 ('20190207144949'),
 ('20190219190427'),
-('20190404173252'),
-('20190405154306');
+('20190405154306'),
+('20190725143552');
 
 


### PR DESCRIPTION
- Add `slug` column to `indc_labels` table
- Acknowledge `slug` when importing labels 
- Add `label_slug` or `slug` to serializers (depending on endpoints), i.e. here: `api/v1/ndcs?category=overview` there's a change in locations array, if there is an association between value and a label and label slug is not null, it will be included in the endpoint

Note: not sure when I ran migrations `agriculture_profile_metadata_sources ` tagged along and was removed from structure.sql, maybe structure.sql wasn't commited last time when migrations were ran.