### PR TITLE
Add extra column and fix columns width

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-component.jsx
@@ -5,6 +5,7 @@ import { Table } from 'cw-components';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
 import exploreTableTheme from 'styles/themes/table/explore-table-theme.scss';
+import exploreTableTwoHighlightedColumnsTheme from 'styles/themes/table/explore-table-two-highlighted-theme.scss';
 
 import layout from 'styles/layout.scss';
 import styles from 'components/ndcs/shared/explore-table-styles.scss';
@@ -26,7 +27,8 @@ const LTSExploreTable = ({
   noContentMsg,
   columns,
   setColumnWidth,
-  titleLinks
+  titleLinks,
+  extraColumn
 }) => (
   <div>
     <div className={styles.wrapper}>
@@ -47,7 +49,11 @@ const LTSExploreTable = ({
               setColumnWidth={setColumnWidth}
               defaultColumns={columns}
               titleLinks={titleLinks}
-              theme={exploreTableTheme}
+              theme={
+                extraColumn
+                  ? exploreTableTwoHighlightedColumnsTheme
+                  : exploreTableTheme
+              }
             />
           </div>
         )}
@@ -64,6 +70,7 @@ LTSExploreTable.propTypes = {
   noContentMsg: PropTypes.string,
   query: PropTypes.string,
   tableData: PropTypes.array,
+  extraColumn: PropTypes.string,
   handleSearchChange: PropTypes.func.isRequired,
   setColumnWidth: PropTypes.func.isRequired,
   columns: PropTypes.array,

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -80,9 +80,17 @@ export const getSelectedIndicatorHeader = createSelector(
   }
 );
 
+export const getExtraColumn = createSelector(
+  [getMapIndicator],
+  selectedIndicator => {
+    if (!selectedIndicator) return null;
+    return selectedIndicator.value === 'lts_submission' ? 'lts_target' : null;
+  }
+);
+
 export const getDefaultColumns = createSelector(
-  [getIndicatorsParsed, getSelectedIndicatorHeader],
-  (indicators, selectedIndicatorHeader) => {
+  [getIndicatorsParsed, getSelectedIndicatorHeader, getExtraColumn],
+  (indicators, selectedIndicatorHeader, extraColumn) => {
     if (!indicators || isEmpty(indicators)) return [];
     const columnIds = [
       'country',
@@ -91,6 +99,10 @@ export const getDefaultColumns = createSelector(
       'lts_date',
       'lts_ghg'
     ];
+
+    if (extraColumn) {
+      columnIds.splice(2, 0, extraColumn);
+    }
 
     const columns = columnIds.map(id => {
       const match = indicators.find(indicator => indicator.value === id);

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table.js
@@ -13,7 +13,8 @@ import {
   getISOCountries,
   removeIsoFromData,
   getDefaultColumns,
-  getTitleLinks
+  getTitleLinks,
+  getExtraColumn
 } from './lts-explore-table-selectors';
 
 const mapStateToProps = (state, { location }) => {
@@ -38,7 +39,8 @@ const mapStateToProps = (state, { location }) => {
     isoCountries: getISOCountries(LTSWithSelection),
     tableData: removeIsoFromData(LTSWithSelection),
     columns: getDefaultColumns(LTSWithSelection),
-    titleLinks: getTitleLinks(LTSWithSelection)
+    titleLinks: getTitleLinks(LTSWithSelection),
+    extraColumn: getExtraColumn(LTSWithSelection)
   };
 };
 
@@ -48,16 +50,18 @@ class LTSExploreTableContainer extends PureComponent {
     this.state = {};
   }
 
-  setColumnWidth = column =>
-    setColumnWidth({
+  setColumnWidth = column => {
+    const { extraColumn } = this.props;
+    return setColumnWidth({
       column,
       columns: this.props.columns,
-      tableWidth: 1170,
-      narrowColumnWidth: 110,
-      wideColumnWidth: 380,
-      narrowColumns: [0, 3],
-      wideColumns: [1]
+      tableWidth: 1100,
+      narrowColumnWidth: extraColumn ? 100 : 120,
+      wideColumnWidth: extraColumn ? 290 : 400,
+      narrowColumns: extraColumn ? [0, 4, 5] : [0, 3, 4],
+      wideColumns: extraColumn ? [2] : [1]
     });
+  };
 
   updateUrlParam(param, clear) {
     const { history, location } = this.props;
@@ -88,7 +92,8 @@ LTSExploreTableContainer.propTypes = {
   location: PropTypes.object.isRequired,
   tableData: PropTypes.array,
   columns: PropTypes.array,
-  query: PropTypes.object
+  query: PropTypes.object,
+  extraColumn: PropTypes.string
 };
 
 export default withRouter(

--- a/app/javascript/app/styles/themes/table/explore-table-two-highlighted-theme.scss
+++ b/app/javascript/app/styles/themes/table/explore-table-two-highlighted-theme.scss
@@ -1,0 +1,44 @@
+@import '~styles/settings.scss';
+
+.column {
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+
+  > div,
+  > a {
+    margin: auto 0;
+  }
+
+  &:nth-child(2),
+  &:nth-child(3) {
+    padding: 0 10px;
+  }
+
+  &:nth-child(2) {
+    margin-right: 0;
+  }
+}
+
+.row {
+  padding-top: 0 !important; // Due to the :global in styles
+  padding-bottom: 0 !important; // Due to the :global in styles
+}
+
+.evenRow {
+  .column {
+    &:nth-child(2),
+    &:nth-child(3) {
+      background-color: $lighter-blue;
+    }
+  }
+}
+
+.oddRow {
+  .column {
+    &:nth-child(2),
+    &:nth-child(3) {
+      background-color: $lighter-blue-2;
+    }
+  }
+}


### PR DESCRIPTION
A second column needed to be added on LTS explore when 'Communication of Long-term Strategy' is selected. 

Also fixed the column widths so we can see all the columns in a normal situation

![image](https://user-images.githubusercontent.com/9701591/74765710-5dbc3e80-5284-11ea-8b70-b8e13e89540a.png)
