### PR TITLE
don't constrain importing WB Extra data to countries

### DIFF
--- a/app/controllers/api/v1/wb_extra_country_data_controller.rb
+++ b/app/controllers/api/v1/wb_extra_country_data_controller.rb
@@ -13,17 +13,17 @@ module Api
       end
 
       def show
-        country = Location.find_by(location_type: 'COUNTRY',
-                                   iso_code3: params[:code])
-        unless country
+        location = Location.find_by(iso_code3: params[:code])
+
+        unless location
           render json: {
-            error: 'Country not found',
+            error: 'Location not found',
             status: 404
           }, status: :not_found and return
         end
 
         collection = ::WbExtra::CountryData.
-          where(location: country).
+          where(location: location).
           filter_by_dates(params[:startYear], params[:endYear])
 
         render json: collection,

--- a/app/services/import_wb_extra.rb
+++ b/app/services/import_wb_extra.rb
@@ -32,7 +32,7 @@ class ImportWbExtra
   end
 
   def import_data
-    all_countries = Location.where(location_type: 'COUNTRY')
+    all_countries = Location.all
     not_included_countries = []
 
     all_countries.each do |country|
@@ -53,7 +53,6 @@ class ImportWbExtra
   def create_country_data(country_code, year)
     year_index = (year - FIRST_YEAR)
     country_location = Location.find_by(
-      location_type: 'COUNTRY',
       iso_code3: country_code
     )
 


### PR DESCRIPTION
This PR removes location type restrictions from both the importing of World Bank Extra data and the API endpoint to get a location World Bank Extra data.

You'll need to run `rails wb_extra:import` and then you will see the GHG emissions graph on the EU28 page changing when changing the Per GDP to Per Capita.