### PR TITLE
Don't return all docs when the filtered docs are 0

### DIFF
--- a/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
+++ b/app/javascript/app/pages/ndc-search/ndc-search-selectors.js
@@ -25,10 +25,11 @@ const getDocumentSelected = createSelector(
 );
 
 export const filterSearchResults = createSelector(
-  [getResultsData, getDocumentSelected],
-  (results, docSelected) => {
+  [getResultsData, getDocumentSelected, getDocQuery],
+  (results, docSelected, docQuery) => {
     if (!results) return null;
-    if (!docSelected) return results;
+    if (docQuery === 'all') return results;
+    if (!docSelected) return null;
     return uniqBy(
       results.filter(d => d.document_type === docSelected.value),
       'location.iso_code3'


### PR DESCRIPTION
The NDC search with the Second NDC filter selected was returning all documents. Now its really filtered by ndc2

![image](https://user-images.githubusercontent.com/9701591/72004860-9a8c2300-324c-11ea-8efd-6a155f524838.png)
