### PR TITLE
Fix/overview metadata

### DIFF
--- a/app/javascript/app/assets/icons/external-link.svg
+++ b/app/javascript/app/assets/icons/external-link.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="8px" height="12px" viewBox="0 0 8 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="UI-KIT" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="GENERAL-UI-COMPONENT" transform="translate(-312.000000, -2400.000000)" fill="#0a1941">
+            <g id="icon/external" transform="translate(312.000000, 2400.000000)">
+                <g id="open_in_new">
+                    <path d="M1.096,0.3 L7.8688,0.3 L7.8688,7.00575 L5.2744,4.674375 C3.8128,6.136125 0.8648,8.28975 2.3996,11.699625 C-2.3464,7.8795 1.5688,4.348875 3.21,2.60775 L1.0956,0.299625 L1.096,0.3 Z" id="Path"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
@@ -28,7 +28,7 @@ class LawsAndPolicies extends PureComponent {
   handleInfoOnClick = () => {
     this.props.setModalMetadata({
       category: 'Country',
-      slugs: ['national_laws_politices', 'ndc_cw'],
+      slugs: ['national_laws_policies', 'ndc_cw'],
       customTitle: 'Targets in Laws and Policies',
       open: true
     });

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -10,7 +10,6 @@ import QuestionCard from './question-card';
 const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
   const { title, description, hint, questions, color } = data;
   const isEmbed = isEmbededComponent(location);
-
   return (
     <div
       className={cx({
@@ -25,7 +24,13 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
                 <h1 className={styles.title}>{`${
                   isEmbed ? '' : `${section} `
                 }${title}`}</h1>
-                <p className={styles.description}>{description}</p>
+                <p
+                  className={cx(styles.description, {
+                    [styles.firstDescription]: parseInt(section, 10) === 1
+                  })}
+                >
+                  {description}
+                </p>
               </div>
               <p className={styles.hint}>{hint}</p>
             </div>
@@ -44,10 +49,10 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
                 metadataSlug={question.metadataSlug}
                 link={question.link}
                 color={color}
-                linkSlug={question.linkSlug}
                 questionText={question.questionText}
                 answerLabel={question.answerLabel}
                 handleInfoClick={handleInfoClick}
+                hasExternalLink={question.hasExternalLink}
               />
             ))}
           </div>

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -7,7 +7,7 @@ import ShareButton from 'components/button/share-button';
 import styles from './ndcs-overview-section-styles.scss';
 import QuestionCard from './question-card';
 
-const NdcsOverviewSection = ({ data, section, location }) => {
+const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
   const { title, description, hint, questions, color } = data;
   const isEmbed = isEmbededComponent(location);
 
@@ -41,11 +41,13 @@ const NdcsOverviewSection = ({ data, section, location }) => {
               <QuestionCard
                 key={`${question.slug}${question.questionText}`}
                 slug={question.slug}
+                metadataSlug={question.metadataSlug}
                 link={question.link}
                 color={color}
                 linkSlug={question.linkSlug}
                 questionText={question.questionText}
                 answerLabel={question.answerLabel}
+                handleInfoClick={handleInfoClick}
               />
             ))}
           </div>
@@ -58,6 +60,7 @@ const NdcsOverviewSection = ({ data, section, location }) => {
 NdcsOverviewSection.propTypes = {
   section: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   location: PropTypes.object,
+  handleInfoClick: PropTypes.func.isRequired,
   data: PropTypes.shape({
     title: PropTypes.string,
     description: PropTypes.string,

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -12,6 +12,7 @@ export const commitmentsData = [
         link:
           'https://unfccc.int/process/the-paris-agreement/status-of-ratification',
         slug: 'pa_ratified',
+        metadataSlug: 'ndc_cw',
         answerLabel: 'Yes'
       },
       {
@@ -19,12 +20,14 @@ export const commitmentsData = [
           'How many Parties submitted first Nationally Determined Contributions?',
         link: 'https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx',
         slug: 'submission',
+        metadataSlug: 'ndc_cw',
         answerLabel: 'First NDC Submitted'
       },
       {
         questionText: 'How many Parties have submitted Long-Term Strategies?',
         link: '/lts-tracker',
         slug: 'lts_submission',
+        metadataSlug: 'ndc_cw',
         answerLabel: 'Long-term Strategy Submitted'
       }
     ]
@@ -43,6 +46,7 @@ export const commitmentsData = [
         link: '/ndc-tracker',
         slug: 'ndce_status_2020',
         linkSlug: 'enhance_2020',
+        metadataSlug: 'ndc_cw',
         answerLabel: 'Intends to Enhance Ambition or Action in 2020 NDC'
       },
       {
@@ -51,6 +55,7 @@ export const commitmentsData = [
         link: '/ndc-tracker',
         slug: 'ndce_status_2020',
         linkSlug: 'submitted_2020',
+        metadataSlug: 'ndc_cw',
         answerLabel: '2020 NDC Submitted'
       }
     ]

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export const commitmentsData = [
   {
     title: 'Climate commitments under the Paris Agreement.',
@@ -70,12 +71,14 @@ export const commitmentsData = [
     questions: [
       {
         questionText: 'How many countries have a net zero emission target?',
-        link: 'https://eciu.net/netzerotracker'
+        link: 'https://eciu.net/netzerotracker',
+        metadataSlug: 'net_zero'
       },
       {
         questionText:
           'How many countries have an economy-wide target in a national law or policy?',
-        link: 'https://climate-laws.org/'
+        link: 'https://climate-laws.org/',
+        metadataSlug: 'national_laws_policies'
       }
     ]
   }

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -10,8 +10,7 @@ export const commitmentsData = [
     questions: [
       {
         questionText: 'How many Parties ratified the Paris Agreement?',
-        link:
-          'https://unfccc.int/process/the-paris-agreement/status-of-ratification',
+        link: '/ndcs-explore?indicator=pa_status',
         slug: 'pa_ratified',
         metadataSlug: 'ndc_cw',
         answerLabel: 'Yes'
@@ -19,7 +18,7 @@ export const commitmentsData = [
       {
         questionText:
           'How many Parties submitted first Nationally Determined Contributions?',
-        link: 'https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx',
+        link: '/ndcs-explore',
         slug: 'submission',
         metadataSlug: 'ndc_cw',
         answerLabel: 'First NDC Submitted'
@@ -44,18 +43,16 @@ export const commitmentsData = [
       {
         questionText:
           'How many Parties intend to enhance ambition or action in their NDCs?',
-        link: '/ndc-tracker',
+        link: '/ndcs-explore',
         slug: 'ndce_status_2020',
-        linkSlug: 'enhance_2020',
         metadataSlug: 'ndc_cw',
         answerLabel: 'Intends to Enhance Ambition or Action in 2020 NDC'
       },
       {
         questionText:
           'How many Parties have submitted an updated or second NDC?',
-        link: '/ndc-tracker',
+        link: '/ndcs-explore',
         slug: 'ndce_status_2020',
-        linkSlug: 'submitted_2020',
         metadataSlug: 'ndc_cw',
         answerLabel: '2020 NDC Submitted'
       }
@@ -64,21 +61,23 @@ export const commitmentsData = [
   {
     title: 'Other climate commitments.',
     description:
-      'Aside from commitments made through NDCs and LTS, some countries also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these targets are not explicitly for the Paris Agreement, they indicate countries’ commitment to climate action and may align with commitments under the Paris Agreement.',
+      'Aside from commitments made through NDCs and LTS, some parties also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these targets are not explicitly for the Paris Agreement, they indicate parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
     hint:
-      'See how many countries have submitted additional commitments and explore the details by clicking on each box.',
+      'See how many parties have submitted additional commitments and explore the details by clicking on each box.',
     color: '#2EC9DF',
     questions: [
       {
-        questionText: 'How many countries have a net zero emission target?',
+        questionText: 'How many parties have a net zero emission target?',
         link: 'https://eciu.net/netzerotracker',
-        metadataSlug: 'net_zero'
+        metadataSlug: 'net_zero',
+        hasExternalLink: true
       },
       {
         questionText:
-          'How many countries have an economy-wide target in a national law or policy?',
+          'How many parties have an economy-wide target in a national law or policy?',
         link: 'https://climate-laws.org/',
-        metadataSlug: 'national_laws_policies'
+        metadataSlug: 'national_laws_policies',
+        hasExternalLink: true
       }
     ]
   }

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-styles.scss
@@ -47,6 +47,10 @@
   font-size: $font-size;
   line-height: $line-height-modal;
   margin-bottom: 20px;
+
+  &.firstDescription {
+    margin-bottom: 145px;
+  }
 }
 
 .hint {

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import actions from 'pages/ndcs/ndcs-actions';
+import { actions as modalActions } from 'components/modal-metadata';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 
@@ -13,6 +14,16 @@ const NdcsOverviewSection = props => {
     fetchNDCS(true);
   }, []);
 
+  const handleInfoClick = source => {
+    if (source) {
+      props.setModalMetadata({
+        category: 'NDC Overview',
+        slugs: source,
+        open: true
+      });
+    }
+  };
+
   const { match, location } = props;
   let { section } = props;
   section = section || match.params.section;
@@ -23,6 +34,7 @@ const NdcsOverviewSection = props => {
         key={commitmentData.title}
         section={index + 1}
         location={location}
+        handleInfoClick={handleInfoClick}
       />
     ));
   }
@@ -31,6 +43,7 @@ const NdcsOverviewSection = props => {
       data={commitmentsData[section - 1]}
       section={section}
       location={location}
+      handleInfoClick={handleInfoClick}
     />
   );
 };
@@ -38,6 +51,9 @@ const NdcsOverviewSection = props => {
 NdcsOverviewSection.propTypes = {
   section: PropTypes.number,
   location: PropTypes.object,
-  match: PropTypes.object
+  match: PropTypes.object,
+  setModalMetadata: PropTypes.func.isRequired
 };
-export default withRouter(connect(null, actions)(NdcsOverviewSection));
+export default withRouter(
+  connect(null, { ...actions, ...modalActions })(NdcsOverviewSection)
+);

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Progress from 'components/progress';
 import Icon from 'components/icon';
 import infoIcon from 'assets/icons/info.svg';
+import externalLinkIcon from 'assets/icons/external-link.svg';
 import ReactTooltip from 'react-tooltip';
 import Loading from 'components/loading';
 import styles from './question-card.scss';
@@ -12,6 +13,7 @@ const QuestionCard = ({
   link,
   questionText,
   questionStats,
+  hasExternalLink,
   color,
   handleInfoClick
 }) => {
@@ -33,9 +35,14 @@ const QuestionCard = ({
         className={styles.questionCardLink}
         href={link}
         target="_blank"
-        title="Paris agreement - Status of ratification"
+        title={questionText}
       >
-        <div className={styles.questionText}>{questionText}</div>
+        <div className={styles.questionText}>
+          {questionText}
+          {hasExternalLink && (
+            <Icon className={styles.externalLinkIcon} icon={externalLinkIcon} />
+          )}
+        </div>
         {answerNumber || answerNumber === 0 ? (
           <React.Fragment>
             <div className={styles.answerText}>
@@ -66,6 +73,7 @@ const QuestionCard = ({
 QuestionCard.propTypes = {
   questionText: PropTypes.string,
   link: PropTypes.string,
+  hasExternalLink: PropTypes.bool,
   metadataSlug: PropTypes.string,
   handleInfoClick: PropTypes.func.isRequired,
   color: PropTypes.string,

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-component.jsx
@@ -7,55 +7,67 @@ import ReactTooltip from 'react-tooltip';
 import Loading from 'components/loading';
 import styles from './question-card.scss';
 
-const QuestionCard = ({ link, questionText, questionStats, color }) => {
+const QuestionCard = ({
+  metadataSlug,
+  link,
+  questionText,
+  questionStats,
+  color,
+  handleInfoClick
+}) => {
   const { answerNumber, maxPartiesNumber, emissionPercentage } =
     questionStats || {};
   return (
-    <a
-      className={styles.questionCard}
-      href={link}
-      target="_blank"
-      title="Paris agreement - Status of ratification"
-    >
+    <div className={styles.questionCard}>
       <button
         title="Information"
         className={styles.infoButton}
         data-for="info-button"
         data-tip="Information"
+        onClick={() => handleInfoClick(metadataSlug)}
       >
         <Icon icon={infoIcon} />
         <ReactTooltip id="info-button" effect="solid" />
       </button>
-      <div className={styles.questionText}>{questionText}</div>
-      {answerNumber || answerNumber === 0 ? (
-        <React.Fragment>
-          <div className={styles.answerText}>
-            <span className={styles.answerNumber}>{answerNumber}</span> out of{' '}
-            {maxPartiesNumber} covering{' '}
-            <span className={styles.percentage}>
-              {emissionPercentage || emissionPercentage === 0
-                ? Math.round(emissionPercentage * 10) / 10
-                : '-'}{' '}
-              %
-            </span>{' '}
-            of total GHG emissions
-          </div>
-          <Progress
-            value={(answerNumber / maxPartiesNumber) * 100}
-            className={styles.progressBar}
-            color={color}
-          />
-        </React.Fragment>
-      ) : (
-        <Loading light mini className={styles.loader} />
-      )}
-    </a>
+      <a
+        className={styles.questionCardLink}
+        href={link}
+        target="_blank"
+        title="Paris agreement - Status of ratification"
+      >
+        <div className={styles.questionText}>{questionText}</div>
+        {answerNumber || answerNumber === 0 ? (
+          <React.Fragment>
+            <div className={styles.answerText}>
+              <span className={styles.answerNumber}>{answerNumber}</span> out of{' '}
+              {maxPartiesNumber} covering{' '}
+              <span className={styles.percentage}>
+                {emissionPercentage || emissionPercentage === 0
+                  ? Math.round(emissionPercentage * 10) / 10
+                  : '-'}{' '}
+                %
+              </span>{' '}
+              of total GHG emissions
+            </div>
+            <Progress
+              value={(answerNumber / maxPartiesNumber) * 100}
+              className={styles.progressBar}
+              color={color}
+            />
+          </React.Fragment>
+        ) : (
+          <Loading light mini className={styles.loader} />
+        )}
+      </a>
+    </div>
   );
 };
 
 QuestionCard.propTypes = {
   questionText: PropTypes.string,
   link: PropTypes.string,
+  metadataSlug: PropTypes.string,
+  handleInfoClick: PropTypes.func.isRequired,
   color: PropTypes.string,
   questionStats: PropTypes.object
 };

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
@@ -7,8 +7,6 @@
   padding: 30px 20px 20px;
   clear: both;
   display: block;
-  color: $theme-color;
-  text-decoration: none;
   margin-bottom: 20px;
 
   @media #{$tablet-portrait} {
@@ -18,6 +16,11 @@
   &:hover {
     background-color: $gray3;
   }
+}
+
+.questionCardLink {
+  color: $theme-color;
+  text-decoration: none;
 }
 
 .infoButton {

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card.scss
@@ -23,6 +23,12 @@
   text-decoration: none;
 }
 
+.externalLinkIcon {
+  margin-left: 10px;
+  height: 12px;
+  width: 12px;
+}
+
 .infoButton {
   position: absolute;
   z-index: $z-index-over-map;

--- a/app/javascript/app/pages/ndc-overview/ndc-overview-component.jsx
+++ b/app/javascript/app/pages/ndc-overview/ndc-overview-component.jsx
@@ -6,6 +6,7 @@ import Intro from 'components/intro';
 import { NDCS_OVERVIEW } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import { renderRoutes } from 'react-router-config';
+import ModalMetadata from 'components/modal-metadata';
 import styles from './ndc-overview-styles.scss';
 
 const NdcOverview = ({ route }) => (
@@ -28,6 +29,7 @@ const NdcOverview = ({ route }) => (
       </div>
     </Header>
     {renderRoutes(route.routes)}
+    <ModalMetadata />
   </div>
 );
 


### PR DESCRIPTION
Adress Overview feedback and feed metadata to info modal
[Metadata Document](https://onewri.sharepoint.com/:w:/r/sites/climatewatch/_layouts/15/Doc.aspx?sourcedoc=%7BA95A2CFB-9C4B-40B0-8A51-C55164717A4C%7D&file=AoA%20Overivew%20page%20links.docx&action=default&mobileredirect=true&cid=f85b6657-d913-4f53-8189-ea5359229cf4)
[Feedback Document](https://onewri.sharepoint.com/:w:/r/sites/climatewatch/_layouts/15/Doc.aspx?sourcedoc=%7BEFE6B29E-1A1B-4716-A129-179175F612D8%7D&file=Feedback%20on%20the%20LTS%20explorer.docx&action=default&mobileredirect=true&cid=11d702f4-caee-4b57-940d-9938035c0dbd)

- Add metadata with info modals
- Update links and metadata
- Fix typo on metadata slug
- Fix layout on the first section
- Add external link icon

TRY: use `rails wri_metadata:import` to import the last metadata

![image](https://user-images.githubusercontent.com/9701591/73676982-a6d19780-46b5-11ea-80bd-2be6743b4b2b.png)
