### PR TITLE
Fix carousel: revert 'topSlide' and 'bottomSlide' flag

### DIFF
--- a/app/javascript/app/pages/home/carousel-section/carousel-section-component.jsx
+++ b/app/javascript/app/pages/home/carousel-section/carousel-section-component.jsx
@@ -86,6 +86,7 @@ class CarouselSectionComponent extends Component {
           smImage={slide.smImage}
           bgImage={slide.bgImage}
           altText={slide.altText}
+          topSlide
         />
       ));
 
@@ -99,6 +100,7 @@ class CarouselSectionComponent extends Component {
           buttons={slide.buttons}
           countriesOptions={countriesOptions}
           handleDropDownChange={this.handleDropDownChange}
+          bottomSlide
         />
       ));
 


### PR DESCRIPTION
This tiny PR fixes missing carousel section on the homepage