### PR TITLE
Fix/lts dropdown

### DIFF
--- a/app/javascript/app/components/country/country-lts-overview/country-lts-overview.js
+++ b/app/javascript/app/components/country/country-lts-overview/country-lts-overview.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import isEmpty from 'lodash/isEmpty';
+import Proptypes from 'prop-types';
 
 import { isEmbededComponent } from 'utils/navigation';
 import { actions } from 'components/modal-metadata';
-
+import { actions as fetchActions } from 'components/ndcs/ndcs-country-accordion';
 import CountryLtsOverviewComponent from './country-lts-overview-component';
 import { getCardsData } from './country-lts-overview-selectors';
 
@@ -30,10 +31,27 @@ const mapStateToProps = (state, { location, match }) => {
   };
 };
 
-const CountryLtsOverviewContainer = props => (
-  <CountryLtsOverviewComponent {...props} />
-);
+const CountryLtsOverviewContainer = props => {
+  const { iso, fetchNdcsCountryAccordion } = props;
+  useEffect(() => {
+    fetchNdcsCountryAccordion({
+      locations: iso,
+      category: 'summary',
+      compare: false,
+      lts: true
+    });
+  }, [iso]);
+  return <CountryLtsOverviewComponent {...props} />;
+};
+
+CountryLtsOverviewContainer.propTypes = {
+  iso: Proptypes.func.isRequired,
+  fetchNdcsCountryAccordion: Proptypes.func.isRequired
+};
 
 export default withRouter(
-  connect(mapStateToProps, actions)(CountryLtsOverviewContainer)
+  connect(mapStateToProps, {
+    ...actions,
+    ...fetchActions
+  })(CountryLtsOverviewContainer)
 );

--- a/app/javascript/app/components/country/country-lts-overview/country-lts-overview.js
+++ b/app/javascript/app/components/country/country-lts-overview/country-lts-overview.js
@@ -45,7 +45,7 @@ const CountryLtsOverviewContainer = props => {
 };
 
 CountryLtsOverviewContainer.propTypes = {
-  iso: Proptypes.func.isRequired,
+  iso: Proptypes.string,
   fetchNdcsCountryAccordion: Proptypes.func.isRequired
 };
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
@@ -1,4 +1,4 @@
-import { PureComponent, createElement } from 'react';
+import { useEffect, createElement } from 'react';
 import { connect } from 'react-redux';
 import Proptypes from 'prop-types';
 import { withRouter } from 'react-router';
@@ -7,6 +7,7 @@ import { handleAnalytics } from 'utils/analytics';
 
 import { isPageNdcp, isEmbededComponent } from 'utils/navigation';
 import { actions } from 'components/modal-metadata';
+import { actions as fetchActions } from 'components/ndcs/ndcs-country-accordion';
 
 import CountryNdcOverviewComponent from './country-ndc-overview-component';
 import {
@@ -37,13 +38,24 @@ const mapStateToProps = (state, { location, match }) => {
   };
 };
 
-class CountryNdcOverviewContainer extends PureComponent {
-  handleAnalyticsClick = () => {
+function CountryNdcOverviewContainer(props) {
+  const { iso, fetchNdcsCountryAccordion, setModalMetadata } = props;
+
+  useEffect(() => {
+    fetchNdcsCountryAccordion({
+      locations: iso,
+      category: 'summary',
+      compare: false,
+      lts: false
+    });
+  }, [iso]);
+
+  const handleAnalyticsClick = () => {
     handleAnalytics('Country', 'Leave page to explore data', 'Ndc Overview');
   };
 
-  handleInfoClick = () => {
-    this.props.setModalMetadata({
+  const handleInfoClick = () => {
+    setModalMetadata({
       category: 'Country',
       slugs: ['ndc_cw', 'ndc_wb', 'ndc_die'],
       customTitle: 'Nationally Determined Contribution (NDC) Overview',
@@ -51,13 +63,11 @@ class CountryNdcOverviewContainer extends PureComponent {
     });
   };
 
-  render() {
-    return createElement(CountryNdcOverviewComponent, {
-      ...this.props,
-      handleInfoClick: this.handleInfoClick,
-      handleAnalyticsClick: this.handleAnalyticsClick
-    });
-  }
+  return createElement(CountryNdcOverviewComponent, {
+    ...props,
+    handleInfoClick,
+    handleAnalyticsClick
+  });
 }
 
 CountryNdcOverviewContainer.propTypes = {
@@ -65,5 +75,7 @@ CountryNdcOverviewContainer.propTypes = {
 };
 
 export default withRouter(
-  connect(mapStateToProps, actions)(CountryNdcOverviewContainer)
+  connect(mapStateToProps, { ...actions, ...fetchActions })(
+    CountryNdcOverviewContainer
+  )
 );

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -49,9 +49,10 @@ class NdcsCountryAccordionContainer extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { fetchNdcsCountryAccordion, compare, lts } = this.props;
-    const newLocations = qs.parse(nextProps.location.search).locations;
-    const oldLocations = qs.parse(this.props.location.search).locations;
+    const { fetchNdcsCountryAccordion, compare, lts, iso } = this.props;
+    const newLocations =
+      nextProps.iso || qs.parse(nextProps.location.search).locations;
+    const oldLocations = iso || qs.parse(this.props.location.search).locations;
     if (newLocations !== oldLocations) {
       fetchNdcsCountryAccordion({
         locations: newLocations,

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
@@ -18,7 +18,7 @@
 
 .infoButton {
   position: absolute;
-  z-index: $z-index-over-dropdown;
+  z-index: $z-index-over-map;
   cursor: pointer;
   top: 12px;
   right: 12px;

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -57,7 +57,7 @@ class LTSCountryContainer extends PureComponent {
       country.iso_code3,
       selected.value
     );
-    history.push(path);
+    history.replace(path);
   };
 
   render() {
@@ -73,7 +73,7 @@ class LTSCountryContainer extends PureComponent {
 LTSCountryContainer.propTypes = {
   history: Proptypes.object.isRequired,
   location: Proptypes.object.isRequired,
-  country: Proptypes.object.isRequired
+  country: Proptypes.object
 };
 
 export default withRouter(connect(mapStateToProps, null)(LTSCountryContainer));

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -67,7 +67,7 @@ class NDCCountryContainer extends PureComponent {
       country.iso_code3,
       selected.value
     );
-    history.push(path);
+    history.replace(path);
   };
 
   render() {


### PR DESCRIPTION
Fetch NDCs on the summary pages to avoid the Bug with summary cards when accessing country without data.

Steps to Reproduce:

1- Visit the LTS Explore page;
2- Click on Mexico;
3- Search for Bulgaria;
4- Search for United States...  BUG! (No more) The summary data is not loaded correctly. If we change tabs and back it then loads.

Extra:
- Fix z-index on overview - question cards - info button when mobile and share modal is open
![image](https://user-images.githubusercontent.com/9701591/72171204-c6d1ac00-33d2-11ea-9580-c67acd7baf6a.png)
