### PR TITLE
Filter undefined country links on data

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-table/ndcs-lts-table-selectors.js
@@ -137,15 +137,17 @@ const getFilteredData = createSelector(
   [tableRemoveIsoFromData, getDefaultColumns],
   (data, columnHeaders) => {
     if (!data || isEmpty(data)) return null;
-    return data.map(d => {
-      const filteredHeadersD = {};
-      Object.keys(d).forEach(k => {
-        if (columnHeaders.includes(k)) {
-          filteredHeadersD[k] = d[k];
-        }
-      });
-      return filteredHeadersD;
-    });
+    return data
+      .map(d => {
+        const filteredHeadersD = {};
+        Object.keys(d).forEach(k => {
+          if (columnHeaders.includes(k)) {
+            filteredHeadersD[k] = d[k];
+          }
+        });
+        return filteredHeadersD;
+      })
+      .filter(d => !d.country.includes('undefined')); // Should be removed when the data is fixed
   }
 );
 


### PR DESCRIPTION
The problem in production:

![image](https://user-images.githubusercontent.com/9701591/72521827-82c02a80-385c-11ea-87b7-c3dc4354da86.png)

https://www.climatewatchdata.org/lts-tracker

Some countries column (the ones without LTS) have this data: 
`<a href="/ndcs/country/undefined">undefined</a>
`
So we are filtering on the frontend. This should be fixed in the data at some point