### PR TITLE
Add share "copy embed code" to the share modal & fix "copy embed link…

### DIFF
--- a/app/javascript/app/components/modal-share/modal-share-component.jsx
+++ b/app/javascript/app/components/modal-share/modal-share-component.jsx
@@ -96,13 +96,15 @@ const ModalShare = ({
       onRequestClose={() => setShareModal({ open: false })}
       header={<ModalHeader title="Share" />}
     >
-      <ul className={styles.links}>
-        {shareMenuOptions.map(option => (
-          <li className={styles.linkContainer} key={option.label}>
-            {renderLink(option)}
-          </li>
-        ))}
-      </ul>
+      {shareMenuOptions.map(({ key, options }) => (
+        <ul className={styles.links} key={key}>
+          {options.map(option => (
+            <li className={styles.linkContainer} key={option.label}>
+              {renderLink(option)}
+            </li>
+          ))}
+        </ul>
+      ))}
     </Modal>
   );
 };

--- a/app/javascript/app/components/modal-share/modal-share-styles.scss
+++ b/app/javascript/app/components/modal-share/modal-share-styles.scss
@@ -54,7 +54,7 @@
         }
 
         .title {
-          min-width: 80px;
+          width: max-content;
         }
 
         &.withDownloadIcon {

--- a/app/javascript/app/components/modal-share/modal-share-styles.scss
+++ b/app/javascript/app/components/modal-share/modal-share-styles.scss
@@ -5,7 +5,8 @@
   height: 90%;
 
   @media #{$tablet-portrait} {
-    height: 210px;
+    height: 270px;
+    width: 500px;
   }
 }
 
@@ -15,7 +16,7 @@
 
 .links {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-evenly;
   flex-direction: column;
 
   @media #{$tablet-portrait} {

--- a/app/javascript/app/components/modal-share/modal-share.js
+++ b/app/javascript/app/components/modal-share/modal-share.js
@@ -27,29 +27,39 @@ const mapStateToProps = (
   const copyCode = () => copy(iframeCode);
   const shareMenuOptions = [
     {
-      label: 'Email',
-      icon: mailIcon,
-      link: `mailto:?subject=Climate%20Watch&body=${url}`
+      key: 'socialOptions',
+      options: [
+        {
+          label: 'Email',
+          icon: mailIcon,
+          link: `mailto:?subject=Climate%20Watch&body=${url}`
+        },
+        {
+          label: 'Facebook',
+          icon: facebookIcon,
+          link: `https://www.facebook.com/sharer/sharer.php?u=${url}`
+        },
+        {
+          label: 'Twitter',
+          icon: twitterIcon,
+          link: `https://twitter.com/intent/tweet?url=${url}`
+        }
+      ]
     },
     {
-      label: 'Facebook',
-      icon: facebookIcon,
-      link: `https://www.facebook.com/sharer/sharer.php?u=${url}`
-    },
-    {
-      label: 'Twitter',
-      icon: twitterIcon,
-      link: `https://twitter.com/intent/tweet?url=${url}`
-    },
-    {
-      label: 'Copy Embed URL',
-      icon: linkIcon,
-      action: copyUrl
-    },
-    {
-      label: 'Copy Embed code',
-      icon: codeIcon,
-      action: copyCode
+      key: 'embedOptions',
+      options: [
+        {
+          label: 'Copy Embed URL',
+          icon: linkIcon,
+          action: copyUrl
+        },
+        {
+          label: 'Copy Embed code',
+          icon: codeIcon,
+          action: copyCode
+        }
+      ]
     }
   ];
 

--- a/app/javascript/app/components/modal-share/modal-share.js
+++ b/app/javascript/app/components/modal-share/modal-share.js
@@ -20,7 +20,8 @@ const mapStateToProps = (
   const { origin, pathname, search, hash } = location;
   const isEmbed = isEmbededComponent(location);
   const queryParams = shouldEmbedQueryParams ? search + hash : '';
-  const url = origin + (sharePath || pathname) + queryParams;
+  const url = `${origin}${!isEmbed ? '/embed' : ''}${sharePath ||
+    pathname}${queryParams}`;
   const copyUrl = () => copy(url);
   const iframeCode = `<iframe src="${url}" frameborder="0" style="height: 600px; width: 1230px"></iframe>`;
   const copyCode = () => copy(iframeCode);
@@ -44,16 +45,14 @@ const mapStateToProps = (
       label: 'Copy Embed URL',
       icon: linkIcon,
       action: copyUrl
-    }
-  ];
-
-  if (isEmbed) {
-    shareMenuOptions.push({
+    },
+    {
       label: 'Copy Embed code',
       icon: codeIcon,
       action: copyCode
-    });
-  }
+    }
+  ];
+
   return {
     shareMenuOptions,
     shareIcon,

--- a/app/javascript/app/components/modal/modal-styles.scss
+++ b/app/javascript/app/components/modal/modal-styles.scss
@@ -21,7 +21,7 @@ $close-position: 35px;
   border-radius: 0;
 
   @media #{$tablet-landscape} {
-    width: 810px;
+    width: 770px;
     max-height: 640px;
     height: calc(100vh - 100px);
     top: auto;

--- a/app/javascript/app/components/modal/modal-styles.scss
+++ b/app/javascript/app/components/modal/modal-styles.scss
@@ -21,7 +21,7 @@ $close-position: 35px;
   border-radius: 0;
 
   @media #{$tablet-landscape} {
-    width: 770px;
+    width: 810px;
     max-height: 640px;
     height: calc(100vh - 100px);
     top: auto;
@@ -38,7 +38,7 @@ $close-position: 35px;
 
 .modalContent {
   flex: 1;
-  overflow: scroll;
+  overflow: auto;
   padding: $modal-padding $gutter-padding;
   word-break: break-word;
   overscroll-behavior: none; /* stylelint-disable-line property-no-unknown */


### PR DESCRIPTION
This small PR improves a few issues pointed out in feedback:
![image](https://user-images.githubusercontent.com/15097138/74761304-b6371000-5273-11ea-95f6-40c84bf9d5b8.png)


- removes disabled scrollbars from the share menu,
- fixes broken `Copy embed URL` feature (it was pointing to the page link, not embed version),
- adds `Copy embed code` option to the share modal,

![image](https://user-images.githubusercontent.com/15097138/74761142-6eb08400-5273-11ea-9ca2-7cf02c5fee2f.png)


However, I discovered another bug in the `Overview` section - embed URL doesn't contain information about shared Section so at the end, this link redirects to the homepage. It happens because clicking on any `Share` button dispatches an action `setShareModal` that displays all three instances of the `ModalShare` component, one on top of the other. I'll put that as [a bug to the Pivotal Tracker](https://www.pivotaltracker.com/story/show/171335591)

![2rfer-7qg9c](https://user-images.githubusercontent.com/15097138/74761914-cbf90500-5274-11ea-9b33-1f4f745556f6.gif)