### PR TITLE
Fix/metadata modal markdown

### DIFF
--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -23,27 +23,17 @@ MetadataAllProps.propTypes = {
   data: PropTypes.object.isRequired
 };
 
-const urlTitles = ['url', 'Link'];
 const MetadataProp = ({ title, data }) =>
   data &&
   (title === 'logo' ? (
     <img src={`https:${data}`} />
   ) : (
-    <p className={styles.text}>
-      <span className={styles.textHighlight}>{toStartCase(title)}: </span>
-      {urlTitles.includes(title) ? (
-        <a className={styles.link} href={data}>
-          {data}
-        </a>
-      ) : (
-        <ReactMarkdown
-          className={cx(styles.markdown, {
-            [styles.empty]: data === 'Not specified'
-          })}
-          source={data}
-        />
-      )}
-    </p>
+    <ReactMarkdown
+      className={cx(styles.markdown, {
+        [styles.empty]: data === 'Not specified'
+      })}
+      source={`**${toStartCase(title)}**: ${data}`}
+    />
   ));
 
 MetadataProp.propTypes = {
@@ -100,15 +90,7 @@ class MetadataText extends PureComponent {
             )}
             {cautions && <MetadataProp title="Cautions" data={cautions} />}
             {learn_more_link && (
-              <MetadataProp
-                title="Read more"
-                data={
-                  <a key="link" className={styles.link} href={learn_more_link}>
-                    {' '}
-                    {learn_more_link}{' '}
-                  </a>
-                }
-              />
+              <MetadataProp title="Read more" data={learn_more_link} />
             )}
             {summary_of_licenses && (
               <MetadataProp
@@ -120,16 +102,7 @@ class MetadataText extends PureComponent {
             {terms_of_service_link && (
               <MetadataProp
                 title="Terms of service link"
-                data={
-                  <a
-                    key="link"
-                    className={styles.link}
-                    href={terms_of_service_link}
-                  >
-                    {' '}
-                    {terms_of_service_link}{' '}
-                  </a>
-                }
+                data={terms_of_service_link}
               />
             )}
             {displayDisclaimer && (

--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -4,6 +4,8 @@ import cx from 'classnames';
 import Disclaimer from 'components/disclaimer';
 import { toStartCase } from 'utils/utils';
 import { isArray } from 'util';
+import ReactMarkdown from 'react-markdown';
+
 import styles from './metadata-text-styles.scss';
 
 const MetadataAllProps = ({ data }) =>
@@ -34,13 +36,12 @@ const MetadataProp = ({ title, data }) =>
           {data}
         </a>
       ) : (
-        <span
-          className={cx({
+        <ReactMarkdown
+          className={cx(styles.markdown, {
             [styles.empty]: data === 'Not specified'
           })}
-        >
-          {data}
-        </span>
+          source={data}
+        />
       )}
     </p>
   ));

--- a/app/javascript/app/components/metadata-text/metadata-text-styles.scss
+++ b/app/javascript/app/components/metadata-text/metadata-text-styles.scss
@@ -1,24 +1,5 @@
 @import '~styles/layout.scss';
 
-.text {
-  font-size: $font-size;
-  line-height: $line-height-modal;
-  color: $theme-color;
-  margin-bottom: 5px;
-
-  &Highlight {
-    font-weight: $font-weight-bold;
-  }
-}
-
-.link {
-  font-size: $font-size;
-  line-height: $line-height-medium;
-  height: 1.62;
-  color: $theme-color;
-  border-bottom: 1px solid $theme-secondary;
-}
-
 .title {
   font-weight: bold;
   margin-bottom: 12px;
@@ -29,11 +10,25 @@
 }
 
 .markdown {
+  font-size: $font-size;
+  line-height: $line-height-modal;
+  color: $theme-color;
+  margin-bottom: 5px;
+
+  &Highlight {
+    font-weight: $font-weight-bold;
+  }
+
   ul {
     list-style: unset;
     margin-left: 20px;
   }
-  p {
-    margin: 16px 0;
+
+  a {
+    font-size: $font-size;
+    line-height: $line-height-medium;
+    height: 1.62;
+    color: $theme-color;
+    border-bottom: 1px solid $theme-secondary;
   }
 }

--- a/app/javascript/app/components/metadata-text/metadata-text-styles.scss
+++ b/app/javascript/app/components/metadata-text/metadata-text-styles.scss
@@ -27,3 +27,13 @@
 .empty {
   opacity: 0.7;
 }
+
+.markdown {
+  ul {
+    list-style: unset;
+    margin-left: 20px;
+  }
+  p {
+    margin: 16px 0;
+  }
+}


### PR DESCRIPTION
This PR fixes a part of the metadata formatting issue in GHG emissions. These changes enable support for markdown syntax in metadata modal in GHG emissions, but they need to update their data files with the correct markdown syntax
[PIVOTAL](https://www.pivotaltracker.com/story/show/170675310) | [BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/406051530)



Once we merge & release this fix, I'll let them know that they can update their CV file.