### PR TITLE
Fix ndcp embed

### DIFF
--- a/app/javascript/app/layouts/embed/embed-component.jsx
+++ b/app/javascript/app/layouts/embed/embed-component.jsx
@@ -16,7 +16,7 @@ class Embed extends PureComponent {
     const link = location.pathname.replace('/embed', '');
     const isNdcp = isPageNdcp(location);
     return (
-      <div className={styles.embed}>
+      <div className={cx(styles.embed, { [styles.embedNdcp]: isNdcp })}>
         <CountriesProvider />
         <div
           className={cx(layout.content, styles.embedContent, {

--- a/app/javascript/app/layouts/embed/embed-styles.scss
+++ b/app/javascript/app/layouts/embed/embed-styles.scss
@@ -9,6 +9,11 @@ $footer-height: 65px;
   border: solid 1px $gray1;
   height: 100%;
   background-color: $white;
+
+  &.embedNdcp {
+    height: initial;
+    border: none;
+  }
 }
 
 .hasFooter {


### PR DESCRIPTION
This is a little PR that removes the border and the height 100% if the page is embedded on the NDC Partnership page.

We needed to remove this height:100% because of the iframeResizer calculation