### PR TITLE
Adds lts_content api v1 data controllers

### DIFF
--- a/app/controllers/api/v1/data/lts_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/categories_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    module Data
+      module LtsContent
+        class CategoriesController < Api::V1::Data::ApiController
+          def index
+            source = ::Indc::Source.lts.pluck(:id)
+            categories = ::Indc::Category.includes(:category_type).
+              joins(:indicators).
+              where(indc_indicators: { source_id: source }).
+              where(
+                'indc_category_types.name' => [
+                  ::Indc::CategoryType::GLOBAL, ::Indc::CategoryType::OVERVIEW
+                ]
+              )
+            render json: categories,
+                   adapter: :json,
+                   each_serializer: Api::V1::Data::NdcContent::CategorySerializer,
+                   root: :data
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/data/lts_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/categories_controller.rb
@@ -7,7 +7,7 @@ module Api
             source = ::Indc::Source.lts.pluck(:id)
             categories = ::Indc::Category.includes(:category_type).
               joins(:indicators).
-              where(indc_indicators: { source_id: source }).
+              where(indc_indicators: {source_id: source}).
               where(
                 'indc_category_types.name' => [
                   ::Indc::CategoryType::GLOBAL, ::Indc::CategoryType::OVERVIEW

--- a/app/controllers/api/v1/data/lts_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/categories_controller.rb
@@ -2,21 +2,11 @@ module Api
   module V1
     module Data
       module LtsContent
-        class CategoriesController < Api::V1::Data::ApiController
-          def index
-            source = ::Indc::Source.lts.pluck(:id)
-            categories = ::Indc::Category.includes(:category_type).
-              joins(:indicators).
-              where(indc_indicators: {source_id: source}).
-              where(
-                'indc_category_types.name' => [
-                  ::Indc::CategoryType::GLOBAL, ::Indc::CategoryType::OVERVIEW
-                ]
-              )
-            render json: categories,
-                   adapter: :json,
-                   each_serializer: Api::V1::Data::NdcContent::CategorySerializer,
-                   root: :data
+        class CategoriesController < Api::V1::Data::NdcContent::CategoriesController
+          private
+
+          def source
+            ::Indc::Source.non_lts.pluck(:id)
           end
         end
       end

--- a/app/controllers/api/v1/data/lts_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/categories_controller.rb
@@ -6,7 +6,7 @@ module Api
           private
 
           def source
-            ::Indc::Source.non_lts.pluck(:id)
+            ::Indc::Source.lts.pluck(:id)
           end
         end
       end

--- a/app/controllers/api/v1/data/lts_content/data_sources_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/data_sources_controller.rb
@@ -2,13 +2,11 @@ module Api
   module V1
     module Data
       module LtsContent
-        class DataSourcesController < Api::V1::Data::ApiController
-          def index
-            data_sources = ::Indc::Source.lts
-            render json: data_sources,
-                   adapter: :json,
-                   each_serializer: Api::V1::Data::NdcContent::DataSourceSerializer,
-                   root: :data
+        class DataSourcesController < Api::V1::Data::NdcContent::DataSourcesController
+          private
+
+          def data_sources
+            ::Indc::Source.lts
           end
         end
       end

--- a/app/controllers/api/v1/data/lts_content/data_sources_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/data_sources_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    module Data
+      module LtsContent
+        class DataSourcesController < Api::V1::Data::ApiController
+          def index
+            data_sources = ::Indc::Source.lts
+            render json: data_sources,
+                   adapter: :json,
+                   each_serializer: Api::V1::Data::NdcContent::DataSourceSerializer,
+                   root: :data
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/data/lts_content/indicators_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/indicators_controller.rb
@@ -2,22 +2,15 @@ module Api
   module V1
     module Data
       module LtsContent
-        class IndicatorsController < Api::V1::Data::ApiController
-          def index
-            set_links_header(
-              [
-                {
-                  link: '/api/v1/data/lts_content/data_sources',
-                  rel: 'meta data_sources'
-                }
-              ]
-            )
-            source = ::Indc::Source.lts.pluck(:id)
-            indicators = ::Indc::Indicator.where(source_id: source).includes(:categories).all
-            render json: indicators,
-                   adapter: :json,
-                   each_serializer: Api::V1::Data::NdcContent::IndicatorSerializer,
-                   root: :data
+        class IndicatorsController < Api::V1::Data::NdcContent::IndicatorsController
+          private
+
+          def source
+            ::Indc::Source.lts.pluck(:id)
+          end
+
+          def link_prefix
+            '/api/v1/data/lts_content/data_sources'
           end
         end
       end

--- a/app/controllers/api/v1/data/lts_content/indicators_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/indicators_controller.rb
@@ -1,0 +1,26 @@
+module Api
+  module V1
+    module Data
+      module LtsContent
+        class IndicatorsController < Api::V1::Data::ApiController
+          def index
+            set_links_header(
+              [
+                {
+                  link: '/api/v1/data/lts_content/data_sources',
+                  rel: 'meta data_sources'
+                }
+              ]
+            )
+            source = ::Indc::Source.lts.pluck(:id)
+            indicators = ::Indc::Indicator.where(source_id: source).includes(:categories).all
+            render json: indicators,
+                   adapter: :json,
+                   each_serializer: Api::V1::Data::NdcContent::IndicatorSerializer,
+                   root: :data
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/data/lts_content/sectors_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/sectors_controller.rb
@@ -2,13 +2,7 @@ module Api
   module V1
     module Data
       module LtsContent
-        class SectorsController < ApiController
-          def index
-            render json: ::Indc::Sector.all,
-                   adapter: :json,
-                   each_serializer: Api::V1::Data::NdcContent::SectorSerializer,
-                   root: :data
-          end
+        class SectorsController < Api::V1::Data::NdcContent::SectorsController
         end
       end
     end

--- a/app/controllers/api/v1/data/lts_content/sectors_controller.rb
+++ b/app/controllers/api/v1/data/lts_content/sectors_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    module Data
+      module LtsContent
+        class SectorsController < ApiController
+          def index
+            render json: ::Indc::Sector.all,
+                   adapter: :json,
+                   each_serializer: Api::V1::Data::NdcContent::SectorSerializer,
+                   root: :data
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/data/lts_content_controller.rb
+++ b/app/controllers/api/v1/data/lts_content_controller.rb
@@ -1,39 +1,12 @@
 module Api
   module V1
     module Data
-      class LtsContentController < Api::V1::Data::ApiController
-        include Streamable
-        before_action :parametrise_filter, only: [:index, :download]
-
-        def index
-          @records = paginate @filter.call
-          render json: @records,
-                 adapter: :json,
-                 each_serializer: Api::V1::Data::NdcContent::NdcContentSerializer,
-                 params: params,
-                 root: :data,
-                 meta: @filter.meta
-        end
-
-        def meta
-          set_links_header(
-            [
-              :data_sources, :indicators, :categories, :sectors
-            ].map do |resource|
-              {
-                link: "/api/v1/data/lts_content/#{resource}",
-                rel: "meta #{resource}"
-              }
-            end + [{link: '/api/v1/locations/countries', rel: 'meta locations'}]
-          )
-        end
-
-        def download
-          zipped_download = Api::V1::Data::NdcContent::ZippedDownload.new(@filter)
-          stream_file(zipped_download.filename) { zipped_download.call }
-        end
-
+      class LtsContentController < Api::V1::Data::NdcContentController
         private
+
+        def link_prefix
+          '/api/v1/data/lts_content/'
+        end
 
         def parametrise_filter
           params[:source_ids] = ::Indc::Source.lts.pluck(:id)

--- a/app/controllers/api/v1/data/lts_content_controller.rb
+++ b/app/controllers/api/v1/data/lts_content_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module Data
-      class NdcContentController < Api::V1::Data::ApiController
+      class LtsContentController < Api::V1::Data::ApiController
         include Streamable
         before_action :parametrise_filter, only: [:index, :download]
 
@@ -21,7 +21,7 @@ module Api
               :data_sources, :indicators, :categories, :sectors
             ].map do |resource|
               {
-                link: "/api/v1/data/ndc_content/#{resource}",
+                link: "/api/v1/data/lts_content/#{resource}",
                 rel: "meta #{resource}"
               }
             end + [{link: '/api/v1/locations/countries', rel: 'meta locations'}]
@@ -36,7 +36,7 @@ module Api
         private
 
         def parametrise_filter
-          params[:source_ids] = ::Indc::Source.not_lts.pluck(:id) unless params[:source_ids]
+          params[:source_ids] = ::Indc::Source.lts.pluck(:id)
           @filter = Data::NdcContent::Filter.new(params)
         end
       end

--- a/app/controllers/api/v1/data/ndc_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/categories_controller.rb
@@ -7,7 +7,7 @@ module Api
             source = ::Indc::Source.lts.pluck(:id)
             categories = ::Indc::Category.includes(:category_type).
               joins(:indicators).
-              where(indc_indicators: { source_id: source }).
+              where(indc_indicators: {source_id: source}).
               where(
                 'indc_category_types.name' => [
                   ::Indc::CategoryType::GLOBAL, ::Indc::CategoryType::OVERVIEW

--- a/app/controllers/api/v1/data/ndc_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/categories_controller.rb
@@ -4,7 +4,7 @@ module Api
       module NdcContent
         class CategoriesController < Api::V1::Data::ApiController
           def index
-            source = ::Indc::Source.lts.pluck(:id)
+            source = ::Indc::Source.non_lts.pluck(:id)
             categories = ::Indc::Category.includes(:category_type).
               joins(:indicators).
               where(indc_indicators: {source_id: source}).

--- a/app/controllers/api/v1/data/ndc_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/categories_controller.rb
@@ -4,7 +4,6 @@ module Api
       module NdcContent
         class CategoriesController < Api::V1::Data::ApiController
           def index
-            source = ::Indc::Source.non_lts.pluck(:id)
             categories = ::Indc::Category.includes(:category_type).
               joins(:indicators).
               where(indc_indicators: {source_id: source}).
@@ -17,6 +16,12 @@ module Api
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::CategorySerializer,
                    root: :data
+          end
+
+          private
+
+          def source
+            ::Indc::Source.non_lts.pluck(:id)
           end
         end
       end

--- a/app/controllers/api/v1/data/ndc_content/categories_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/categories_controller.rb
@@ -4,7 +4,10 @@ module Api
       module NdcContent
         class CategoriesController < Api::V1::Data::ApiController
           def index
+            source = ::Indc::Source.lts.pluck(:id)
             categories = ::Indc::Category.includes(:category_type).
+              joins(:indicators).
+              where(indc_indicators: { source_id: source }).
               where(
                 'indc_category_types.name' => [
                   ::Indc::CategoryType::GLOBAL, ::Indc::CategoryType::OVERVIEW

--- a/app/controllers/api/v1/data/ndc_content/data_sources_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/data_sources_controller.rb
@@ -4,11 +4,16 @@ module Api
       module NdcContent
         class DataSourcesController < Api::V1::Data::ApiController
           def index
-            data_sources = ::Indc::Source.non_lts
             render json: data_sources,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::DataSourceSerializer,
                    root: :data
+          end
+
+          private
+
+          def data_sources
+            ::Indc::Source.non_lts
           end
         end
       end

--- a/app/controllers/api/v1/data/ndc_content/data_sources_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/data_sources_controller.rb
@@ -4,7 +4,7 @@ module Api
       module NdcContent
         class DataSourcesController < Api::V1::Data::ApiController
           def index
-            data_sources = ::Indc::Source.all
+            data_sources = ::Indc::Source.non_lts
             render json: data_sources,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::DataSourceSerializer,

--- a/app/controllers/api/v1/data/ndc_content/indicators_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/indicators_controller.rb
@@ -7,17 +7,26 @@ module Api
             set_links_header(
               [
                 {
-                  link: '/api/v1/data/ndc_content/data_sources',
+                  link: link_prefix,
                   rel: 'meta data_sources'
                 }
               ]
             )
-            source = ::Indc::Source.non_lts.pluck(:id)
             indicators = ::Indc::Indicator.where(source_id: source).includes(:categories).all
             render json: indicators,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::IndicatorSerializer,
                    root: :data
+          end
+
+          private
+
+          def source
+            ::Indc::Source.non_lts.pluck(:id)
+          end
+
+          def link_prefix
+            '/api/v1/data/ndc_content/data_sources'
           end
         end
       end

--- a/app/controllers/api/v1/data/ndc_content/indicators_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/indicators_controller.rb
@@ -12,7 +12,8 @@ module Api
                 }
               ]
             )
-            indicators = ::Indc::Indicator.includes(:categories).all
+            source = ::Indc::Source.non_lts.pluck(:id)
+            indicators = ::Indc::Indicator.where(source_id: source).includes(:categories).all
             render json: indicators,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::IndicatorSerializer,

--- a/app/controllers/api/v1/data/ndc_content_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content_controller.rb
@@ -21,7 +21,7 @@ module Api
               :data_sources, :indicators, :categories, :sectors
             ].map do |resource|
               {
-                link: "/api/v1/data/ndc_content/#{resource}",
+                link: "#{link_prefix}#{resource}",
                 rel: "meta #{resource}"
               }
             end + [{link: '/api/v1/locations/countries', rel: 'meta locations'}]
@@ -34,6 +34,10 @@ module Api
         end
 
         private
+
+        def link_prefix
+          '/api/v1/data/ndc_content/'
+        end
 
         def parametrise_filter
           params[:source_ids] = ::Indc::Source.non_lts.pluck(:id) unless params[:source_ids]

--- a/app/controllers/api/v1/data/ndc_content_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content_controller.rb
@@ -36,7 +36,7 @@ module Api
         private
 
         def parametrise_filter
-          params[:source_ids] = ::Indc::Source.not_lts.pluck(:id) unless params[:source_ids]
+          params[:source_ids] = ::Indc::Source.non_lts.pluck(:id) unless params[:source_ids]
           @filter = Data::NdcContent::Filter.new(params)
         end
       end

--- a/app/models/indc/source.rb
+++ b/app/models/indc/source.rb
@@ -2,5 +2,7 @@ module Indc
   class Source < ApplicationRecord
     validates :name, presence: true
     validates :name, uniqueness: true
+    scope :lts, -> { where("name ilike 'LTS'") }
+    scope :non_lts, -> { where.not("name ilike 'LTS'") }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,17 @@ Rails.application.routes.draw do
           resources :labels, only: [:index]
           resources :sectors, only: [:index]
         end
+        resources :lts_content, only: [:index] do
+          get :download, on: :collection, defaults: { format: 'zip' }
+          get :meta, on: :collection
+        end
+        namespace :lts_content do
+          resources :indicators, only: [:index]
+          resources :data_sources, only: [:index]
+          resources :categories, only: [:index]
+          resources :labels, only: [:index]
+          resources :sectors, only: [:index]
+        end
         namespace :agriculture_profile, only: [:index] do
           resources :emissions, only: [:index]
           resources :country_contexts, only: [:index]

--- a/spec/controllers/api/v1/data/lts_content/categories_controller_spec.rb
+++ b/spec/controllers/api/v1/data/lts_content/categories_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::LtsContent::CategoriesController, type: :controller do
+  include_context 'LTS categories'
+
+  describe 'GET index' do
+    it 'renders categories' do
+      get :index
+      expect(@response).to match_response_schema('ndc_content_categories')
+    end
+  end
+end

--- a/spec/controllers/api/v1/data/lts_content/data_sources_controller_spec.rb
+++ b/spec/controllers/api/v1/data/lts_content/data_sources_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::LtsContent::DataSourcesController, type: :controller do
+  include_context 'LTS sources'
+
+  describe 'GET index' do
+    it 'renders data sources' do
+      get :index
+      expect(@response).to match_response_schema('ndc_content_data_sources')
+    end
+  end
+end

--- a/spec/controllers/api/v1/data/lts_content/indicators_controller_spec.rb
+++ b/spec/controllers/api/v1/data/lts_content/indicators_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::LtsContent::IndicatorsController, type: :controller do
+  include_context 'LTS indicators'
+
+  describe 'GET index' do
+    it 'renders indicators' do
+      get :index
+      expect(@response).to match_response_schema('ndc_content_indicators')
+    end
+  end
+end

--- a/spec/controllers/api/v1/data/lts_content/sectors_controller_spec.rb
+++ b/spec/controllers/api/v1/data/lts_content/sectors_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::LtsContent::SectorsController, type: :controller do
+  include_context 'LTS sectors'
+
+  describe 'GET index' do
+    it 'renders sectors' do
+      get :index
+      expect(@response).to match_response_schema('ndc_content_sectors')
+    end
+  end
+end

--- a/spec/controllers/api/v1/data/lts_content_controller_spec.rb
+++ b/spec/controllers/api/v1/data/lts_content_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Data::LtsContentController, type: :controller do
+  include_context 'LTS values'
+
+  before(:each) do
+    Indc::SearchableValue.refresh
+  end
+
+  describe 'GET index' do
+    it 'renders LTS values' do
+      get :index, params: {
+        countries: [spain.iso_code3],
+        source_ids: [lts.id],
+        indicator_ids: [ghg_target_type.id],
+        category_ids: [overview.id],
+        label_ids: [baseline_scenario_target.id]
+      }
+      expect(@response).to match_response_schema('ndc_content')
+    end
+
+    it 'sorts by indicator ascending' do
+      get :index, params: {
+        sort_col: 'indicator_name', sort_dir: 'ASC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['indicator_name']).to eq(ghg_target_type.name)
+    end
+
+    it 'sorts by indicator descending' do
+      get :index, params: {
+        sort_col: 'indicator_name', sort_dir: 'DESC'
+      }
+      records = JSON.parse(@response.body)['data']
+      expect(records.first['indicator_name']).to eq(sectoral_targets_on.name)
+    end
+
+    it 'sets pagination headers' do
+      get :index
+      expect(@response.headers).to include('Total')
+    end
+  end
+
+  describe 'GET download' do
+    it 'returns data as csv' do
+      get :download
+      expect(response.content_type).to eq('application/zip')
+      expect(response.headers['Content-Disposition']).
+        to eq('attachment; filename="ndc_content.zip"')
+    end
+  end
+
+  describe 'HEAD meta' do
+    it 'returns a header link with path to categories' do
+      head :meta
+      links = response.headers['Link'].split(',')
+      categories_link = links.find do |l|
+        _path, rel = l.split(';')
+        rel =~ /meta categories/
+      end
+      expect(categories_link).to be_present
+    end
+  end
+end

--- a/spec/support/shared_contexts/lts_content/categories.rb
+++ b/spec/support/shared_contexts/lts_content/categories.rb
@@ -1,0 +1,59 @@
+RSpec.shared_context 'LTS categories' do
+  let(:global_type) {
+    FactoryBot.create(:indc_category_type, name: ::Indc::CategoryType::GLOBAL)
+  }
+  let(:overview_type) {
+    FactoryBot.create(
+      :indc_category_type, name: ::Indc::CategoryType::OVERVIEW
+    )
+  }
+  let!(:overview) {
+    FactoryBot.create(
+      :indc_category,
+      parent: nil,
+      category_type: global_type,
+      slug: 'overview',
+      name: 'Overview'
+    )
+  }
+
+  let!(:lts_category) {
+    FactoryBot.create(
+      :indc_category,
+      parent: overview,
+      category_type: overview_type,
+      slug: 'lts_category',
+      name: 'LTS Category'
+    )
+  }
+
+  let!(:sectoral_information) {
+    FactoryBot.create(
+      :indc_category,
+      parent: nil,
+      category_type: global_type,
+      slug: 'sectoral_information',
+      name: 'Sectoral Information'
+    )
+  }
+
+  let!(:sectoral_plans) {
+    FactoryBot.create(
+      :indc_category,
+      parent: sectoral_information,
+      category_type: overview_type,
+      slug: 'sectoral_plans',
+      name: 'Sectoral Mitigation Plans'
+    )
+  }
+
+  let!(:sectoral_targets) {
+    FactoryBot.create(
+      :indc_category,
+      parent: sectoral_information,
+      category_type: overview_type,
+      slug: 'sectoral_targets',
+      name: 'Sectoral Mitigation Targets'
+    )
+  }
+end

--- a/spec/support/shared_contexts/lts_content/indicators.rb
+++ b/spec/support/shared_contexts/lts_content/indicators.rb
@@ -1,0 +1,37 @@
+RSpec.shared_context 'LTS indicators' do
+  include_context 'LTS sources'
+  include_context 'LTS categories'
+
+  let!(:ghg_target_type) {
+    i = FactoryBot.create(
+      :indc_indicator,
+      source: lts,
+      slug: 'ghg_target_type',
+      name: 'GHG target type'
+    )
+    i.categories = [overview, lts_category]
+    i
+  }
+
+  let!(:sectoral_plans_on) {
+    i = FactoryBot.create(
+      :indc_indicator,
+      source: lts,
+      slug: 'M_SecGen3',
+      name: 'Sectoral plans on'
+    )
+    i.categories = [sectoral_information, sectoral_plans]
+    i
+  }
+
+  let!(:sectoral_targets_on) {
+    i = FactoryBot.create(
+      :indc_indicator,
+      source: lts,
+      slug: 'M_SecTar1',
+      name: 'Sectoral targets on'
+    )
+    i.categories = [sectoral_information, sectoral_targets]
+    i
+  }
+end

--- a/spec/support/shared_contexts/lts_content/labels.rb
+++ b/spec/support/shared_contexts/lts_content/labels.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context 'LTS labels' do
+  include_context 'LTS indicators'
+
+  let!(:baseline_scenario_target) {
+    FactoryBot.create(
+      :indc_label,
+      indicator: ghg_target_type,
+      value: 'Baseline scenario target'
+    )
+  }
+end

--- a/spec/support/shared_contexts/lts_content/sectors.rb
+++ b/spec/support/shared_contexts/lts_content/sectors.rb
@@ -1,0 +1,25 @@
+RSpec.shared_context 'LTS sectors' do
+  let!(:transport) {
+    FactoryBot.create(
+      :indc_sector,
+      parent: nil,
+      name: 'Transport'
+    )
+  }
+
+  let!(:vehicle_fleet) {
+    FactoryBot.create(
+      :indc_sector,
+      parent: transport,
+      name: 'Vehicle Fleet'
+    )
+  }
+
+  let!(:aviation) {
+    FactoryBot.create(
+      :indc_sector,
+      parent: transport,
+      name: 'Aviation'
+    )
+  }
+end

--- a/spec/support/shared_contexts/lts_content/sources.rb
+++ b/spec/support/shared_contexts/lts_content/sources.rb
@@ -1,0 +1,8 @@
+RSpec.shared_context 'LTS sources' do
+  let!(:lts) {
+    FactoryBot.create(
+      :indc_source,
+      name: 'LTS'
+    )
+  }
+end

--- a/spec/support/shared_contexts/lts_content/values.rb
+++ b/spec/support/shared_contexts/lts_content/values.rb
@@ -1,0 +1,37 @@
+RSpec.shared_context 'LTS values' do
+  include_context 'locations'
+  include_context 'LTS indicators'
+  include_context 'LTS labels'
+  include_context 'LTS sectors'
+
+  let!(:value_1) {
+    FactoryBot.create(
+      :indc_value,
+      indicator: ghg_target_type,
+      sector: aviation,
+      label: baseline_scenario_target,
+      location: spain,
+      value: 'Baseline scenario target'
+    )
+  }
+
+  let!(:value_2) {
+    FactoryBot.create(
+      :indc_value,
+      indicator: sectoral_plans_on,
+      sector: vehicle_fleet,
+      location: spain,
+      value: 'Increase share of electric vehicles'
+    )
+  }
+
+  let!(:value_3) {
+    FactoryBot.create(
+      :indc_value,
+      indicator: sectoral_targets_on,
+      sector: vehicle_fleet,
+      location: spain,
+      value: '-30% in fuel consumption in 2025'
+    )
+  }
+end


### PR DESCRIPTION
Adds API endpoints for the lts data.

They work similarly to the ndc_content ones, just with `lts_content`.

It will need some improvements to DRY up the code a little, but this should work to support the frontend.