### PR TITLE
Fix/lts tracker and tooltips

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -221,13 +221,18 @@ export const getTooltipCountryValues = createSelector(
     if (!indicators || !selectedIndicator) {
       return null;
     }
+    let updatedSelectedIndicator = selectedIndicator;
+    if (selectedIndicator.value === 'lts_submission') {
+      updatedSelectedIndicator = indicators.find(i => i.slug === 'lts_target');
+    }
+
     const emissionsIndicator = indicators.find(i => i.slug === 'lts_ghg');
     const tooltipCountryValues = {};
-    Object.keys(selectedIndicator.locations).forEach(iso => {
+    Object.keys(updatedSelectedIndicator.locations).forEach(iso => {
       tooltipCountryValues[iso] = {
         value:
-          selectedIndicator.locations[iso] &&
-          selectedIndicator.locations[iso].value,
+          updatedSelectedIndicator.locations[iso] &&
+          updatedSelectedIndicator.locations[iso].value,
         emissionsValue:
           emissionsIndicator.locations[iso] &&
           emissionsIndicator.locations[iso].value

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -224,11 +224,10 @@ export const getTooltipCountryValues = createSelector(
     const emissionsIndicator = indicators.find(i => i.slug === 'lts_ghg');
     const tooltipCountryValues = {};
     Object.keys(selectedIndicator.locations).forEach(iso => {
-      const labelId =
-        selectedIndicator.locations[iso] &&
-        selectedIndicator.locations[iso].label_id;
       tooltipCountryValues[iso] = {
-        value: labelId && selectedIndicator.legendBuckets[labelId].name,
+        value:
+          selectedIndicator.locations[iso] &&
+          selectedIndicator.locations[iso].value,
         emissionsValue:
           emissionsIndicator.locations[iso] &&
           emissionsIndicator.locations[iso].value

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -216,11 +216,10 @@ export const getTooltipCountryValues = createSelector(
     const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
     const tooltipCountryValues = {};
     Object.keys(selectedIndicator.locations).forEach(iso => {
-      const labelId =
-        selectedIndicator.locations[iso] &&
-        selectedIndicator.locations[iso].label_id;
       tooltipCountryValues[iso] = {
-        value: labelId && selectedIndicator.legendBuckets[labelId].name,
+        value:
+          selectedIndicator.locations[iso] &&
+          selectedIndicator.locations[iso].value,
         emissionsValue:
           emissionsIndicator.locations[iso] &&
           emissionsIndicator.locations[iso].value

--- a/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz-selectors.js
@@ -26,13 +26,13 @@ export const getIndicatorsParsed = createSelector(
   [getCategories, getIndicatorsData, getISOCountries],
   (categories, indicators, isos) => {
     if (!categories || !indicators || !indicators.length) return null;
-
     const categoryIds = Object.keys(categories).filter(
       // Need to get the NDC Enhancement data category to borrow the emissions figure from that dataset for consistency
       id =>
         categories[id].slug === 'longterm_strategy' ||
         categories[id].slug === 'ndc_enhancement' ||
-        (FEATURE_LTS_UPDATED_DATA && categories[id].slug === 'overview')
+        (FEATURE_LTS_UPDATED_DATA &&
+          categories[id].slug === 'summary_information')
     );
     const preppedIndicators = sortBy(
       uniqBy(
@@ -54,6 +54,7 @@ export const getIndicatorsParsed = createSelector(
       ),
       'label'
     );
+
     let filteredIndicators = [];
     categoryIds.forEach(id => {
       filteredIndicators = filteredIndicators.concat(
@@ -62,6 +63,7 @@ export const getIndicatorsParsed = createSelector(
         )
       );
     });
+
     return filteredIndicators;
   }
 );

--- a/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz.js
+++ b/app/javascript/app/components/ndcs/ndcs-lts-viz/ndcs-lts-viz.js
@@ -66,10 +66,10 @@ class NDCSLTSVizContainer extends PureComponent {
     if (!geometryIdHover || !indicator) return '';
 
     const id = geometryIdHover;
-
     const targetIndicator = indicators.find(i => i.value === 'lts_target');
 
     if (
+      targetIndicator &&
       indicator.locations &&
       indicator.locations[id] &&
       indicator.locations[id].value === 'Long-term Strategy Submitted'

--- a/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip-styles.scss
+++ b/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip-styles.scss
@@ -13,4 +13,5 @@
 
 .tooltipValue {
   font-size: $font-size-sm;
+  margin-bottom: 10px;
 }

--- a/app/javascript/app/styles/themes/map-tooltip/map-tooltip.scss
+++ b/app/javascript/app/styles/themes/map-tooltip/map-tooltip.scss
@@ -4,9 +4,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  //to correct padding: 8px 21px; fromreact-tooltip componet
+  // to correct padding from react-tooltip component
   margin: 7px -6px;
   pointer-events: all;
+  text-transform: initial;
 }
 
 .info {


### PR DESCRIPTION
Apparently LTS tracker was not working on staging as the slug was changed

- Updated tooltip text of LTS and NDC explore according to feedback: https://onewri.sharepoint.com/:w:/r/sites/climatewatch/_layouts/15/doc2.aspx?sourcedoc=%7BEFE6B29E-1A1B-4716-A129-179175F612D8%7D&file=Feedback%20on%20the%20LTS%20explorer.docx&action=default&mobileredirect=true&cid=e313da24-5783-4a35-b901-ee29544a9514

![image](https://user-images.githubusercontent.com/9701591/74660710-fd9b9e80-5196-11ea-960b-03fc8f317181.png)

![image](https://user-images.githubusercontent.com/9701591/74661151-acd87580-5197-11ea-91e1-b64075d25210.png)
