### PR TITLE
New LTS country page

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -83,7 +83,7 @@ class LTSExploreMapContainer extends PureComponent {
     const { isoCountries } = this.props;
     const iso = geography.properties && geography.properties.id;
     if (iso && isCountryIncluded(isoCountries, iso)) {
-      this.props.history.push(`/ndcs/country/${iso}`);
+      this.props.history.push(`/lts/country/${iso}`);
       handleAnalytics(
         'LTS Explore Map',
         'Use map to find country',

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -14,13 +14,13 @@ const fetchNdcsCountryAccordionFailed = createAction(
 const fetchNdcsCountryAccordion = createThunkAction(
   'fetchNdcsCountryAccordion',
   params => dispatch => {
-    const { locations, category, compare } = params;
+    const { locations, category, compare, lts } = params;
     if (locations) {
       dispatch(fetchNdcsCountryAccordionInit());
       fetch(
-        `/api/v1/ndcs?location=${locations}&category=${category}${!compare
-          ? '&filter=overview'
-          : ''}`
+        `/api/v1/ndcs?location=${locations}&category=${category}${
+          lts ? '&source=LTS' : ''
+        }${!compare ? '&filter=overview' : ''}`
       )
         .then(response => {
           if (response.ok) return response.json();

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -41,21 +41,23 @@ class NdcsCountryAccordionContainer extends PureComponent {
       fetchNdcsCountryAccordion,
       category,
       search,
-      compare
+      compare,
+      lts
     } = this.props;
     const locations = iso || search.locations;
-    fetchNdcsCountryAccordion({ locations, category, compare });
+    fetchNdcsCountryAccordion({ locations, category, compare, lts });
   }
 
   componentWillReceiveProps(nextProps) {
-    const { fetchNdcsCountryAccordion, compare } = this.props;
+    const { fetchNdcsCountryAccordion, compare, lts } = this.props;
     const newLocations = qs.parse(nextProps.location.search).locations;
     const oldLocations = qs.parse(this.props.location.search).locations;
     if (newLocations !== oldLocations) {
       fetchNdcsCountryAccordion({
         locations: newLocations,
         category: nextProps.category,
-        compare
+        compare,
+        lts
       });
     }
   }
@@ -73,7 +75,8 @@ NdcsCountryAccordionContainer.propTypes = {
   category: PropTypes.string,
   search: PropTypes.object,
   location: PropTypes.object,
-  compare: PropTypes.bool
+  compare: PropTypes.bool,
+  lts: PropTypes.bool
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/data/SEO.js
+++ b/app/javascript/app/data/SEO.js
@@ -14,6 +14,8 @@ export const NDC_LTS =
   'Analyze and compare every national climate pledge (Nationally Determined Contribution – or NDC) under the Paris Agreement, with the ability to search key words and see summaries by topic across all.';
 export const NDC_COUNTRY = ({ countryName = '' }) =>
   `Explore the Commitments (NDCs) made by ${countryName} to act on climate change, as part of the Paris Agreement`;
+export const LTS_COUNTRY = ({ countryName = '' }) =>
+  `Explore the Long-term strategies (LTSs) made by ${countryName} to act on climate change`;
 export const NDC_SDG_LINKAGES =
   'Comprehensive mapping of linkages between Nationally Determined Contributions (NDCs) and the Sustainable Development Goals (SDGs) and associated targets of the 2030 Agenda for Sustainable Development.';
 export const HISTORICAL_GHG_EMISIONS =

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { renderRoutes } from 'react-router-config';
+import Header from 'components/header';
+import Intro from 'components/intro';
+import Search from 'components/search';
+import cx from 'classnames';
+import Sticky from 'react-stickynode';
+import AnchorNav from 'components/anchor-nav';
+import { LTS_COUNTRY } from 'data/SEO';
+import { MetaDescription, SocialMetadata } from 'components/seo';
+
+import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
+import lightSearch from 'styles/themes/search/search-light.scss';
+import styles from './lts-country-styles.scss';
+
+class LTSCountry extends PureComponent {
+  render() {
+    const {
+      country,
+      onSearchChange,
+      search,
+      route,
+      anchorLinks,
+      notSummary
+    } = this.props;
+    const countryName = country && `${country.wri_standard_name}`;
+    return (
+      <div>
+        <MetaDescription
+          descriptionContext={LTS_COUNTRY({ countryName })}
+          subtitle={countryName}
+        />
+        <SocialMetadata
+          descriptionContext={LTS_COUNTRY({ countryName })}
+          href={location.href}
+        />
+        {country && (
+          <Header route={route}>
+            <div className={cx(styles.doubleFold, styles.header)}>
+              <div className={styles.title}>
+                <Intro title={country.wri_standard_name} />
+              </div>
+              {notSummary && (
+                <Search
+                  theme={lightSearch}
+                  placeholder="Search"
+                  value={search}
+                  onChange={onSearchChange}
+                />
+              )}
+            </div>
+            <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
+              <AnchorNav
+                useRoutes
+                links={anchorLinks}
+                className={styles.anchorNav}
+                theme={anchorNavRegularTheme}
+                gradientColor={route.headerColor}
+              />
+            </Sticky>
+          </Header>
+        )}
+        <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
+      </div>
+    );
+  }
+}
+
+LTSCountry.propTypes = {
+  route: PropTypes.object.isRequired,
+  country: PropTypes.object,
+  onSearchChange: PropTypes.func.isRequired,
+  search: PropTypes.string,
+  anchorLinks: PropTypes.array,
+  notSummary: PropTypes.bool
+};
+
+export default LTSCountry;

--- a/app/javascript/app/pages/lts-country/lts-country-selectors.js
+++ b/app/javascript/app/pages/lts-country/lts-country-selectors.js
@@ -1,0 +1,36 @@
+import { createSelector } from 'reselect';
+import qs from 'query-string';
+
+const getCountries = state => state.countries || null;
+const getIso = state => state.iso || null;
+
+const getCountryByIso = (countries, iso) =>
+  countries.find(country => country.iso_code3 === iso);
+
+export const getCountry = createSelector(
+  [getCountries, getIso],
+  getCountryByIso
+);
+
+export const getAnchorLinks = createSelector(
+  [
+    state => state.route.routes || [],
+    state => state.iso,
+    state => state.location.search
+  ],
+  (routes, iso, search) => {
+    const searchParams = { search: qs.parse(search).search };
+    return routes
+      .filter(route => route.anchor)
+      .map(route => ({
+        label: route.label,
+        path: `/lts/country/${iso}/${route.param ? route.param : ''}`,
+        search: `?${qs.stringify(searchParams)}`
+      }));
+  }
+);
+
+export default {
+  getCountry,
+  getAnchorLinks
+};

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -1,0 +1,53 @@
+@import '~styles/layout.scss';
+
+.anchorNav {
+  @include row('shrink', $wrap: false);
+}
+
+.doubleFold {
+  @include row(12);
+
+  > :not(:first-child) {
+    @include xy-gutters($gutter-position: ('bottom'));
+  }
+
+  z-index: $z-index-sticky;
+
+  > :nth-child(4) {
+    height: 100%;
+  }
+
+  @media #{$tablet-portrait} {
+    @include row((12, 6, 6));
+
+    > :not(:first-child) {
+      @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
+    }
+  }
+
+  @media #{$tablet-landscape} {
+    @include row((5, 3, 2, 2));
+
+    > :not(:first-child) {
+      @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
+    }
+
+    z-index: $z-index-base;
+  }
+}
+
+.backButton {
+  margin-right: 20px;
+}
+
+.backIcon {
+  fill: $white;
+  width: 60px;
+  height: 60px;
+}
+
+.title {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+}

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -1,0 +1,62 @@
+import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import Proptypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import qs from 'query-string';
+import { getLocationParamUpdated } from 'utils/navigation';
+
+import LTSCountryComponent from './lts-country-component';
+import { getCountry, getAnchorLinks } from './lts-country-selectors';
+
+const mapStateToProps = (state, { match, location, route }) => {
+  const { iso } = match.params;
+  const search = qs.parse(location.search);
+  const countryData = {
+    countries: state.countries.data,
+    iso: match.params.iso
+  };
+  const routeData = {
+    iso,
+    location,
+    route
+  };
+  const pathname = location.pathname.split('/');
+  const notSummary = [
+    'overview',
+    'mitigation',
+    'adaptation',
+    'sectoral-information'
+  ].includes(pathname[pathname.length - 1]);
+  return {
+    country: getCountry(countryData),
+    search: search.search,
+    anchorLinks: getAnchorLinks(routeData),
+    notSummary
+  };
+};
+
+class LTSCountryContainer extends PureComponent {
+  onSearchChange = query => {
+    this.updateUrlParam({ name: 'search', value: query });
+  };
+
+  updateUrlParam = (params, clear) => {
+    const { history, location } = this.props;
+    history.replace(getLocationParamUpdated(location, params, clear));
+  };
+
+  render() {
+    return createElement(LTSCountryComponent, {
+      ...this.props,
+      onSearchChange: this.onSearchChange,
+      handleDropDownChange: this.handleDropDownChange
+    });
+  }
+}
+
+LTSCountryContainer.propTypes = {
+  history: Proptypes.object.isRequired,
+  location: Proptypes.object.isRequired
+};
+
+export default withRouter(connect(mapStateToProps, null)(LTSCountryContainer));

--- a/app/javascript/app/routes/app-routes/LTSCountry-routes/LTSCountry-routes.js
+++ b/app/javascript/app/routes/app-routes/LTSCountry-routes/LTSCountry-routes.js
@@ -1,0 +1,62 @@
+import { createElement } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import NDCCountryAccordion from 'components/ndcs/ndcs-country-accordion';
+
+export default [
+  {
+    path: '/lts/country/:iso/overview',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'overview',
+        lts: true
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Overview',
+    param: 'overview'
+  },
+  {
+    path: '/lts/country/:iso/mitigation',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'mitigation',
+        lts: true
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Mitigation',
+    param: 'mitigation'
+  },
+  {
+    path: '/lts/country/:iso/adaptation',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'adaptation',
+        lts: true
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Adaptation',
+    param: 'adaptation'
+  },
+  {
+    path: '/lts/country/:iso/sectoral-information',
+    component: () =>
+      createElement(NDCCountryAccordion, {
+        category: 'sectoral_information',
+        lts: true
+      }),
+    exact: true,
+    anchor: true,
+    label: 'Sectoral Information',
+    param: 'sectoral-information'
+  },
+  {
+    path: '/lts/country/:iso',
+    component: ({ match }) =>
+      createElement(Redirect, {
+        to: `/lts/country/${match.params.iso}/overview`
+      })
+  }
+];

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -9,6 +9,7 @@ import CountriesSelect from 'components/countries-select';
 import CountryCompare from 'pages/country-compare';
 import NDCCountryFull from 'pages/ndc-country-full';
 import NDCCountry from 'pages/ndc-country';
+import LTSCountry from 'pages/lts-country';
 import NDCCompare from 'pages/ndc-compare';
 import NDCS from 'pages/ndcs';
 import NDCSEnhancements from 'pages/ndcs-enhancements';
@@ -30,6 +31,7 @@ import LTSExplore from 'pages/lts-explore';
 // routes
 import NDCSRoutes from './NDCS-routes';
 import NDCCountryRoutes from './NDCCountry-routes';
+import LTSCountryRoutes from './LTSCountry-routes';
 import NDCCompareRoutes from './NDCCompare-routes';
 import NDCSContentRoutes from './NDCSContent-routes';
 import MyCwRoutes from './my-cw-routes';
@@ -114,6 +116,13 @@ export default [
     headerImage: 'ndc',
     headerColor: '#035388',
     routes: NDCCountryRoutes
+  },
+  {
+    path: '/lts/country/:iso',
+    component: LTSCountry,
+    headerImage: 'ndc',
+    headerColor: '#035388',
+    routes: LTSCountryRoutes
   },
   {
     path: '/ndcs/compare',


### PR DESCRIPTION
New LTS country page:

- You can access this page from the lts-explore page.
- It is missing the changes on the new NDC country page. Including the styling of the header (Search input should probably be on the right but it will be fixed with the changes)
- The final LTS country page should have a overview summary. In this case we just have the overview section of the indicator.
- No compare or full text link buttons for now.

![image](https://user-images.githubusercontent.com/9701591/70052020-a2640200-15d2-11ea-95e8-04787bbb4ed7.png)
