### PR TITLE
Feature/move card theme to styles folder

### DIFF
--- a/app/javascript/app/components/country/country-lts-overview/country-lts-overview-component.jsx
+++ b/app/javascript/app/components/country/country-lts-overview/country-lts-overview-component.jsx
@@ -8,18 +8,11 @@ import Loading from 'components/loading';
 import NoContent from 'components/no-content';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import introTheme from 'styles/themes/intro/intro-simple.scss';
+import cardTheme from 'styles/themes/card/card-light.scss';
 import layout from 'styles/layout.scss';
 import NdcCountryAccordionProvider from 'providers/ndc-country-accordion-provider';
 
 import styles from './country-lts-overview-styles.scss';
-
-const { card, contentContainer, data, title } = styles;
-const theme = {
-  card,
-  contentContainer,
-  data,
-  title
-};
 
 const CardRow = ({ rowData }) => (
   <React.Fragment>
@@ -46,20 +39,20 @@ const Cards = ({ cardData }) => (
           <div className="grid-column-item">
             {cardData ? (
               <div className={styles.cardsRowContainer}>
-                <Card title="Submission" contentFirst theme={theme}>
+                <Card title="Submission" contentFirst theme={cardTheme}>
                   <div className={styles.cardContent}>
                     <CardRow rowData={cardData.lts_document} />
                     <CardRow rowData={cardData.lts_date} />
                   </div>
                 </Card>
-                <Card title="Mitigation" contentFirst theme={theme}>
+                <Card title="Mitigation" contentFirst theme={cardTheme}>
                   <div className={styles.cardContent}>
                     <CardRow rowData={cardData.lts_target} />
                     <CardRow rowData={cardData.lts_m_tt} />
                     <CardRow rowData={cardData.lts_zero} />
                   </div>
                 </Card>
-                <Card title="Modeling" contentFirst theme={theme}>
+                <Card title="Modeling" contentFirst theme={cardTheme}>
                   <div className={styles.cardContent}>
                     <CardRow rowData={cardData.lts_m_sce_yn} />
                     <CardRow rowData={cardData.lts_m_model} />

--- a/app/javascript/app/components/country/country-lts-overview/country-lts-overview-styles.scss
+++ b/app/javascript/app/components/country/country-lts-overview/country-lts-overview-styles.scss
@@ -103,20 +103,6 @@
   min-height: 450px;
 }
 
-.card {
-  color: "pink";
-  border-radius: 6px;
-  border-color: transparent;
-}
-
-.contentContainer {
-  background-color: #ecf1fa;
-  display: flex;
-  align-items: center;
-  padding: 0 30px;
-  min-height: 70px;
-}
-
 .cardRow {
   background-color: white;
   padding: 16px 28px 24px;
@@ -124,12 +110,4 @@
   &:not(:last-child) {
     border-bottom: 2px solid #e8ecf5;
   }
-}
-
-.title {
-  font-weight: $font-weight;
-}
-
-.data {
-  background-color: white;
 }

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -57,6 +57,8 @@ $placeholder-gray: #393f44;
 $slate: #555;
 $link-color: #0845cb;
 $ebony-clay: #233140;
+$catskill-white: #e8ecf5;
+$link-water: #ecf1fa;
 
 $bg-main: #00548b;
 $bg-blue: #1b3b5a;

--- a/app/javascript/app/styles/themes/card/card-light.scss
+++ b/app/javascript/app/styles/themes/card/card-light.scss
@@ -1,0 +1,25 @@
+@import '~styles/settings.scss';
+
+.card {
+  color: "pink";
+  border-radius: 6px;
+  border-color: transparent;
+  box-shadow: 0 2px 20px 0 #E8ECF5;
+  margin: 0.9375rem;
+}
+
+.contentContainer {
+  background-color: #ecf1fa;
+  display: flex;
+  align-items: center;
+  padding: 0 30px;
+  min-height: 70px;
+}
+
+.title {
+  font-weight: $font-weight;
+}
+
+.data {
+  background-color: white;
+}

--- a/app/javascript/app/styles/themes/card/card-light.scss
+++ b/app/javascript/app/styles/themes/card/card-light.scss
@@ -1,15 +1,14 @@
 @import '~styles/settings.scss';
 
 .card {
-  color: "pink";
   border-radius: 6px;
   border-color: transparent;
-  box-shadow: 0 2px 20px 0 #e8ecf5;
+  box-shadow: 0 2px 20px 0 $catskill-white;
   margin: 15px;
 }
 
 .contentContainer {
-  background-color: #ecf1fa;
+  background-color: $link-water;
   display: flex;
   align-items: center;
   padding: 0 30px;
@@ -21,5 +20,5 @@
 }
 
 .data {
-  background-color: white;
+  background-color: $white;
 }

--- a/app/javascript/app/styles/themes/card/card-light.scss
+++ b/app/javascript/app/styles/themes/card/card-light.scss
@@ -4,8 +4,8 @@
   color: "pink";
   border-radius: 6px;
   border-color: transparent;
-  box-shadow: 0 2px 20px 0 #E8ECF5;
-  margin: 0.9375rem;
+  box-shadow: 0 2px 20px 0 #e8ecf5;
+  margin: 15px;
 }
 
 .contentContainer {


### PR DESCRIPTION
This tiny PR moves the new theme for card component to `styles/themes/card` folder, according to the [@Bluesmile82 comment](https://github.com/Vizzuality/climate-watch/pull/916#discussion_r357559996). It also adds the box-shadow to the card-light theme, as it is done on the design.
[PIVOTAL](https://www.pivotaltracker.com/story/show/170005132)