### PR TITLE
Fix/donut chart layout

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -499,8 +499,10 @@ export const parseExternalParams = createSelector(
             ids.map(f => parseInt(f, 10)).includes(i.id) ||
             ids.includes(i.number) ||
             ids.includes(i.iso_code3) ||
-            ids.includes(i.iso)
+            ids.includes(i.iso) ||
+            ids.includes(i.slug)
         );
+
         const selectedIds = filterObjects.map(labelObject => {
           const label = POSSIBLE_VALUE_FIELDS.find(
             f => labelObject && labelObject[f]

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -13,6 +13,7 @@ import ModalMetadata from 'components/modal-metadata';
 import Dropdown from 'components/dropdown';
 import { PieChart } from 'cw-components';
 import CustomTooltip from 'components/ndcs/shared/donut-tooltip';
+import CustomInnerHoverLabel from 'components/ndcs/shared/donut-custom-label';
 import LegendItem from 'components/ndcs/shared/legend-item';
 import handCursorIcon from 'assets/icons/hand-cursor.svg';
 import ShareButton from 'components/button/share-button';
@@ -103,6 +104,7 @@ class LTSExploreMap extends PureComponent {
             data={emissionsCardData.data}
           />
         }
+        customInnerHoverLabel={CustomInnerHoverLabel}
         theme={{ pieChart: styles.pieChart }}
       />
     </div>
@@ -211,7 +213,9 @@ class LTSExploreMap extends PureComponent {
                             delayHide={isTablet ? 0 : 3000}
                           >
                             <Button
-                              onClick={() => handleCountryClick(null, countryData)}
+                              onClick={() =>
+                                handleCountryClick(null, countryData)
+                              }
                               className={tooltipTheme.container}
                             >
                               <div

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -2,12 +2,15 @@ import { createSelector } from 'reselect';
 import { getColorByIndex, createLegendBuckets } from 'utils/map';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
-import camelCase from 'lodash/camelCase';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { PATH_LAYERS } from 'app/data/constants';
 import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
-import { sortByIndexAndNotInfo } from 'components/ndcs/shared/utils';
+import {
+  sortByIndexAndNotInfo,
+  getIndicatorEmissionsData,
+  getLabels
+} from 'components/ndcs/shared/utils';
 
 const NO_DOCUMENT_SUBMITTED = 'No Document Submitted';
 
@@ -215,33 +218,12 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
     const emissionsIndicator = indicators.find(i => i.slug === 'lts_ghg');
-    if (!emissionsIndicator) return null;
-
-    const emissionPercentages = emissionsIndicator.locations;
-    let summedPercentage = 0;
-    const data = legend.map(legendItem => {
-      let legendItemValue = 0;
-      Object.entries(selectedIndicator.locations).forEach(entry => {
-        const [locationIso, { label_id: labelId }] = entry;
-        if (
-          labelId === parseInt(legendItem.id, 10) &&
-          locationIso !== 'EU28' && // To avoid double counting
-          emissionPercentages[locationIso]
-        ) {
-          legendItemValue += parseFloat(emissionPercentages[locationIso].value);
-        }
-      });
-      summedPercentage += legendItemValue;
-
-      // The 'No information' label is always the last one so we can calculate its value substracting from 100
-      return {
-        name: camelCase(legendItem.name),
-        value:
-          legendItem.name === NO_DOCUMENT_SUBMITTED
-            ? 100 - summedPercentage
-            : legendItemValue
-      };
-    });
+    const data = getIndicatorEmissionsData(
+      emissionsIndicator,
+      selectedIndicator,
+      legend,
+      NO_DOCUMENT_SUBMITTED
+    );
 
     const config = {
       animation: true,
@@ -249,22 +231,10 @@ export const getEmissionsCardData = createSelector(
       outerRadius: 70,
       hideLabel: true,
       hideLegend: true,
-      innerHoverLabel: true
+      innerHoverLabel: true,
+      ...getLabels(legend, NO_DOCUMENT_SUBMITTED)
     };
 
-    const tooltipLabels = {};
-    const themeLabels = {};
-    legend.forEach(l => {
-      tooltipLabels[camelCase(l.name)] = {
-        label: l.name
-      };
-      themeLabels[camelCase(l.name)] = {
-        label: l.name,
-        stroke: l.color
-      };
-    });
-    config.tooltip = tooltipLabels;
-    config.theme = themeLabels;
     return {
       config,
       data

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -225,6 +225,7 @@ export const getEmissionsCardData = createSelector(
         const [locationIso, { label_id: labelId }] = entry;
         if (
           labelId === parseInt(legendItem.id, 10) &&
+          locationIso !== 'EU28' && // To avoid double counting
           emissionPercentages[locationIso]
         ) {
           legendItemValue += parseFloat(emissionPercentages[locationIso].value);

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -13,6 +13,7 @@ import ModalMetadata from 'components/modal-metadata';
 import Dropdown from 'components/dropdown';
 import { PieChart } from 'cw-components';
 import CustomTooltip from 'components/ndcs/shared/donut-tooltip';
+import CustomInnerHoverLabel from 'components/ndcs/shared/donut-custom-label';
 import LegendItem from 'components/ndcs/shared/legend-item';
 import handCursorIcon from 'assets/icons/hand-cursor.svg';
 import ShareButton from 'components/button/share-button';
@@ -97,6 +98,7 @@ class NDCSExploreMap extends PureComponent {
         data={emissionsCardData.data}
         width={200}
         config={emissionsCardData.config}
+        customInnerHoverLabel={CustomInnerHoverLabel}
         customTooltip={
           <CustomTooltip
             reference={this.state.tooltipParentRef}
@@ -210,7 +212,9 @@ class NDCSExploreMap extends PureComponent {
                             delayHide={isTablet ? 0 : 3000}
                           >
                             <Button
-                              onClick={() => handleCountryClick(null, countryData)}
+                              onClick={() =>
+                                handleCountryClick(null, countryData)
+                              }
                               className={tooltipTheme.container}
                             >
                               <div

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -217,6 +217,7 @@ export const getEmissionsCardData = createSelector(
         const [locationIso, { label_id: labelId }] = entry;
         if (
           labelId === parseInt(legendItem.id, 10) &&
+          locationIso !== 'EU28' && // To avoid double counting
           emissionPercentages[locationIso]
         ) {
           legendItemValue += parseFloat(emissionPercentages[locationIso].value);

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -3,12 +3,15 @@ import { getColorByIndex, createLegendBuckets } from 'utils/map';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
-import camelCase from 'lodash/camelCase';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { PATH_LAYERS } from 'app/data/constants';
 import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
-import { sortByIndexAndNotInfo } from 'components/ndcs/shared/utils';
+import {
+  sortByIndexAndNotInfo,
+  getIndicatorEmissionsData,
+  getLabels
+} from 'components/ndcs/shared/utils';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -208,57 +211,22 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
     const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
-    if (!emissionsIndicator) return null;
-    const emissionPercentages = emissionsIndicator.locations;
-    let summedPercentage = 0;
-    const data = legend.map(legendItem => {
-      let legendItemValue = 0;
-      Object.entries(selectedIndicator.locations).forEach(entry => {
-        const [locationIso, { label_id: labelId }] = entry;
-        if (
-          labelId === parseInt(legendItem.id, 10) &&
-          locationIso !== 'EU28' && // To avoid double counting
-          emissionPercentages[locationIso]
-        ) {
-          legendItemValue += parseFloat(emissionPercentages[locationIso].value);
-        }
-      });
-      summedPercentage += legendItemValue;
+    const data = getIndicatorEmissionsData(
+      emissionsIndicator,
+      selectedIndicator,
+      legend
+    );
 
-      // The 'No information' label is always the last one so we can calculate its value substracting from 100
-      if (legendItem.name === NOT_APPLICABLE_LABEL && summedPercentage < 100) {
-        return {
-          name: camelCase(legendItem.name),
-          value: 100 - summedPercentage
-        };
-      }
-      return {
-        name: camelCase(legendItem.name),
-        value: legendItemValue
-      };
-    });
     const config = {
       animation: true,
       innerRadius: 50,
       outerRadius: 70,
       hideLabel: true,
       hideLegend: true,
-      innerHoverLabel: true
+      innerHoverLabel: true,
+      ...getLabels(legend)
     };
 
-    const tooltipLabels = {};
-    const themeLabels = {};
-    legend.forEach(l => {
-      tooltipLabels[camelCase(l.name)] = {
-        label: l.name
-      };
-      themeLabels[camelCase(l.name)] = {
-        label: l.name,
-        stroke: l.color
-      };
-    });
-    config.tooltip = tooltipLabels;
-    config.theme = themeLabels;
     return {
       config,
       data

--- a/app/javascript/app/components/ndcs/shared/donut-custom-label/donut-custom-label.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-custom-label/donut-custom-label.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CustomInnerHoverLabel = ({ x, y, value }) => (
+  <text x={x} y={y - 18}>
+    <tspan x={x} textAnchor="middle">
+      {Math.round(value * 1000) / 10} %
+    </tspan>
+    <tspan x={x} textAnchor="middle" dy="20">
+      of global
+    </tspan>
+    <tspan x={x} textAnchor="middle" dy="20">
+      emissions.
+    </tspan>
+  </text>
+);
+
+CustomInnerHoverLabel.propTypes = {
+  x: PropTypes.number,
+  y: PropTypes.number,
+  value: PropTypes.string
+};
+
+export default CustomInnerHoverLabel;

--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -9,13 +9,11 @@ const DonutTooltip = props => {
   const {
     reference,
     chartReference,
-    content: { payload, coordinate },
-    data
+    content: { payload, coordinate }
   } = props;
   if (!payload || !payload[0]) return null;
 
-  const total = Object.values(data).reduce((acc, d) => acc + d.value, 0);
-  const percentage = Math.round((payload[0].value * 100) / total);
+  const percentage = parseFloat(Math.round(payload[0].value * 10)) / 10;
 
   const legendItemName = capitalize(lowerCase(payload[0].name));
 

--- a/app/javascript/app/components/ndcs/shared/utils.js
+++ b/app/javascript/app/components/ndcs/shared/utils.js
@@ -1,6 +1,74 @@
+import camelCase from 'lodash/camelCase';
+
+const NOT_APPLICABLE_LABEL = 'Not Applicable';
+const NOT_APPLICABLE_OR_NOT_INFO_LABEL = 'Not applicable or No information';
+
 export const sortByIndexAndNotInfo = (a, b) => {
   const isNotInfo = i => i.index <= 0;
   if (isNotInfo(a)) return 1;
   if (isNotInfo(b)) return -1;
   return a.index - b.index;
+};
+
+export const getIndicatorEmissionsData = (
+  emissionsIndicator,
+  selectedIndicator,
+  legend,
+  noInformationLabel = NOT_APPLICABLE_OR_NOT_INFO_LABEL
+) => {
+  if (!emissionsIndicator) return null;
+  const emissionPercentages = emissionsIndicator.locations;
+  let summedPercentage = 0;
+  const data = legend.map(legendItem => {
+    let legendItemValue = 0;
+    Object.entries(selectedIndicator.locations).forEach(entry => {
+      const [locationIso, { label_id: labelId }] = entry;
+      if (
+        labelId === parseInt(legendItem.id, 10) &&
+        locationIso !== 'EU28' && // To avoid double counting
+        emissionPercentages[locationIso]
+      ) {
+        legendItemValue += parseFloat(emissionPercentages[locationIso].value);
+      }
+    });
+    summedPercentage += legendItemValue;
+
+    return {
+      name: camelCase(legendItem.name),
+      value: legendItemValue
+    };
+  });
+
+  if (summedPercentage < 100) {
+    data.push({
+      name: noInformationLabel,
+      value: 100 - summedPercentage
+    });
+  }
+  return data;
+};
+
+export const getLabels = (
+  legend,
+  noInformationLabel = NOT_APPLICABLE_OR_NOT_INFO_LABEL
+) => {
+  const tooltip = {};
+  const theme = {};
+  legend.forEach(l => {
+    const legendName =
+      l.name === noInformationLabel || l.name === NOT_APPLICABLE_LABEL
+        ? noInformationLabel
+        : l.name;
+    tooltip[camelCase(legendName)] = {
+      label: legendName
+    };
+    theme[camelCase(legendName)] = {
+      label: legendName,
+      stroke: l.color
+    };
+  });
+  return {
+    tooltip,
+    theme
+  };
 };

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -178,6 +178,9 @@ export const DATA_EXPLORER_TO_MODULES_PARAMS = {
     },
     categories: {
       key: 'category'
+    },
+    indicators: {
+      key: 'indicator'
     }
   },
   'emission-pathways': {

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -53,7 +53,7 @@ export const FILTER_DEFAULTS = {
     sectors: 'Total including LUCF'
   },
   'ndc-content': {
-    categories: ALL_SELECTED,
+    categories: 'UNFCCC Process',
     indicators: ALL_SELECTED,
     sectors: ALL_SELECTED,
     countries: ALL_SELECTED

--- a/app/javascript/app/utils/data-explorer.js
+++ b/app/javascript/app/utils/data-explorer.js
@@ -2,7 +2,8 @@ import invertBy from 'lodash/invertBy';
 import qs from 'querystring';
 import {
   DATA_EXPLORER_TO_MODULES_PARAMS,
-  FILTERS_DATA_WITHOUT_MODEL
+  FILTERS_DATA_WITHOUT_MODEL,
+  DATA_EXPLORER_EXTERNAL_PREFIX
 } from 'data/data-explorer-constants';
 import { replaceAll } from 'utils/utils';
 import { getStorageWithExpiration } from 'utils/localStorage';
@@ -54,9 +55,10 @@ const parseFilters = (search, section) => {
   );
   const parsedFilters = {};
   Object.keys(search).forEach(key => {
-    const parsedKey = `external-${section}-${modulesToDataExplorerParamsSchema[
-      key
-    ]}`.replace('_', '-');
+    const parsedKey = `${DATA_EXPLORER_EXTERNAL_PREFIX}-${section}-${modulesToDataExplorerParamsSchema[key]}`.replace(
+      '_',
+      '-'
+    );
     parsedFilters[parsedKey] = search[key];
   });
   return parsedFilters;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.56.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.56.1",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",
     "d3-time-format": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,9 +2965,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.56.0":
-  version "1.56.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/8d92ee852cdd636c2ce9541d84576beb7792a6d6"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.56.1":
+  version "1.56.1"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/ba2cec6f908c8d723b5b11fa752d9ba45d031916"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
This PR fixes the emission donut chart on NDC and LTS explorer:

- Add different text to the inner label to show that these are GHG emissions.
- Show 'Not applicable or no information' for the missing data on the emissions chart
- Instead of recalculating the percentage use the real percentages
- Remove EU28 from the calculation to avoid double counting

![image](https://user-images.githubusercontent.com/9701591/73271759-7e432c80-41e1-11ea-9c15-8fe7ec883d36.png)

Extra:

- Fix NDC to data explorer link:
[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/391404521)
Try: https://climate-watch.vizzuality.com/ndcs-content?category=unfccc_process&indicator=revised and go to Data explorer