### PR TITLE
Fix search filtering order

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -156,7 +156,7 @@ LTSExploreMapContainer.propTypes = {
   isoCountries: PropTypes.array.isRequired,
   setModalMetadata: PropTypes.func.isRequired,
   fetchLTS: PropTypes.func.isRequired,
-  query: PropTypes.object,
+  query: PropTypes.string,
   summaryData: PropTypes.object,
   indicator: PropTypes.object
 };

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -8,7 +8,7 @@ import { getMapIndicator } from 'components/ndcs/lts-explore-map/lts-explore-map
 const getCountries = state => state.countries || null;
 const getCategories = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
-const getQuery = state => deburrUpper(state.query) || '';
+export const getQuery = state => deburrUpper(state.query) || '';
 
 export const getISOCountries = createSelector([getCountries], countries =>
   countries.map(country => country.iso_code3)
@@ -63,22 +63,6 @@ export const tableGetSelectedData = createSelector(
   }
 );
 
-export const tableGetFilteredData = createSelector(
-  [tableGetSelectedData, getQuery],
-  (data, query) => {
-    if (!data || isEmpty(data)) return null;
-    return data.filter(d => {
-      let match = false;
-      Object.keys(d).forEach(col => {
-        if (deburrUpper(d[col]).indexOf(query) > -1) {
-          match = true;
-        }
-      });
-      return match;
-    });
-  }
-);
-
 const headerChanges = {
   'Communication of Long-term Strategy':
     'Latest submission (Current selection)',
@@ -116,7 +100,7 @@ export const getDefaultColumns = createSelector(
 );
 
 export const addIndicatorColumn = createSelector(
-  [tableGetFilteredData, getMapIndicator, getSelectedIndicatorHeader],
+  [tableGetSelectedData, getMapIndicator, getSelectedIndicatorHeader],
   (data, selectedIndicator, selectedIndicatorHeader) => {
     if (!data || isEmpty(data)) return null;
     const updatedTableData = data;
@@ -151,7 +135,7 @@ const addDocumentTarget = createSelector([addIndicatorColumn], data => {
   });
 });
 
-export const getFilteredData = createSelector(
+const getFilteredData = createSelector(
   [addDocumentTarget, getDefaultColumns],
   (data, columnHeaders) => {
     if (!data || isEmpty(data)) return null;
@@ -164,6 +148,22 @@ export const getFilteredData = createSelector(
         }
       });
       return filteredAndChangedHeadersD;
+    });
+  }
+);
+
+export const getFilteredDataBySearch = createSelector(
+  [getFilteredData, getQuery],
+  (data, query) => {
+    if (!data || isEmpty(data)) return null;
+    return data.filter(d => {
+      let match = false;
+      Object.keys(d).forEach(col => {
+        if (deburrUpper(d[col]).indexOf(query) > -1) {
+          match = true;
+        }
+      });
+      return match;
     });
   }
 );

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { deburrUpper } from 'app/utils';
+import { deburrUpper, filterQuery } from 'app/utils';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
 import isEmpty from 'lodash/isEmpty';
@@ -156,14 +156,6 @@ export const getFilteredDataBySearch = createSelector(
   [getFilteredData, getQuery],
   (data, query) => {
     if (!data || isEmpty(data)) return null;
-    return data.filter(d => {
-      let match = false;
-      Object.keys(d).forEach(col => {
-        if (deburrUpper(d[col]).indexOf(query) > -1) {
-          match = true;
-        }
-      });
-      return match;
-    });
+    return filterQuery(data, query);
   }
 );

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table.js
@@ -11,7 +11,7 @@ import Component from './lts-explore-table-component';
 
 import {
   getISOCountries,
-  getFilteredData,
+  getFilteredDataBySearch,
   getDefaultColumns,
   getTitleLinks
 } from './lts-explore-table-selectors';
@@ -36,7 +36,7 @@ const mapStateToProps = (state, { location }) => {
     loading,
     query: LTSWithSelection.query,
     isoCountries: getISOCountries(LTSWithSelection),
-    tableData: getFilteredData(LTSWithSelection),
+    tableData: getFilteredDataBySearch(LTSWithSelection),
     columns: getDefaultColumns(LTSWithSelection),
     titleLinks: getTitleLinks(LTSWithSelection)
   };

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-table/ndcs-enhancements-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-table/ndcs-enhancements-table.js
@@ -3,18 +3,14 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import qs from 'query-string';
-import { handleAnalytics } from 'utils/analytics';
-import { isCountryIncluded } from 'app/utils';
 import { getLocationParamUpdated } from 'utils/navigation';
-import { europeSlug, europeanCountries } from 'app/data/european-countries';
-
 import { actions as fetchActions } from 'pages/ndcs-enhancements';
 
 import Component from './ndcs-enhancements-table-component';
 
 import {
   getISOCountries,
-  tableRemoveIsoFromData,
+  getFilteredDataBySearch,
   getDefaultColumns
 } from './ndcs-enhancements-table-selectors';
 
@@ -34,7 +30,7 @@ const mapStateToProps = (state, { location }) => {
     loading,
     query: ndcsEnhancementsWithSelection.query,
     isoCountries: getISOCountries(ndcsEnhancementsWithSelection),
-    tableData: tableRemoveIsoFromData(ndcsEnhancementsWithSelection),
+    tableData: getFilteredDataBySearch(ndcsEnhancementsWithSelection),
     columns: getDefaultColumns(ndcsEnhancementsWithSelection)
   };
 };
@@ -44,10 +40,6 @@ class NDCSEnhancementsTableContainer extends PureComponent {
     super(props);
     this.state = {};
   }
-
-  handleSearchChange = query => {
-    this.updateUrlParam({ name: 'search', value: query });
-  };
 
   componentWillMount() {
     this.props.fetchNDCSEnhancements();
@@ -79,7 +71,8 @@ class NDCSEnhancementsTableContainer extends PureComponent {
 NDCSEnhancementsTableContainer.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  isoCountries: PropTypes.array.isRequired,
+  query: PropTypes.string,
+  tableData: PropTypes.array,
   fetchNDCSEnhancements: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { deburrUpper } from 'app/utils';
+import { filterQuery } from 'app/utils';
 import {
   getSelectedIndicatorHeader,
   addIndicatorColumn,
@@ -73,14 +73,6 @@ export const getFilteredDataBySearch = createSelector(
   [getFilteredData, getQuery],
   (data, query) => {
     if (!data || isEmpty(data)) return null;
-    return data.filter(d => {
-      let match = false;
-      Object.keys(d).forEach(col => {
-        if (deburrUpper(d[col]).indexOf(query) > -1) {
-          match = true;
-        }
-      });
-      return match;
-    });
+    return filterQuery(data, query);
   }
 );

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -1,9 +1,11 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import { deburrUpper } from 'app/utils';
 import {
   getSelectedIndicatorHeader,
   addIndicatorColumn,
-  getIndicatorsParsed
+  getIndicatorsParsed,
+  getQuery
 } from 'components/ndcs/lts-explore-table/lts-explore-table-selectors';
 
 const getCountries = state => state.countries || null;
@@ -40,7 +42,7 @@ export const getDefaultColumns = createSelector(
   }
 );
 
-export const getFilteredData = createSelector(
+const getFilteredData = createSelector(
   [addIndicatorColumn, getDefaultColumns],
   (data, columnHeaders) => {
     if (!data || isEmpty(data)) return null;
@@ -66,3 +68,19 @@ export const getTitleLinks = createSelector([addIndicatorColumn], data => {
     }
   ]);
 });
+
+export const getFilteredDataBySearch = createSelector(
+  [getFilteredData, getQuery],
+  (data, query) => {
+    if (!data || isEmpty(data)) return null;
+    return data.filter(d => {
+      let match = false;
+      Object.keys(d).forEach(col => {
+        if (deburrUpper(d[col]).indexOf(query) > -1) {
+          match = true;
+        }
+      });
+      return match;
+    });
+  }
+);

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
@@ -87,7 +87,7 @@ NDCSExploreTableContainer.propTypes = {
   location: PropTypes.object.isRequired,
   tableData: PropTypes.array,
   columns: PropTypes.array,
-  query: PropTypes.object
+  query: PropTypes.string
 };
 
 export default withRouter(

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
@@ -11,7 +11,7 @@ import Component from './ndcs-explore-table-component';
 
 import {
   getISOCountries,
-  getFilteredData,
+  getFilteredDataBySearch,
   getDefaultColumns,
   getTitleLinks
 } from './ndcs-explore-table-selectors';
@@ -35,7 +35,7 @@ const mapStateToProps = (state, { location }) => {
     loading,
     query: ndcsNDCSWithSelection.query,
     isoCountries: getISOCountries(ndcsNDCSWithSelection),
-    tableData: getFilteredData(ndcsNDCSWithSelection),
+    tableData: getFilteredDataBySearch(ndcsNDCSWithSelection),
     columns: getDefaultColumns(ndcsNDCSWithSelection),
     titleLinks: getTitleLinks(ndcsNDCSWithSelection)
   };

--- a/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
@@ -76,24 +76,8 @@ export const tableGetSelectedData = createSelector(
   }
 );
 
-export const tableGetFilteredData = createSelector(
-  [tableGetSelectedData, getQuery],
-  (data, query) => {
-    if (!data || isEmpty(data)) return null;
-    return data.filter(d => {
-      let match = false;
-      Object.keys(d).forEach(col => {
-        if (deburrUpper(d[col]).indexOf(query) > -1) {
-          match = true;
-        }
-      });
-      return match;
-    });
-  }
-);
-
 export const tableRemoveIsoFromData = createSelector(
-  [tableGetFilteredData],
+  [tableGetSelectedData],
   data => {
     if (!data || isEmpty(data)) return null;
 
@@ -145,6 +129,38 @@ export const getDefaultColumns = createSelector(
     return columnIds.map(id => {
       const match = indicators.find(indicator => indicator.value === id);
       return match ? match.label : id;
+    });
+  }
+);
+
+const getFilteredData = createSelector(
+  [tableRemoveIsoFromData, getDefaultColumns],
+  (data, columnHeaders) => {
+    if (!data || isEmpty(data)) return null;
+    return data.map(d => {
+      const filteredHeadersD = {};
+      Object.keys(d).forEach(k => {
+        if (columnHeaders.includes(k)) {
+          filteredHeadersD[k] = d[k];
+        }
+      });
+      return filteredHeadersD;
+    });
+  }
+);
+
+export const getFilteredDataBySearch = createSelector(
+  [getFilteredData, getQuery],
+  (data, query) => {
+    if (!data || isEmpty(data)) return null;
+    return data.filter(d => {
+      let match = false;
+      Object.keys(d).forEach(col => {
+        if (deburrUpper(d[col]).indexOf(query) > -1) {
+          match = true;
+        }
+      });
+      return match;
     });
   }
 );

--- a/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { deburrUpper } from 'app/utils';
+import { deburrUpper, filterQuery } from 'app/utils';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
 import isEmpty from 'lodash/isEmpty';
@@ -153,15 +153,7 @@ export const getFilteredDataBySearch = createSelector(
   [getFilteredData, getQuery],
   (data, query) => {
     if (!data || isEmpty(data)) return null;
-    return data.filter(d => {
-      let match = false;
-      Object.keys(d).forEach(col => {
-        if (deburrUpper(d[col]).indexOf(query) > -1) {
-          match = true;
-        }
-      });
-      return match;
-    });
+    return filterQuery(data, query);
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table.js
@@ -11,7 +11,7 @@ import Component from './ndcs-lts-table-component';
 
 import {
   getISOCountries,
-  tableRemoveIsoFromData,
+  getFilteredDataBySearch,
   getDefaultColumns
 } from './ndcs-lts-table-selectors';
 
@@ -31,7 +31,7 @@ const mapStateToProps = (state, { location }) => {
     loading,
     query: ndcsLTSWithSelection.query,
     isoCountries: getISOCountries(ndcsLTSWithSelection),
-    tableData: tableRemoveIsoFromData(ndcsLTSWithSelection),
+    tableData: getFilteredDataBySearch(ndcsLTSWithSelection),
     columns: getDefaultColumns(ndcsLTSWithSelection)
   };
 };

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -43,7 +43,8 @@ export const compareIndexByKey = attribute =>
     const divideByDot = /(.*)\.(.*)/;
     const isNotNumber = /[^0-9.]/;
     const match = x => x[attribute].match(divideByDot);
-    const fullNumber = x => (match(x) && match(x)[1]) || x[attribute].match(divideByDot);
+    const fullNumber = x =>
+      (match(x) && match(x)[1]) || x[attribute].match(divideByDot);
     const decimalNumber = x => match(x) && match(x)[2];
     const fullA = fullNumber(a);
     const fullB = fullNumber(b);
@@ -78,7 +79,8 @@ export function importAllImagesFromFolder(r) {
   return images;
 }
 
-export const truncateDecimals = (number, decimalPlaces) => number.toFixed(decimalPlaces) / 1;
+export const truncateDecimals = (number, decimalPlaces) =>
+  number.toFixed(decimalPlaces) / 1;
 
 const r2lWrittedLanguages = ['AR'];
 export function isR2LWrittedLanguage(lang) {
@@ -96,7 +98,8 @@ export const sanitize = data => {
   return data;
 };
 
-export const sanitizeUrl = url => (url.startsWith('http') ? url : `http://${url}`);
+export const sanitizeUrl = url =>
+  (url.startsWith('http') ? url : `http://${url}`);
 
 export const hexToRgba = (hex, opacity) => {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -129,11 +132,16 @@ export const wordWrap = (long_string, max_char) => {
   for (let i = 0; i < split_string.length; i++) {
     const word = split_string[i];
 
-    if (sum_length_of_words(split_out[split_out.length - 1]) + word.length > max_char) {
+    if (
+      sum_length_of_words(split_out[split_out.length - 1]) + word.length >
+      max_char
+    ) {
       split_out = split_out.concat([[]]);
     }
 
-    split_out[split_out.length - 1] = split_out[split_out.length - 1].concat(word);
+    split_out[split_out.length - 1] = split_out[split_out.length - 1].concat(
+      word
+    );
   }
 
   for (let i = 0; i < split_out.length; i++) {
@@ -185,7 +193,8 @@ export const replaceAll = (text, replacements) => {
   return updatedText;
 };
 
-export const findEqual = (parent, children, value) => children.find(c => parent[c] === value);
+export const findEqual = (parent, children, value) =>
+  children.find(c => parent[c] === value);
 
 export function noEmptyValues(object) {
   const noEmptyResult = {};
@@ -198,7 +207,8 @@ export function noEmptyValues(object) {
 }
 
 export const arrayToSentence = arr => {
-  const sentence = arr.length > 1 ? `${arr.slice(0, arr.length - 1).join(', ')}, and ` : '';
+  const sentence =
+    arr.length > 1 ? `${arr.slice(0, arr.length - 1).join(', ')}, and ` : '';
   return `${sentence}${arr.slice(-1)}`;
 };
 
@@ -208,12 +218,25 @@ export function precentageTwoPlacesRound(percentage) {
 }
 
 export function orderByColumns(columnOrder) {
-  const indexOf = col => (columnOrder.indexOf(col) > -1 ? columnOrder.indexOf(col) : Infinity);
+  const indexOf = col =>
+    (columnOrder.indexOf(col) > -1 ? columnOrder.indexOf(col) : Infinity);
   return (a, b) => indexOf(a) - indexOf(b);
 }
 
 export function stripHTML(text) {
   return text.replace(/<(?:.|\n)*?>/gm, '');
+}
+
+export function filterQuery(data, query) {
+  return data.filter(d => {
+    let match = false;
+    Object.keys(d).forEach(col => {
+      if (deburrUpper(d[col]).indexOf(query) > -1) {
+        match = true;
+      }
+    });
+    return match;
+  });
 }
 
 export default {


### PR DESCRIPTION
This PR fixes the problem with the search in LTS - NDCs Explorer and LTS tracker
The order of filtering was not correct on the selectors so some data that was not shown was taken into account on the search.

Note: There are still some cases on some links that the href matches with the search but the text doesn't. I don't think we can do much about this as we are receiving the HTML directly on this case. We could parse it but that would be a different task

![image](https://user-images.githubusercontent.com/9701591/71081641-e5f06b80-218f-11ea-853c-3fbfead778ea.png)
