### PR TITLE
Fix/loader on iframe

### DIFF
--- a/app/javascript/app/components/about/about-contact/about-contact-component.jsx
+++ b/app/javascript/app/components/about/about-contact/about-contact-component.jsx
@@ -1,26 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
 import cx from 'classnames';
 import layout from 'styles/layout';
+import Loading from 'components/loading';
 import styles from './about-contact-styles.scss';
 
-const AboutContact = () => (
-  <div className={cx(styles.aboutContact, layout.content)}>
-    <p>
-      We’d love to hear from you. Please submit questions, comments or feedback
-      to <a href="mailto:ClimateWatch@WRI.org">ClimateWatch@WRI.org</a>
-    </p>
-    <h3>Sign Up for Updates</h3>
-    <p>
-      Subscribe to our newsletter for updates and events on Climate Watch and
-      other climate-related tools.
-    </p>
-    <iframe
-      title="contact-form"
-      className={styles.contactIframe}
-      src="//go.pardot.com/l/120942/2017-09-11/3khdjq"
-      frameBorder="0"
-    />
-  </div>
-);
+const AboutContact = () => {
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+  return (
+    <div className={cx(styles.aboutContact, layout.content)}>
+      <p>
+        We’d love to hear from you. Please submit questions, comments or
+        feedback to{' '}
+        <a href="mailto:ClimateWatch@WRI.org">ClimateWatch@WRI.org</a>
+      </p>
+      <h3>Sign Up for Updates</h3>
+      <p>
+        Subscribe to our newsletter for updates and events on Climate Watch and
+        other climate-related tools.
+      </p>
+      {!iframeLoaded && <Loading light className={styles.loader} />}
+      <iframe
+        onLoad={() => setIframeLoaded(true)}
+        title="contact-form"
+        id="contact-form"
+        className={styles.contactIframe}
+        src="//go.pardot.com/l/120942/2017-09-11/3khdjq"
+        frameBorder="0"
+      />
+    </div>
+  );
+};
 
 export default AboutContact;

--- a/app/javascript/app/components/about/about-contact/about-contact-styles.scss
+++ b/app/javascript/app/components/about/about-contact/about-contact-styles.scss
@@ -21,4 +21,8 @@
     height: 580px;
     width: 100%;
   }
+
+  .loader {
+    min-height: 580px;
+  }
 }

--- a/app/javascript/app/components/button/button-styles.scss
+++ b/app/javascript/app/components/button/button-styles.scss
@@ -10,7 +10,6 @@
   border-radius: 4px;
   font-family: $font-family-1;
   font-size: $font-size;
-  text-transform: capitalize;
   color: $theme-color;
   cursor: pointer;
   transition: background-color 150ms ease-out;

--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-component.jsx
@@ -82,7 +82,7 @@ class CompareGhgChart extends PureComponent {
         link={`/ghg-emissions?breakBy=regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}&regions=${selectedLocationsFilter}`}
         onClick={handleAnalyticsClick}
       >
-        Explore emissions
+        Explore Emissions
       </Button>
     ];
   }

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -94,7 +94,7 @@ class CountryGhgEmissions extends PureComponent {
         link={isNdcp ? null : link}
         onClick={handleAnalyticsClick}
       >
-        Explore emissions
+        Explore Emissions
       </Button>
     ];
   }

--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages-component.jsx
@@ -158,7 +158,7 @@ class CountrySDGLinkages extends PureComponent {
         link={isNdcp ? null : link}
         onClick={handleAnalyticsClick}
       >
-        Explore global linkages
+        Explore Global Linkages
       </Button>
     );
     const buttonGroupConfig = isEmbed

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -22,7 +22,7 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
             <div className={styles.commitmentText}>
               <div>
                 <h1 className={styles.title}>{`${
-                  isEmbed ? '' : `${section} `
+                  isEmbed ? '' : `${section}. `
                 }${title}`}</h1>
                 <p
                   className={cx(styles.description, {

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 export const commitmentsData = [
   {
-    title: 'Climate commitments under the Paris Agreement.',
+    title: 'Climate commitments under the Paris Agreement',
     description:
       'Countries that are Parties to the Paris Agreement are required to outline their post-2020 climate actions, known as Nationally Determined Contributions (NDCs). NDCs embody efforts by each country to reduce national emissions and adapt to the impacts of climate change. Countries are also invited to communicate “mid-century long-term low GHG emissions development strategies” (long-term strategies, or LTS). NDCs and LTS are central to achieving the Paris Agreement’s goal of limiting global warming to well below 2°C and pursuing efforts to limit the increase to 1.5°C.',
     hint:
@@ -33,7 +33,7 @@ export const commitmentsData = [
     ]
   },
   {
-    title: 'Increasing ambition of climate commitments.',
+    title: 'Increasing ambition of climate commitments',
     description:
       'Under the Paris Agreement, Parties are requested to submit new or updated NDCs every five years, starting in 2020. The Paris Agreement is built on the idea of increasing ambition of NDCs to meet its temperature goals.',
     hint:
@@ -59,7 +59,7 @@ export const commitmentsData = [
     ]
   },
   {
-    title: 'Other climate commitments.',
+    title: 'Other climate commitments',
     description:
       'Aside from commitments made through NDCs and LTS, some parties also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these targets are not explicitly for the Paris Agreement, they indicate parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
     hint:

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-component.jsx
@@ -119,7 +119,7 @@ class HistoricalEmissionsGraph extends PureComponent {
     ];
     return (
       <ExploreButtonGroup
-        exploreButtonText="Explore emissions"
+        exploreButtonText="Explore Emissions"
         exploreButtonConfig={exploreEmissionsConfig}
         buttonGroupConfig={buttonGroupConfig}
         theme={{

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -46,7 +46,7 @@ class LTSCountry extends PureComponent {
           className={styles.compareButton}
           disabled
         >
-          Compare countries and submissions
+          Compare Countries and Submissions
         </Button>
       </div>
     );

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -60,7 +60,7 @@ class NDCCountry extends PureComponent {
           variant="primary"
           link={`/ndcs/compare/mitigation?locations=${match.params.iso}`}
         >
-          {'Compare'}
+          Compare
         </Button>
       );
     }
@@ -71,7 +71,7 @@ class NDCCountry extends PureComponent {
           link={`/ndcs/compare/mitigation?locations=${match.params.iso}`}
           className={styles.compareButton}
         >
-          Compare countries and submissions
+          Compare Countries and Submissions
         </Button>
       </div>
     );

--- a/app/javascript/app/pages/ndcs-explore/ndcs-explore-component.jsx
+++ b/app/javascript/app/pages/ndcs-explore/ndcs-explore-component.jsx
@@ -22,7 +22,7 @@ const NDCSExplore = ({ route }) => (
         <div className="grid-column-item">
           <div className={styles.headerLayout}>
             <Intro
-              title="Explore National determined Contributions (NDCS)"
+              title="Explore Nationally Determined Contributions (NDCs)"
               description="Under the Paris Agreement, nearly every nation made a commitment to tackle climate change and strengthen their efforts over time. Explore the content of these nationally determined contributions (NDCs) by searching for key terms. You can analyze and compare NDCs using over 150 structured indicators."
             />
           </div>


### PR DESCRIPTION
There was a bug warning that the contact form was not displayed on firefox. This might be due a temporary problem on the target website (out of our reach) or due to a long time waiting. For this case I added a loader so the user doesn´t feel its broken.

![image](https://user-images.githubusercontent.com/9701591/74164554-3631fa00-4c24-11ea-81ee-336fe569796f.png)

Extra:

- Fix overview page dots. Remove the one at the end of the title and add the one after the number.
- Don't always capitalize the text in buttons: We were ending with some strange behavior like "Countries **And** Submissions"