### PR TITLE
Feature/lts first card

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -215,24 +215,27 @@ export const getEmissionsCardData = createSelector(
     if (!emissionsIndicator) return null;
 
     const emissionPercentages = emissionsIndicator.locations;
-    const totalEmissions = Object.values(emissionPercentages).reduce(
-      (a, b) => a + parseFloat(b.value),
-      0
-    );
+    let summedPercentage = 0;
     const data = legend.map(legendItem => {
       let legendItemValue = 0;
       Object.entries(selectedIndicator.locations).forEach(entry => {
-        const [locationIso, { value: legendItemName }] = entry;
+        const [locationIso, { label_id: labelId }] = entry;
         if (
-          legendItemName === legendItem.name &&
+          labelId === parseInt(legendItem.id, 10) &&
           emissionPercentages[locationIso]
         ) {
           legendItemValue += parseFloat(emissionPercentages[locationIso].value);
         }
       });
+      summedPercentage += legendItemValue;
+
+      // The 'No information' label is always the last one so we can calculate its value substracting from 100
       return {
         name: camelCase(legendItem.name),
-        value: percentage(legendItemValue, totalEmissions)
+        value:
+          legendItem.name === NO_INFORMATION_LABEL
+            ? 100 - summedPercentage
+            : legendItemValue
       };
     });
 

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -267,6 +267,7 @@ export const getEmissionsCardData = createSelector(
     };
   }
 );
+
 export const getSummaryCardData = createSelector(
   [getMaximumCountries, getIndicatorsData],
   (maximumCountries, indicators) => {

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -228,14 +228,17 @@ export const getEmissionsCardData = createSelector(
   }
 );
 export const getSummaryCardData = createSelector(
-  [getLegend, getMapIndicator, getMaximumCountries],
-  (legend, indicator, maximumCountries) => {
-    if (!indicator || !legend) return null;
-    // TODO: This may change. The info will come from the backend
-    const selectedLegendItem = legend[0];
+  [getMaximumCountries, getIndicatorsData],
+  (maximumCountries, indicators) => {
+    if (!indicators || !maximumCountries) return null;
+    const LTSIndicator = indicators.find(i => i.slug === 'lts_document');
+    if (!LTSIndicator) return null;
+    const partiesNumber = Object.values(LTSIndicator.locations).filter(
+      l => l.value
+    ).length;
     return {
-      value: selectedLegendItem.partiesNumber,
-      description: `out of ${maximumCountries} parties - ${indicator.label}`
+      value: partiesNumber,
+      description: `out of ${maximumCountries} parties have submitted long-term strategies`
     };
   }
 );

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -9,14 +9,8 @@ import { getLocationParamUpdated } from 'utils/navigation';
 
 import { actions as fetchActions } from 'pages/lts-explore';
 import { actions as modalActions } from 'components/modal-metadata';
-import {
-  getCategories,
-  getCategoryIndicators,
-  getSelectedCategory
-} from 'components/ndcs/ndcs-map/ndcs-map-selectors';
 
 import Component from './lts-explore-map-component';
-
 import {
   getMapIndicator,
   getPathsWithStyles,
@@ -24,7 +18,10 @@ import {
   getLinkToDataExplorer,
   getEmissionsCardData,
   getLegend,
-  getSummaryCardData
+  getSummaryCardData,
+  getCategories,
+  getCategoryIndicators,
+  getSelectedCategory
 } from './lts-explore-map-selectors';
 
 const actions = { ...fetchActions, ...modalActions };

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -104,7 +104,7 @@ export const getDefaultColumns = createSelector(
       selectedIndicatorHeader,
       'lts_document',
       'lts_date',
-      'ndce_ghg'
+      'lts_ghg'
     ];
 
     const columns = columnIds.map(id => {

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
@@ -1,12 +1,12 @@
 import { createSelector } from 'reselect';
 import { getColorByIndex, createLegendBuckets } from 'utils/map';
-import { deburrUpper } from 'app/utils';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import { PATH_LAYERS } from 'app/data/constants';
+import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
@@ -76,30 +76,6 @@ export const getMapIndicator = createSelector(
   }
 );
 
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
-
 export const MAP_COLORS = [
   [
     'rgb(255, 108, 47)',
@@ -145,7 +121,7 @@ export const getPathsWithStyles = createSelector(
         if (!locations) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -156,19 +132,19 @@ export const getPathsWithStyles = createSelector(
           ? locations[europeSlug]
           : locations[iso];
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex, MAP_COLORS);
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
-              fill: color ,
+              ...COUNTRY_STYLES.default,
+              fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }
@@ -211,7 +187,7 @@ export const summarizeIndicators = createSelector(
     // ONLY country totals currently displayed in component
     labels.forEach(label => {
       summaryData[label.slug] = {
-        includesEU:false,
+        includesEU: false,
         countries: {
           value: 0,
           max: locations.length,
@@ -245,8 +221,8 @@ export const summarizeIndicators = createSelector(
       const location = indicator.locations[l];
       const type = location.label_slug;
       if (type) {
-        if (l == 'EU28') summaryData[type].includesEU = true;
-        summaryData[type].countries.value += l == 'EU28' ? 28 : 1;
+        if (l === 'EU28') summaryData[type].includesEU = true;
+        summaryData[type].countries.value += l === 'EU28' ? 28 : 1;
         if (emissionsIndicator.locations[l]) {
           summaryData[type].emissions.value += parseFloat(
             emissionsIndicator.locations[l].value
@@ -258,27 +234,32 @@ export const summarizeIndicators = createSelector(
       summaryData[type].emissions.value = parseFloat(
         summaryData[type].emissions.value.toFixed(1)
       );
-      let count = summaryData[type].countries.value;
+      const count = summaryData[type].countries.value;
       summaryData[type].countries.opts.label = (() => {
         switch (type) {
           case 'enhance_2020':
-            return '<strong>countr'+(count == 1 ? 'y has' : 'ies have')+' stated their intention to <span title="Definition: Strengthening mitigation ambition and/or increasing adaptation action in the 2020 NDC.">enhance ambition or action</span> in an NDC by 2020';
-            break;
+            return `<strong>countr${
+              count === 1 ? 'y has' : 'ies have'
+            } stated their intention to <span title="Definition: Strengthening mitigation ambition and/or increasing adaptation action in the 2020 NDC.">enhance ambition or action</span> in an NDC by 2020`;
           case 'intend_2020':
-            return '<strong>countr'+(count == 1 ? 'y has' : 'ies have')+' stated their intention to <span title="Definition: Includes providing information to improve the clarity of the NDC or on measures to implement the current NDC.">update</span> an NDC by 2020';
-            break;
+            return `<strong>countr${
+              count === 1 ? 'y has' : 'ies have'
+            } stated their intention to <span title="Definition: Includes providing information to improve the clarity of the NDC or on measures to implement the current NDC.">update</span> an NDC by 2020`;
           case 'submitted_2020':
-            return '<strong>countr'+(count == 1 ? 'y has' : 'ies have')+' submitted a 2020 NDC';
-            break;
+            return `<strong>countr${
+              count === 1 ? 'y has' : 'ies have'
+            } submitted a 2020 NDC`;
           default:
-            return '<strong>countr'+(count == 1 ? 'y' : 'ies')+'';
-            break;
+            return `<strong>countr${count === 1 ? 'y' : 'ies'}`;
         }
-      })()
-      if (summaryData[type].includesEU) summaryData[type].countries.opts.label += " (including the European Union)";
-      summaryData[type].countries.opts.label += `</strong>, representing <span title="2014 emissions data">${summaryData[
+      })();
+      if (summaryData[type].includesEU) {
+        summaryData[type].countries.opts.label +=
+          ' (including the European Union)';
+      }
+      summaryData[
         type
-      ].emissions.value}% of global emissions</span>`;
+      ].countries.opts.label += `</strong>, representing <span title="2014 emissions data">${summaryData[type].emissions.value}% of global emissions</span>`;
     });
     return summaryData;
   }

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -178,10 +178,8 @@ class NDCSExploreMap extends PureComponent {
                       className={styles.handCursorIcon}
                     />
                     <span>
-                      Explore which countries have submitted long-term
-                      strategies thus far below. Visit Climate Watch in the
-                      coming months for in-depth analysis of long-term
-                      strategies.
+                      Explore the interactive map to understand which countries
+                      have submitted new or updated NDCs.
                     </span>
                   </p>
                   <Map

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -7,6 +7,7 @@ import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { PATH_LAYERS } from 'app/data/constants';
 import { getSelectedIndicator } from 'components/ndcs/ndcs-map/ndcs-map-selectors';
+import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
@@ -58,30 +59,6 @@ export const getMapIndicator = createSelector(
   }
 );
 
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
-
 export const getPathsWithStyles = createSelector(
   [getMapIndicator],
   indicator => {
@@ -94,7 +71,7 @@ export const getPathsWithStyles = createSelector(
         if (!locations) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -102,19 +79,19 @@ export const getPathsWithStyles = createSelector(
         const iso = path.properties && path.properties.id;
         const countryData = locations[iso];
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex);
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
+              ...COUNTRY_STYLES.default,
               fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -67,8 +67,7 @@ export const getSelectedCategory = createSelector(
   (selected, categories = []) => {
     if (!categories || !categories.length) return null;
     const defaultCategory =
-      categories.find(cat => cat.value === 'longterm_strategy') ||
-      categories[0];
+      categories.find(cat => cat.value === 'unfccc_process') || categories[0];
     if (selected) {
       return (
         categories.find(category => category.value === selected) ||
@@ -94,7 +93,8 @@ export const getSelectedIndicator = createSelector(
   [state => state.indicatorSelected, getCategoryIndicators],
   (selected, indicators = []) => {
     if (!indicators || !indicators.length) return {};
-    const defaultSelection = indicators[0];
+    const defaultSelection =
+      indicators.find(i => i.value === 'submission') || indicators[0];
     return selected
       ? indicators.find(indicator => indicator.value === selected) ||
           defaultSelection

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -152,10 +152,6 @@ export const getEmissionsCardData = createSelector(
     if (!emissionsIndicator) return null;
 
     const emissionPercentages = emissionsIndicator.locations;
-    const totalEmissions = Object.values(emissionPercentages).reduce(
-      (a, b) => a + parseFloat(b.value),
-      0
-    );
     const data = legend.map(legendItem => {
       let legendItemValue = 0;
       Object.entries(selectedIndicator.locations).forEach(entry => {
@@ -169,7 +165,7 @@ export const getEmissionsCardData = createSelector(
       });
       return {
         name: camelCase(legendItem.name),
-        value: percentage(legendItemValue, totalEmissions)
+        value: legendItemValue
       };
     });
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -9,11 +9,6 @@ import { getLocationParamUpdated } from 'utils/navigation';
 
 import fetchActions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
-import {
-  getCategories,
-  getCategoryIndicators,
-  getSelectedCategory
-} from 'components/ndcs/ndcs-map/ndcs-map-selectors';
 
 import Component from './ndcs-explore-map-component';
 
@@ -24,7 +19,10 @@ import {
   getLinkToDataExplorer,
   getEmissionsCardData,
   getLegend,
-  getSummaryCardData
+  getSummaryCardData,
+  getCategories,
+  getCategoryIndicators,
+  getSelectedCategory
 } from './ndcs-explore-map-selectors';
 
 const actions = { ...fetchActions, ...modalActions };

--- a/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz-selectors.js
@@ -5,6 +5,7 @@ import sortBy from 'lodash/sortBy';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { PATH_LAYERS } from 'app/data/constants';
+import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
@@ -85,30 +86,6 @@ export const getMapIndicator = createSelector(
   }
 );
 
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
-
 export const MAP_COLORS = [
   ['rgb(55, 104, 141)', 'rgb(164, 164, 164)'],
   ['rgb(55, 104, 141)', 'rgb(164, 164, 164)']
@@ -126,7 +103,7 @@ export const getPathsWithStyles = createSelector(
         if (!locations) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -134,19 +111,19 @@ export const getPathsWithStyles = createSelector(
         const iso = path.properties && path.properties.id;
         const countryData = locations[iso];
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex, MAP_COLORS);
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
+              ...COUNTRY_STYLES.default,
               fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }
@@ -201,10 +178,8 @@ export const summarizeIndicators = createSelector(
               switch (slug) {
                 case 'submitted':
                   return 'countries have submitted a long-term strategy document';
-                  break;
                 default:
                   return 'countries';
-                  break;
               }
             })()
           }
@@ -233,7 +208,7 @@ export const summarizeIndicators = createSelector(
           ? 'submitted'
           : 'not_submitted'; // location.label_slug;
       if (type) {
-        summaryData[type].countries.value++;
+        summaryData[type].countries.value += 1;
         if (emissionsIndicator && emissionsIndicator.locations[l]) {
           summaryData[type].emissions.value += parseFloat(
             emissionsIndicator.locations[l].value

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -6,6 +6,7 @@ import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import { PATH_LAYERS } from 'app/data/constants';
+import { COUNTRY_STYLES } from 'constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
@@ -40,6 +41,7 @@ export const getIndicatorsParsed = createSelector(
             i.labels,
             isos
           );
+
           return {
             label: i.name,
             value: i.slug,
@@ -89,34 +91,10 @@ export const getSelectedIndicator = createSelector(
     const defaultSelection = indicators[0];
     return selected
       ? indicators.find(indicator => indicator.value === selected) ||
-        defaultSelection
+          defaultSelection
       : defaultSelection;
   }
 );
-
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
 
 export const getPathsWithStyles = createSelector(
   [getSelectedIndicator],
@@ -129,7 +107,7 @@ export const getPathsWithStyles = createSelector(
         if (!locations) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -140,19 +118,19 @@ export const getPathsWithStyles = createSelector(
           ? locations[europeSlug]
           : locations[iso];
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (countryData && countryData.label_id) {
           const legendData = legendBuckets[countryData.label_id];
           const color = getColorByIndex(legendBuckets, legendData.index);
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
+              ...COUNTRY_STYLES.default,
               fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }

--- a/app/javascript/app/components/ndcs/shared/constants.js
+++ b/app/javascript/app/components/ndcs/shared/constants.js
@@ -1,0 +1,23 @@
+export const COUNTRY_STYLES = {
+  default: {
+    fill: '#e9e9e9',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
+    strokeWidth: 1,
+    outline: 'none'
+  },
+  hover: {
+    fill: '#e9e9e9',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
+    strokeWidth: 1,
+    outline: 'none'
+  },
+  pressed: {
+    fill: '#e9e9e9',
+    fillOpacity: 1,
+    stroke: '#f5f6f7',
+    strokeWidth: 1,
+    outline: 'none'
+  }
+};

--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -9,11 +9,14 @@ const DonutTooltip = props => {
   const {
     reference,
     chartReference,
-    content: { payload, coordinate }
+    content: { payload, coordinate },
+    data
   } = props;
   if (!payload || !payload[0]) return null;
 
-  const percentage = Math.round(payload[0].value);
+  const total = Object.values(data).reduce((acc, d) => acc + d.value, 0);
+  const percentage = Math.round((payload[0].value * 100) / total);
+
   const legendItemName = capitalize(lowerCase(payload[0].name));
 
   const chartTop = chartReference.getBoundingClientRect().top;
@@ -33,8 +36,8 @@ const DonutTooltip = props => {
 
 DonutTooltip.propTypes = {
   content: PropTypes.object,
-  reference: PropTypes.node,
-  chartReference: PropTypes.node
+  reference: PropTypes.object,
+  chartReference: PropTypes.object
 };
 
 export default DonutTooltip;

--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -9,14 +9,11 @@ const DonutTooltip = props => {
   const {
     reference,
     chartReference,
-    content: { payload, coordinate },
-    data
+    content: { payload, coordinate }
   } = props;
   if (!payload || !payload[0]) return null;
 
-  const total = Object.values(data).reduce((acc, d) => acc + d.value, 0);
-  const percentage = Math.round((payload[0].value * 100) / total);
-
+  const percentage = Math.round(payload[0].value);
   const legendItemName = capitalize(lowerCase(payload[0].name));
 
   const chartTop = chartReference.getBoundingClientRect().top;
@@ -35,7 +32,9 @@ const DonutTooltip = props => {
 };
 
 DonutTooltip.propTypes = {
-  content: PropTypes.object
+  content: PropTypes.object,
+  reference: PropTypes.node,
+  chartReference: PropTypes.node
 };
 
 export default DonutTooltip;

--- a/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/ndcs-map/ndcs-map-selectors.js
@@ -5,6 +5,7 @@ import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import { PATH_LAYERS } from 'app/data/constants';
+import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
@@ -124,30 +125,6 @@ export const getSelectedCategory = createSelector(
   }
 );
 
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
-
 export const MAP_COLORS = [
   ['#0677B3', '#1ECDB0'],
   ['#0677B3', '#1ECDB0', '#00A0CA'],
@@ -178,7 +155,7 @@ export const getPathsWithStyles = createSelector(
         if (!locations) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -189,7 +166,7 @@ export const getPathsWithStyles = createSelector(
           ? locations[europeSlug]
           : locations[iso];
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (countryData && countryData.label_id) {
           const legendData = legendBuckets[countryData.label_id];
           const color = getColorByIndex(
@@ -198,14 +175,14 @@ export const getPathsWithStyles = createSelector(
             MAP_COLORS
           );
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
+              ...COUNTRY_STYLES.default,
               fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }
@@ -229,7 +206,9 @@ const getDataExplorerParams = createSelector(
     if (
       !has(metadata, 'ndc-content.sectors') ||
       !has(metadata, 'ndc-content.categories')
-    ) { return null; }
+    ) {
+      return null;
+    }
     const { sectorName, categorySlug } = DEFAULT_DOWNLOAD_LINK_PARAMS;
     const agricultureSector = metadata['ndc-content'].sectors.find(
       ({ name }) => name === sectorName

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-selectors.js
@@ -8,30 +8,7 @@ import {
   AGRICULTURE_INDICATORS_NAMES,
   AGRICULTURE_INDICATORS_MAP_BUCKETS
 } from 'app/data/constants';
-
-const countryStyles = {
-  default: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  hover: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  },
-  pressed: {
-    fill: '#e9e9e9',
-    fillOpacity: 1,
-    stroke: '#f5f6f7',
-    strokeWidth: 1,
-    outline: 'none'
-  }
-};
+import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 export const MAP_COLORS = [
   ['#0677B3', '#1ECDB0'],
@@ -85,10 +62,12 @@ const getYears = createSelector(getAgricultureData, data => {
   if (!data) return null;
   const years = data.map(d => d.year);
   const uniqueYears = [...new Set(years)];
-  return uniqueYears.sort((a, b) => b - a).map(y => ({
-    label: y.toString(),
-    value: y.toString()
-  }));
+  return uniqueYears
+    .sort((a, b) => b - a)
+    .map(y => ({
+      label: y.toString(),
+      value: y.toString()
+    }));
 });
 
 export const getYearsWithData = createSelector(
@@ -151,12 +130,14 @@ export const getMapData = createSelector(
   [getSelectedIndicator, getSelectedYear, getAgricultureData],
   (indicator, year, data) => {
     if (!indicator || !year) return null;
-    return data.filter(d => d.year === parseInt(year.value, 10)).map(l => ({
-      iso: l.iso_code3,
-      value: l[indicator.value],
-      unit: indicator.unit,
-      bucketIndex: getBucketIndex(indicator.value, l[indicator.value])
-    }));
+    return data
+      .filter(d => d.year === parseInt(year.value, 10))
+      .map(l => ({
+        iso: l.iso_code3,
+        value: l[indicator.value],
+        unit: indicator.unit,
+        bucketIndex: getBucketIndex(indicator.value, l[indicator.value])
+      }));
   }
 );
 
@@ -166,7 +147,7 @@ const indicatorValueFormat = (value, unit) => {
   return `${format(',.2s')(value)}`;
 };
 
-const getWidth = (value, maxValue) => value * 100 / maxValue;
+const getWidth = (value, maxValue) => (value * 100) / maxValue;
 
 export const getTopTenCountries = createSelector(
   [getMapData, getCountries, getSelectedIndicator],
@@ -214,7 +195,7 @@ export const getPathsWithStyles = createSelector(
         if (!mapData) {
           paths.push({
             ...path,
-            countryStyles
+            COUNTRY_STYLES
           });
           return null;
         }
@@ -222,7 +203,7 @@ export const getPathsWithStyles = createSelector(
         const iso = path.properties && path.properties.id;
         const countryData = mapData.filter(c => c.iso === iso);
 
-        let style = countryStyles;
+        let style = COUNTRY_STYLES;
         if (!isEmpty(countryData)) {
           const color = getColorByIndex(
             AGRICULTURE_INDICATORS_MAP_BUCKETS[selectedIndicator.value],
@@ -230,14 +211,14 @@ export const getPathsWithStyles = createSelector(
             MAP_COLORS
           );
           style = {
-            ...countryStyles,
+            ...COUNTRY_STYLES,
             default: {
-              ...countryStyles.default,
+              ...COUNTRY_STYLES.default,
               fill: color,
               fillOpacity: 1
             },
             hover: {
-              ...countryStyles.hover,
+              ...COUNTRY_STYLES.hover,
               fill: color,
               fillOpacity: 1
             }

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -17,7 +17,7 @@ const fetchNDCS = createThunkAction('fetchNDCS', () => (dispatch, state) => {
     !ndcs.loading
   ) {
     dispatch(fetchNDCSInit());
-    fetch('/api/v1/ndcs?filter=map')
+    fetch('/api/v1/ndcs?filter=map&source[]=CAIT&source[]=WB&source[]=NDC')
       .then(response => {
         if (response.ok) return response.json();
         throw Error(response.statusText);

--- a/app/javascript/app/utils/map.js
+++ b/app/javascript/app/utils/map.js
@@ -46,7 +46,12 @@ export function getColorByIndex(data, index, colors = buckets) {
   return colors[length - 2][index - 1] || '#E5E5EB';
 }
 
-export function createLegendBuckets(locations, labels, isos) {
+export function createLegendBuckets(
+  locations,
+  labels,
+  isos,
+  notApplicableLabel = 'Not Applicable'
+) {
   if (Object.keys(locations) === isos) return labels;
   // An index of -2 is applied in the backend to 'No Data Submitted'
   const notSubmitted = Object.keys(labels).find(l => labels[l].index === -2);
@@ -54,10 +59,10 @@ export function createLegendBuckets(locations, labels, isos) {
     const notApplicableKey = parseInt(notSubmitted, 10) + 1;
     return {
       ...labels,
-      [notApplicableKey]: { name: 'Not Applicable', index: 0 }
+      [notApplicableKey]: { name: notApplicableLabel, index: 0 }
     };
   }
-  return { ...labels, 0: { name: 'Not Applicable', index: 0 } };
+  return { ...labels, 0: { name: notApplicableLabel, index: 0 } };
 }
 
 export default {


### PR DESCRIPTION
This PR fixes several feedback problems:

- 'Counter' card (First card in LTS explorer) : Now is showing LTS document submission count always
- Updates NDCs explore text on top of the map
- Sort and fix legends and donut chart for LTS and NDC explorer (Now we have a 'Not applicable' or 'No information' at the bottom that has the count of countries without data). There are still a couple of little bugs with the donut chart that are in a new bug task on PT.
- Default for LTS and NDCs categories and indicators
- Apply new data
- Links to LTS country from table
- Filter sources of NDC explore

To try: Remember to run:` bundle exec rails indc:import`

Note: Some selectors have been duplicated as they will produce more bugs in the way we are using selectors. We may do a refactor in the future to pass only the state instead of individual properties.

![image](https://user-images.githubusercontent.com/9701591/70558041-64438100-1b84-11ea-8086-1be206337b34.png)