### PR TITLE
Fix/ndc country without back

### DIFF
--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -125,7 +125,7 @@ class NDCCountry extends PureComponent {
             <div className={styles.header}>
               <div
                 className={cx(styles.actionsContainer, {
-                  [styles.withSearch]: hasSearch || !FEATURE_LTS_EXPLORE,
+                  [styles.withSearch]: hasSearch,
                   [styles.withoutBack]: !FEATURE_LTS_EXPLORE
                 })}
               >

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -60,12 +60,9 @@
     }
 
     &.withoutBack {
-      @include row((9, 3));
-      @include xy-gutters($gutter-position: ('right'), $gutters: $gutter-padding);
-      @include column-offset(9);
+      @include row((6, 3, 3));
 
       &.withSearch {
-        @include row((6, 3, 3));
         @include column-offset(6);
       }
     }

--- a/app/javascript/app/styles/themes/dropdown/dropdown-country.scss
+++ b/app/javascript/app/styles/themes/dropdown/dropdown-country.scss
@@ -7,6 +7,7 @@ $min-width: 250px;
     border: none !important;
     box-shadow: none !important;
     min-height: 70px;
+    padding-left: 0 !important;
 
     .react-selectize-toggle-button-container {
       flex-grow: 0;


### PR DESCRIPTION
A quick fix to NDC country styles with `FEATURE_LTS_EXPLORE`=false
Also, remove the left padding of the country dropdown

![image](https://user-images.githubusercontent.com/9701591/72149320-287a2200-33a3-11ea-9027-2b4d216804cf.png)
