### PR TITLE
DataExplorer/Historical Emissions: fix no-metadata bug & fix `All Selected` sources op…

### DIFF
--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -98,7 +98,8 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
     PIK: ['historical_emissions_pik'],
     CAIT: ['historical_emissions_cait'],
     'UNFCCC Annex I': ['historical_emissions_unfccc'],
-    'UNFCCC Non-Annex I': ['unfccc_documents']
+    'UNFCCC Non-Annex I': ['historical_emissions_unfccc'],
+    GCP: ['historical_emissions_gcp']
   },
   'ndc-sdg-linkages': ['ndc_sdc_all indicators'],
   'ndc-content': ['ndc_cw', 'ndc_wb', 'ndc_die'],

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -97,8 +97,8 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
   'historical-emissions': {
     PIK: ['historical_emissions_pik'],
     CAIT: ['historical_emissions_cait'],
-    UNFCCC: ['historical_emissions_unfccc'],
-    GCP: ['historical_emissions_gcp']
+    'UNFCCC Annex I': ['historical_emissions_unfccc'],
+    'UNFCCC Non-Annex I': ['unfccc_documents']
   },
   'ndc-sdg-linkages': ['ndc_sdc_all indicators'],
   'ndc-content': ['ndc_cw', 'ndc_wb', 'ndc_die'],


### PR DESCRIPTION
This PR fixes the `metadata` bug in `Data Explorer/Historical Emissions`. The tab `Sources & metadata` wasn't displaying any content, after updating hardcoded keys and few changes in `getMethodology` selector it works again. 

I fixed `All Selected` option in `Historical Emissions` tab - now it displays metadata for all 4 sources.

**IMPORTANT**: I'm not sure about the data slug `unfccc_documents` for the "UNFCCC Non-Annex I" source, please check if this is the correct one.