### PR TITLE
Feature/lts country header

### DIFF
--- a/app/javascript/app/components/button/button-component.jsx
+++ b/app/javascript/app/components/button/button-component.jsx
@@ -46,7 +46,7 @@ const Button = props => {
     <NavLink
       className={classNames}
       to={link}
-      onClick={onClick}
+      onClick={disabled ? e => e.preventDefault() : onClick}
       target={target}
       {...tooltipProps}
     >

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -81,7 +81,7 @@ class CountryNdcOverview extends PureComponent {
     );
   }
 
-  renderCards() {
+  renderLegacyCards() {
     const { sectors, values } = this.props;
     const renderSubtitle = (text, paddingLeft) => (
       <h4 className={cx(styles.subTitle, { [styles.paddedLeft]: paddingLeft })}>
@@ -98,9 +98,9 @@ class CountryNdcOverview extends PureComponent {
                 {renderSubtitle('Adaptation contribution', true)}
               </TabletLandscape>
             </div>
-            <div className={styles.cards}>
+            <div className={styles.legacyCards}>
               <div className="grid-column-item">
-                <div className={styles.cardsRowContainer}>
+                <div className={styles.legacyCardsRowContainer}>
                   <Card title="GHG Target" theme={cardTheme} contentFirst>
                     <div className={styles.cardContent}>
                       {values && values.ghg_target_type ? (
@@ -185,6 +185,82 @@ class CountryNdcOverview extends PureComponent {
           </div>
         </div>
       </div>
+    );
+  }
+
+  renderCards() {
+    const { values } = this.props;
+    return FEATURE_LTS_EXPLORE ? (
+      <div className={styles.row}>
+        <div className={styles.cards}>
+          <Card title="Contribution Type" theme={cardTheme} contentFirst>
+            <div className={styles.cardContent}>
+              {values && values.mitigation_contribution_type ? (
+                <React.Fragment>
+                  <CardRowLight
+                    rowData={{
+                      title: 'Mitigation contribution type',
+                      value: values.mitigation_contribution_type[0].value
+                    }}
+                  />
+                  <CardRowLight
+                    rowData={{
+                      title: 'Target type',
+                      value: values.ghg_target_type[0].value
+                    }}
+                  />
+                  <CardRowLight
+                    rowData={{
+                      title: 'Adaptation included',
+                      value: values.adaptation[0].value
+                    }}
+                  />
+                </React.Fragment>
+              ) : (
+                <div className={styles.noContent}>Not included</div>
+              )}
+            </div>
+          </Card>
+          <Card title="GHG Target" theme={cardTheme} contentFirst>
+            <div className={styles.cardContent}>
+              {values && values.time_target_year ? (
+                <React.Fragment>
+                  <CardRowLight
+                    rowData={{
+                      title: 'Target year',
+                      value: values.time_target_year[0].value
+                    }}
+                  />
+                  <CardRowLight
+                    rowData={{
+                      title: 'Sectors covered',
+                      value: values.coverage_sectors[0].value
+                    }}
+                  />
+                </React.Fragment>
+              ) : (
+                <div className={styles.noContent}>Not included</div>
+              )}
+            </div>
+          </Card>
+          <Card title="Non-GHG Target" theme={cardTheme} contentFirst>
+            <div className={styles.cardContent}>
+              {values && values.non_ghg_target ? (
+                <CardRowLight
+                  rowData={{
+                    title: '',
+                    value: values.non_ghg_target[0].value
+                  }}
+                />
+              ) : (
+                <div className={styles.noContent}>Not included</div>
+              )}
+            </div>
+          </Card>
+        </div>
+      </div>
+    ) : (
+      this.renderLegacyCards()
     );
   }
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -60,7 +60,7 @@
   @include columns((9, 3));
 }
 
-.cards {
+.legacyCards {
   @include columns();
 
   > div {
@@ -72,7 +72,25 @@
   }
 }
 
-.cardsRowContainer {
+.legacyCardsRowContainer {
+  @include columns('shrink', $wrap: false);
+
+  > div {
+    width: 270px;
+  }
+
+  overflow: auto;
+
+  @media #{$tablet-landscape} {
+    @include columns((4, 4, 4));
+
+    > div {
+      width: 100%;
+    }
+  }
+}
+
+.cards {
   @include columns('shrink', $wrap: false);
 
   > div {

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -1,20 +1,89 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { renderRoutes } from 'react-router-config';
+import { Link } from 'react-router-dom';
 import Header from 'components/header';
 import Intro from 'components/intro';
+import Icon from 'components/icon';
+import Button from 'components/button';
 import Search from 'components/search';
 import cx from 'classnames';
 import Sticky from 'react-stickynode';
 import AnchorNav from 'components/anchor-nav';
 import { LTS_COUNTRY } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
+import { TabletLandscape } from 'components/responsive';
+import longArrowBack from 'assets/icons/long-arrow-back.svg';
+import { toStartCase } from 'app/utils';
+import NdcsDocumentsMetaProvider from 'providers/ndcs-documents-meta-provider';
 
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import lightSearch from 'styles/themes/search/search-light.scss';
 import styles from './lts-country-styles.scss';
 
+const getPreviousPathLabel = previousPathname => {
+  const updatedPathname = previousPathname;
+  let lastPathLabel = {
+    '/': 'Home'
+  }[previousPathname];
+  const regexs = [
+    { regex: /countries\/compare/, label: 'country compare' },
+    { regex: /countries/, label: 'country' }
+  ];
+
+  regexs.some(regexWithLabel => {
+    const { regex, label } = regexWithLabel;
+    if (previousPathname && previousPathname.match(regex)) {
+      lastPathLabel = label;
+      return true;
+    }
+    return false;
+  });
+  return lastPathLabel || (updatedPathname && toStartCase(updatedPathname));
+};
+
+const shouldClearPath = pathname => {
+  if (!pathname) return false;
+  const clearRegexps = [/\/ndcs\/country/, /\/error-page/, /\/ndcs\/compare/];
+  if (clearRegexps.some(r => pathname.match(r))) {
+    sessionStorage.setItem('previousLocationPathname', '');
+    return true;
+  }
+  return false;
+};
+
 class LTSCountry extends PureComponent {
+  renderFullTextDropdown() {
+    const { match, documentsOptions } = this.props;
+    return (
+      documentsOptions && (
+        <Button
+          color="yellow"
+          link={`/lts/country/${match.params.iso}/full`}
+          className={styles.viewDocumentButton}
+          disabled
+        >
+          View LTS Document
+        </Button>
+      )
+    );
+  }
+
+  renderCompareButton() {
+    const { match } = this.props;
+    return (
+      <div className={styles.compareButton}>
+        <Button
+          color="yellow"
+          link={`/lts/compare/mitigation?locations=${match.params.iso}`}
+          disabled
+        >
+          {'Compare countries and submissions'}
+        </Button>
+      </div>
+    );
+  }
+
   render() {
     const {
       country,
@@ -24,6 +93,15 @@ class LTSCountry extends PureComponent {
       anchorLinks,
       notSummary
     } = this.props;
+
+    const hasSearch = notSummary;
+    const previousPathname = sessionStorage.getItem('previousLocationPathname');
+    const previousSearch = sessionStorage.getItem('previousLocationSearch');
+
+    const previousPathLabel = shouldClearPath(previousPathname)
+      ? null
+      : getPreviousPathLabel(previousPathname);
+
     const countryName = country && `${country.wri_standard_name}`;
     return (
       <div>
@@ -35,20 +113,43 @@ class LTSCountry extends PureComponent {
           descriptionContext={LTS_COUNTRY({ countryName })}
           href={location.href}
         />
+        <NdcsDocumentsMetaProvider />
         {country && (
           <Header route={route}>
-            <div className={cx(styles.doubleFold, styles.header)}>
+            <div className={styles.header}>
+              <div
+                className={cx(styles.actionsContainer, {
+                  [styles.withSearch]: hasSearch,
+                  [styles.withoutBack]: !previousPathname
+                })}
+              >
+                {previousPathLabel && (
+                  <div className={styles.backButton}>
+                    <Link
+                      to={{
+                        pathname: previousPathname,
+                        search: previousSearch
+                      }}
+                    >
+                      <Icon className={styles.backIcon} icon={longArrowBack} />
+                      Back to {previousPathLabel}
+                    </Link>
+                  </div>
+                )}
+                {this.renderFullTextDropdown()}
+                {hasSearch && (
+                  <Search
+                    theme={lightSearch}
+                    placeholder="Search"
+                    value={search}
+                    onChange={onSearchChange}
+                  />
+                )}
+              </div>
               <div className={styles.title}>
                 <Intro title={country.wri_standard_name} />
               </div>
-              {notSummary && (
-                <Search
-                  theme={lightSearch}
-                  placeholder="Search"
-                  value={search}
-                  onChange={onSearchChange}
-                />
-              )}
+              <TabletLandscape>{this.renderCompareButton()}</TabletLandscape>
             </div>
             <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
               <AnchorNav
@@ -73,7 +174,9 @@ LTSCountry.propTypes = {
   onSearchChange: PropTypes.func.isRequired,
   search: PropTypes.string,
   anchorLinks: PropTypes.array,
-  notSummary: PropTypes.bool
+  notSummary: PropTypes.bool,
+  match: PropTypes.object.isRequired,
+  documentsOptions: PropTypes.array
 };
 
 export default LTSCountry;

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -10,14 +10,17 @@ import Search from 'components/search';
 import cx from 'classnames';
 import Sticky from 'react-stickynode';
 import AnchorNav from 'components/anchor-nav';
+import { Dropdown as CWDropdown } from 'cw-components';
 import { LTS_COUNTRY } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import { TabletLandscape } from 'components/responsive';
 import longArrowBack from 'assets/icons/long-arrow-back.svg';
 import NdcsDocumentsMetaProvider from 'providers/ndcs-documents-meta-provider';
 import { previousPathLabel, getPreviousLinkTo } from 'app/utils/history';
+
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import lightSearch from 'styles/themes/search/search-light.scss';
+import countryDropdownTheme from 'styles/themes/dropdown/dropdown-country.scss';
 import styles from './lts-country-styles.scss';
 
 class LTSCountry extends PureComponent {
@@ -78,7 +81,9 @@ class LTSCountry extends PureComponent {
       search,
       route,
       anchorLinks,
-      notSummary
+      notSummary,
+      countriesOptions,
+      handleCountryLink
     } = this.props;
 
     const hasSearch = notSummary;
@@ -90,6 +95,26 @@ class LTSCountry extends PureComponent {
     ];
     const lastPathLabel = previousPathLabel(clearRegexs, directLinksRegexs);
     const countryName = country && `${country.wri_standard_name}`;
+
+    const renderIntroDropdown = () => (
+      <Intro
+        title={
+          <CWDropdown
+            value={
+              country && {
+                label: country.wri_standard_name,
+                value: country.iso_code3
+              }
+            }
+            options={countriesOptions}
+            onValueChange={handleCountryLink}
+            hideResetButton
+            theme={countryDropdownTheme}
+          />
+        }
+      />
+    );
+
     return (
       <div>
         <MetaDescription
@@ -120,9 +145,7 @@ class LTSCountry extends PureComponent {
                   />
                 )}
               </div>
-              <div className={styles.title}>
-                <Intro title={country.wri_standard_name} />
-              </div>
+              <div className={styles.title}>{renderIntroDropdown()}</div>
               <TabletLandscape>{this.renderCompareButton()}</TabletLandscape>
             </div>
             <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
@@ -151,7 +174,9 @@ LTSCountry.propTypes = {
   notSummary: PropTypes.bool,
   match: PropTypes.object.isRequired,
   documentsOptions: PropTypes.array,
-  goBack: PropTypes.func.isRequired
+  goBack: PropTypes.func.isRequired,
+  handleCountryLink: PropTypes.func.isRequired,
+  countriesOptions: PropTypes.array
 };
 
 export default LTSCountry;

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -42,10 +42,11 @@ class LTSCountry extends PureComponent {
 
   renderBackButton(lastPathLabel) {
     const { goBack } = this.props;
+    const previousLinkTo = getPreviousLinkTo();
     return (
       <div className={styles.backButton}>
-        {lastPathLabel ? (
-          <Link to={getPreviousLinkTo}>
+        {lastPathLabel && previousLinkTo.pathname ? (
+          <Link to={previousLinkTo}>
             <Icon className={styles.backIcon} icon={longArrowBack} />
             Back to {lastPathLabel}
           </Link>

--- a/app/javascript/app/pages/lts-country/lts-country-selectors.js
+++ b/app/javascript/app/pages/lts-country/lts-country-selectors.js
@@ -44,3 +44,16 @@ export const getDocumentsOptions = createSelector(
     }));
   }
 );
+
+export const addUrlToCountries = createSelector(
+  [getCountries, getCountry],
+  (countries, country) => {
+    if (!countries) return null;
+    return countries
+      .filter(c => c.iso_code3 !== country.iso_code3)
+      .map(c => ({
+        value: c.iso_code3,
+        label: c.wri_standard_name
+      }));
+  }
+);

--- a/app/javascript/app/pages/lts-country/lts-country-selectors.js
+++ b/app/javascript/app/pages/lts-country/lts-country-selectors.js
@@ -1,8 +1,11 @@
 import { createSelector } from 'reselect';
 import qs from 'query-string';
+import isEmpty from 'lodash/isEmpty';
+import upperCase from 'lodash/upperCase';
 
 const getCountries = state => state.countries || null;
 const getIso = state => state.iso || null;
+const getDocuments = state => state.data || null;
 
 const getCountryByIso = (countries, iso) =>
   countries.find(country => country.iso_code3 === iso);
@@ -30,7 +33,14 @@ export const getAnchorLinks = createSelector(
   }
 );
 
-export default {
-  getCountry,
-  getAnchorLinks
-};
+export const getDocumentsOptions = createSelector(
+  [getDocuments, getIso],
+  (documents, iso) => {
+    if (isEmpty(documents) || !iso || !documents[iso]) return null;
+    return documents[iso].map(doc => ({
+      label: `${upperCase(doc.document_type)}(${doc.language})`,
+      value: `${doc.document_type}(${doc.language})`,
+      path: `/lts/country/${iso}/full?document=${doc.document_type}-${doc.language}`
+    }));
+  }
+);

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -4,50 +4,85 @@
   @include row('shrink', $wrap: false);
 }
 
-.doubleFold {
-  @include row(12);
-
-  > :not(:first-child) {
-    @include xy-gutters($gutter-position: ('bottom'));
-  }
-
-  z-index: $z-index-sticky;
-
-  > :nth-child(4) {
-    height: 100%;
-  }
+.compareButton {
+  @include row();
 
   @media #{$tablet-portrait} {
-    @include row((12, 6, 6));
-
-    > :not(:first-child) {
-      @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
-    }
-  }
-
-  @media #{$tablet-landscape} {
-    @include row((5, 3, 2, 2));
-
-    > :not(:first-child) {
-      @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
-    }
-
-    z-index: $z-index-base;
+    @include row(6);
   }
 }
 
+.title {
+  @include row();
+}
+
 .backButton {
-  margin-right: 20px;
+  @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+
+  > a {
+    color: $white;
+  }
+}
+
+.viewDocumentButton {
+  @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+
+  @media #{$tablet-portrait} {
+    @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
+  }
 }
 
 .backIcon {
   fill: $white;
-  width: 60px;
-  height: 60px;
+  width: 38px;
+  height: 12px;
+  margin-right: 24px;
 }
 
-.title {
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
+.actionsContainer {
+  @include row();
+
+  z-index: $z-index-sticky;
+
+  @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+
+  @media #{$tablet-portrait} {
+    @include row(6);
+    @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+
+    &.withSearch {
+      @include row((6, 3, 3));
+    }
+
+    &.withoutBack {
+      @include row((12, 6, 6));
+      @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+
+      &.withSearch {
+        @include row(6);
+        @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
+      }
+    }
+  }
+
+  @media #{$tablet-landscape} {
+    @include row((9, 3));
+
+    &.withSearch {
+      @include row((6, 3, 3));
+    }
+
+    &.withoutBack {
+      @include row((9, 3));
+      @include xy-gutters($gutter-position: ('right'), $gutters: $gutter-padding);
+      @include column-offset(9);
+
+      &.withSearch {
+        @include row((6, 3, 3));
+        @include column-offset(6);
+      }
+    }
+
+    z-index: $z-index-base;
+  }
 }

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -19,8 +19,11 @@
 .backButton {
   @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
 
-  > a {
+  > a,
+  .linkButton {
     color: $white;
+    font-size: $font-size;
+    cursor: pointer;
   }
 }
 
@@ -53,36 +56,15 @@
     &.withSearch {
       @include row((6, 3, 3));
     }
-
-    &.withoutBack {
-      @include row((12, 6, 6));
-      @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
-
-      &.withSearch {
-        @include row(6);
-        @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
-      }
-    }
   }
 
   @media #{$tablet-landscape} {
     @include row((9, 3));
 
+    z-index: $z-index-base;
+
     &.withSearch {
       @include row((6, 3, 3));
     }
-
-    &.withoutBack {
-      @include row((9, 3));
-      @include xy-gutters($gutter-position: ('right'), $gutters: $gutter-padding);
-      @include column-offset(9);
-
-      &.withSearch {
-        @include row((6, 3, 3));
-        @include column-offset(6);
-      }
-    }
-
-    z-index: $z-index-base;
   }
 }

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -9,6 +9,8 @@
 
   @media #{$tablet-portrait} {
     @include row(6);
+
+    margin-bottom: 110px;
   }
 }
 

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -60,6 +60,7 @@ class LTSCountryContainer extends PureComponent {
   render() {
     return createElement(LTSCountryComponent, {
       ...this.props,
+      goBack: this.props.history.goBack,
       onSearchChange: this.onSearchChange,
       handleDropDownChange: this.handleDropDownChange
     });

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -9,25 +9,18 @@ import LTSCountryComponent from './lts-country-component';
 import {
   getCountry,
   getAnchorLinks,
-  getDocumentsOptions
+  getDocumentsOptions,
+  addUrlToCountries
 } from './lts-country-selectors';
 
 const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
   const search = qs.parse(location.search);
-  const countryData = {
-    countries: state.countries.data,
-    iso: match.params.iso
-  };
-  const routeData = {
+  const stateData = {
     iso,
     location,
-    route
-  };
-
-  // TODO: Update with LTS document meta
-  const documentsData = {
-    iso,
+    route,
+    countries: state.countries.data,
     data: state.ndcsDocumentsMeta.data
   };
 
@@ -39,10 +32,11 @@ const mapStateToProps = (state, { match, location, route }) => {
     'sectoral-information'
   ].includes(pathname[pathname.length - 1]);
   return {
-    country: getCountry(countryData),
+    country: getCountry(stateData),
     search: search.search,
-    anchorLinks: getAnchorLinks(routeData),
-    documentsOptions: getDocumentsOptions(documentsData),
+    anchorLinks: getAnchorLinks(stateData),
+    countriesOptions: addUrlToCountries(stateData),
+    documentsOptions: getDocumentsOptions(stateData),
     notSummary
   };
 };
@@ -57,19 +51,30 @@ class LTSCountryContainer extends PureComponent {
     history.replace(getLocationParamUpdated(location, params, clear));
   };
 
+  handleCountryLink = selected => {
+    const { history, country } = this.props;
+    const path = history.location.pathname.replace(
+      country.iso_code3,
+      selected.value
+    );
+    history.push(path);
+  };
+
   render() {
     return createElement(LTSCountryComponent, {
       ...this.props,
       goBack: this.props.history.goBack,
       onSearchChange: this.onSearchChange,
-      handleDropDownChange: this.handleDropDownChange
+      handleDropDownChange: this.handleDropDownChange,
+      handleCountryLink: this.handleCountryLink
     });
   }
 }
 
 LTSCountryContainer.propTypes = {
   history: Proptypes.object.isRequired,
-  location: Proptypes.object.isRequired
+  location: Proptypes.object.isRequired,
+  country: Proptypes.object.isRequired
 };
 
 export default withRouter(connect(mapStateToProps, null)(LTSCountryContainer));

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -25,7 +25,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     route
   };
 
-  // Update with LTS document meta
+  // TODO: Update with LTS document meta
   const documentsData = {
     iso,
     data: state.ndcsDocumentsMeta.data

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -6,7 +6,11 @@ import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
 
 import LTSCountryComponent from './lts-country-component';
-import { getCountry, getAnchorLinks } from './lts-country-selectors';
+import {
+  getCountry,
+  getAnchorLinks,
+  getDocumentsOptions
+} from './lts-country-selectors';
 
 const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
@@ -20,6 +24,13 @@ const mapStateToProps = (state, { match, location, route }) => {
     location,
     route
   };
+
+  // Update with LTS document meta
+  const documentsData = {
+    iso,
+    data: state.ndcsDocumentsMeta.data
+  };
+
   const pathname = location.pathname.split('/');
   const notSummary = [
     'overview',
@@ -31,6 +42,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     country: getCountry(countryData),
     search: search.search,
     anchorLinks: getAnchorLinks(routeData),
+    documentsOptions: getDocumentsOptions(documentsData),
     notSummary
   };
 };

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -205,6 +205,7 @@ NDCCountry.propTypes = {
   handleCountryLink: PropTypes.func.isRequired,
   goBack: PropTypes.func.isRequired,
   handleCountryLink: PropTypes.func.isRequired,
+  goBack: PropTypes.func.isRequired,
   search: PropTypes.string,
   anchorLinks: PropTypes.array,
   documentsOptions: PropTypes.array,

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -55,10 +55,11 @@ class NDCCountry extends PureComponent {
 
   renderBackButton(lastPathLabel) {
     const { goBack } = this.props;
+    const previousLinkTo = getPreviousLinkTo();
     return (
       <div className={styles.backButton}>
-        {lastPathLabel ? (
-          <Link to={getPreviousLinkTo}>
+        {lastPathLabel && previousLinkTo.pathname ? (
+          <Link to={previousLinkTo}>
             <Icon className={styles.backIcon} icon={longArrowBack} />
             Back to {lastPathLabel}
           </Link>
@@ -202,8 +203,6 @@ NDCCountry.propTypes = {
   match: PropTypes.object.isRequired,
   country: PropTypes.object,
   onSearchChange: PropTypes.func.isRequired,
-  handleCountryLink: PropTypes.func.isRequired,
-  goBack: PropTypes.func.isRequired,
   handleCountryLink: PropTypes.func.isRequired,
   goBack: PropTypes.func.isRequired,
   search: PropTypes.string,

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -204,6 +204,7 @@ NDCCountry.propTypes = {
   onSearchChange: PropTypes.func.isRequired,
   handleCountryLink: PropTypes.func.isRequired,
   goBack: PropTypes.func.isRequired,
+  handleCountryLink: PropTypes.func.isRequired,
   search: PropTypes.string,
   anchorLinks: PropTypes.array,
   documentsOptions: PropTypes.array,

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -9,6 +9,8 @@
 
   @media #{$tablet-portrait} {
     @include row(6);
+
+    margin-bottom: 110px;
   }
 }
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -19,8 +19,11 @@
 .backButton {
   @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
 
-  > a {
+  > a,
+  .linkButton {
     color: $white;
+    font-size: $font-size;
+    cursor: pointer;
   }
 }
 

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -4,11 +4,6 @@ import Proptypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
-import {
-  getFilterUpper,
-  getISOCountries,
-  getFilteredCountriesWithPath
-} from 'components/countries-select/countries-select-selectors';
 
 import NDCCountryComponent from './ndc-country-component';
 import {
@@ -42,17 +37,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     'sectoral-information'
   ].includes(pathname[pathname.length - 1]);
 
-  const { countrySelect, countries } = state;
-  const stateWithFilters = {
-    ...countrySelect,
-    query: countrySelect.query,
-    countries: countries.data
-  };
-
   return {
-    query: getFilterUpper(stateWithFilters),
-    isoCountries: getISOCountries(stateWithFilters),
-    countriesList: getFilteredCountriesWithPath(stateWithFilters),
     countriesOptions: addUrlToCountries(countryData),
     country: getCountry(countryData),
     search: search.search,

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -4,6 +4,11 @@ import Proptypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import {
+  getFilterUpper,
+  getISOCountries,
+  getFilteredCountriesWithPath
+} from 'components/countries-select/countries-select-selectors';
 
 import NDCCountryComponent from './ndc-country-component';
 import {
@@ -37,7 +42,17 @@ const mapStateToProps = (state, { match, location, route }) => {
     'sectoral-information'
   ].includes(pathname[pathname.length - 1]);
 
+  const { countrySelect, countries } = state;
+  const stateWithFilters = {
+    ...countrySelect,
+    query: countrySelect.query,
+    countries: countries.data
+  };
+
   return {
+    query: getFilterUpper(stateWithFilters),
+    isoCountries: getISOCountries(stateWithFilters),
+    countriesList: getFilteredCountriesWithPath(stateWithFilters),
     countriesOptions: addUrlToCountries(countryData),
     country: getCountry(countryData),
     search: search.search,

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -75,7 +75,8 @@ class NDCCountryContainer extends PureComponent {
       ...this.props,
       onSearchChange: this.onSearchChange,
       handleDropDownChange: this.handleDropDownChange,
-      handleCountryLink: this.handleCountryLink
+      handleCountryLink: this.handleCountryLink,
+      goBack: this.props.history.goBack
     });
   }
 }

--- a/app/javascript/app/utils/history.js
+++ b/app/javascript/app/utils/history.js
@@ -36,7 +36,7 @@ const getPreviousPathLabel = directLinksRegexs => {
 export const previousPathLabel = (clearRegexs, directLinksRegexs) =>
   (shouldClearPath(clearRegexs) ? null : getPreviousPathLabel(directLinksRegexs));
 
-export const getPreviousLinkTo = {
+export const getPreviousLinkTo = () => ({
   pathname: getPreviousPathname(),
   search: getPreviousSearch()
-};
+});

--- a/app/javascript/app/utils/history.js
+++ b/app/javascript/app/utils/history.js
@@ -1,0 +1,42 @@
+import { toStartCase } from 'app/utils';
+
+const getPreviousPathname = () =>
+  sessionStorage.getItem('previousLocationPathname');
+const getPreviousSearch = () =>
+  sessionStorage.getItem('previousLocationSearch');
+
+const shouldClearPath = clearRegexps => {
+  const previousPathname = getPreviousPathname();
+  if (!previousPathname) return false;
+  clearRegexps.push(/\/error-page/);
+  if (clearRegexps.some(r => previousPathname.match(r))) {
+    sessionStorage.setItem('previousLocationPathname', '');
+    return true;
+  }
+  return false;
+};
+
+const getPreviousPathLabel = directLinksRegexs => {
+  const updatedPathname = getPreviousPathname();
+  let lastPathLabel = {
+    '/': 'Home'
+  }[updatedPathname];
+
+  directLinksRegexs.some(regexWithLabel => {
+    const { regex, label } = regexWithLabel;
+    if (updatedPathname && updatedPathname.match(regex)) {
+      lastPathLabel = label;
+      return true;
+    }
+    return false;
+  });
+  return lastPathLabel || (updatedPathname && toStartCase(updatedPathname));
+};
+
+export const previousPathLabel = (clearRegexs, directLinksRegexs) =>
+  (shouldClearPath(clearRegexs) ? null : getPreviousPathLabel(directLinksRegexs));
+
+export const getPreviousLinkTo = {
+  pathname: getPreviousPathname(),
+  search: getPreviousSearch()
+};


### PR DESCRIPTION
This PR adapts the LTS country header to the new styles: Adds the back button styles the whole header and the remaining buttons.

- The back button logic has been abstracted to a utils file.
- When we don't have a clear previous page we just show .''Back". This was preferred by the design team.
- The links in LTS are disabled as we still need to create those sections

Extra:

- Added NDC country page changes on cards and slugs: Some data is missing. There will be a new task created for this

![image](https://user-images.githubusercontent.com/9701591/71521246-2eaad180-28c0-11ea-86e3-68d97158eeee.png)
