### PR TITLE
if there's no value for a country in a year, render N/A in the table

### DIFF
--- a/app/javascript/app/components/table/cell-renderer-component.jsx
+++ b/app/javascript/app/components/table/cell-renderer-component.jsx
@@ -53,18 +53,17 @@ const cellRenderer = ({
       </NavLink>
     );
   }
-  // render Html or finally cellData
-  return parseHtml ? (
-    // eslint-disable-next-line react/no-danger
-    <div dangerouslySetInnerHTML={{ __html: cellData }} />
+  const renderWhenEmpty = emptyValueLabel ? (
+    <div className={styles.emptyValue}>{emptyValueLabel}</div>
   ) : (
-    cellData ||
-    (emptyValueLabel ? (
-      <div className={styles.emptyValue}>{emptyValueLabel}</div>
-    ) : (
-      ''
-    ))
+    ''
   );
+  // render Html or finally cellData
+  return parseHtml
+    ? // eslint-disable-next-line react/no-danger
+    (cellData && <div dangerouslySetInnerHTML={{ __html: cellData }} />) ||
+      renderWhenEmpty
+    : cellData || renderWhenEmpty;
 };
 
 cellRenderer.propTypes = {

--- a/app/javascript/app/components/table/cell-renderer-component.jsx
+++ b/app/javascript/app/components/table/cell-renderer-component.jsx
@@ -58,12 +58,15 @@ const cellRenderer = ({
   ) : (
     ''
   );
+
+  if (!cellData) return renderWhenEmpty;
+
   // render Html or finally cellData
-  return parseHtml
-    ? // eslint-disable-next-line react/no-danger
-    (cellData && <div dangerouslySetInnerHTML={{ __html: cellData }} />) ||
-      renderWhenEmpty
-    : cellData || renderWhenEmpty;
+  return parseHtml ? (
+    <div dangerouslySetInnerHTML={{ __html: cellData }} /> // eslint-disable-line react/no-danger
+  ) : (
+    cellData
+  );
 };
 
 cellRenderer.propTypes = {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression-webpack-plugin": "^1.1.11",
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.51.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.51.1",
     "css-loader": "0.28.7",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,9 +2958,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.51.0":
-  version "1.51.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/21a55a373ceef67752dae33e63d2925d42cc4985"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.51.1":
+  version "1.51.1"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/90d8143432aed12ad65a38dc88f50edc4831b3a6"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
We already had this behaviour on the DataExplorer, but we also need it
here in the GHG emissions module.

While fixing this I realised that we had a bug with the default
emptyValueLabel not being used if we passed in "parseHtml", so I have
fixed that too (I think).