### PR TITLE
Check for empty scenariosInChart and avoid page crash - guard

### DIFF
--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -437,7 +437,7 @@ export const getChartConfig = createSelector(
     getChartNeededPrecision
   ],
   (data, allScenarios, scenariosInChart, indicator, precision) => {
-    if (!data || !allScenarios) return null;
+    if (!data || !allScenarios || isEmpty(scenariosInChart)) return null;
     const yColumns = data.map(d => {
       const scenario = scenariosInChart.find(
         s => parseInt(s.value, 10) === d.scenario_id


### PR DESCRIPTION
Add a guard to `getChartConfig` selector to avoid page crash on `/embed/pathways?category=10&currentLocation=267&indicator=388&model=3&scenario=182%2C181%2C180%2C183&subcategory=36`