### PR TITLE
Update ndcs_controller slugs

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -8,7 +8,10 @@ module Api
       'indc_summary_long',
       'coverage_sectors',
       'coverage_sectors_short',
-      'other_adaption info'
+      'other_adaption info',
+      'mitigation_contribution_type',
+      'ghg_target_type',
+      'adaptation'
     ].freeze
 
     SECTORS_INDICATORS = [


### PR DESCRIPTION
Updated the ndcs_controller to show the data on the Ndc country / overview / contribution type card
I'm not sure if there is a better way to not hardcode this. But this will work by now.

![image](https://user-images.githubusercontent.com/9701591/72878146-b2f34780-3cfa-11ea-98aa-396763455cde.png)
