### PR TITLE
 Fix progress bar, Try to create a mask instead of adding it on top

### DIFF
--- a/app/javascript/app/components/progress/progress-component.jsx
+++ b/app/javascript/app/components/progress/progress-component.jsx
@@ -9,10 +9,12 @@ const Progress = ({ value, theme, color, className = '' }) => {
   const classNames = cx(className, theme.icon);
   return (
     <div className={cx(styles.progress, classNames)}>
-      <div
-        className={styles.bar}
-        style={{ backgroundColor: color, width: `${value ? value + 1 : 0}%` }}
-      />
+      {!!value && (
+        <div
+          className={styles.bar}
+          style={{ backgroundColor: color, width: `${value ? value + 1 : 0}%` }}
+        />
+      )}
     </div>
   );
 };

--- a/app/javascript/app/components/progress/progress-styles.scss
+++ b/app/javascript/app/components/progress/progress-styles.scss
@@ -1,16 +1,26 @@
 @import '~styles/settings';
 
 .progress {
-  width: 101%;
   height: 10px;
   background-color: $gray3;
-  border-radius: 10px;
   border: 1px solid $gray1;
+  border-radius: 10px;
+  overflow: hidden;
 
   .bar {
-    border-radius: 10px;
-    height: 130%;
-    margin-top: -1px;
-    margin-left: -1px;
+    background-clip: content-box;
+    height: 100%;
+    padding-right: 4px;
+    position: relative;
+
+    &:after {
+      content: '';
+      background: inherit;
+      border-radius: 0 10px 10px 0;
+      height: 8px;
+      position: absolute;
+      right: 0;
+      width: 4px;
+    }
   }
 }


### PR DESCRIPTION
This PR tweaks a bit the progress bar component on NDCS/LTS Explore pages:
[PIVOTAL](https://www.pivotaltracker.com/story/show/170700083)

**BEFORE:**
![image](https://user-images.githubusercontent.com/15097138/73866879-7fa5d200-483d-11ea-8d1e-82676c079138.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/15097138/73866841-6dc42f00-483d-11ea-9e4b-ebac47f5cd60.png)
