### PR TITLE
Change layout of filter dropdowns in NDC-Search

### DIFF
--- a/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
+++ b/app/javascript/app/pages/ndc-search/ndc-search-component.jsx
@@ -33,7 +33,7 @@ class SearchPage extends PureComponent {
       <div className={styles.page}>
         <Header route={route}>
           <div className={styles.headerCols}>
-            <Intro title="NDC Search" />
+            <Intro className={styles.intro} title="NDC Search" />
             <NdcsAutocompleteSearch
               className={styles.select}
               fetchSearchResults={fetchSearchResults}

--- a/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
+++ b/app/javascript/app/pages/ndc-search/ndc-search-styles.scss
@@ -13,7 +13,6 @@
 
 .headerCols {
   @include row();
-
   margin-bottom: 15px;
   z-index: $z-index-sticky;
 
@@ -24,14 +23,12 @@
   }
 
   @media #{$tablet-landscape} {
-    @include row((4, 8));
-
-    > * {
-      @include xy-gutters($gutter-position: ('bottom'), $gutters: 0);
+    .intro {
+      margin-bottom: 100px;
     }
 
-    > *:first-child {
-      @include xy-gutters($gutter-position: ('right'), $gutters: 0);
+    .select {
+      margin-bottom: 64px;
     }
   }
 }


### PR DESCRIPTION
This tiny PR changes the layout of the filters in the NDC-Search page from horizontal to vertical.
[PIVOTAL](https://www.pivotaltracker.com/story/show/170335080)

BEFORE:
![image](https://user-images.githubusercontent.com/15097138/72159809-199c6b00-33b5-11ea-8136-dce2bbddd109.png)
AFTER:
![image](https://user-images.githubusercontent.com/15097138/72159769-05f10480-33b5-11ea-93cf-1ad8c35efe9a.png)

I see on the design a back button, but I'm not sure of from where, besides the main menu, we can navigate to the NDC-Search, do you have any clue?