### PR TITLE
fix parsing scientific notation

### DIFF
--- a/app/services/import_wb_extra.rb
+++ b/app/services/import_wb_extra.rb
@@ -60,8 +60,8 @@ class ImportWbExtra
     WbExtra::CountryData.create(
       location: country_location,
       year: year,
-      population: @population_by_country[country_code][year_index]&.to_i,
-      gdp: @gdp_by_country[country_code][year_index]&.to_i
+      population: @population_by_country[country_code][year_index]&.to_f,
+      gdp: @gdp_by_country[country_code][year_index]&.to_f
     )
   end
 


### PR DESCRIPTION
Issue described on [basecamp](https://basecamp.com/1756858/projects/13795275/todos/396644492). WbExtra data was imported with having some of the numbers in scientific notation. Those numbers were parsed by the script as number `1` (that's why per gdp metric had strange values on the chart). I'm changing the parsing to float number instead and Rails will take care with parsing float to postgres bigint when saving data into database.

```
bundle exec rake wb_extra:import
```