### PR TITLE
Feature/compare all targets search params

### DIFF
--- a/app/javascript/app/pages/custom-compare/custom-compare-component.jsx
+++ b/app/javascript/app/pages/custom-compare/custom-compare-component.jsx
@@ -20,12 +20,16 @@ const COUNTRY_PLACEHOLDERS = [
   'Add a third country'
 ];
 
-const FiltersGroup = ({ data, countryPlaceholder, handleFilterChange }) => {
+const FiltersGroup = ({
+  data,
+  countryPlaceholder,
+  handleCountryFilterChange,
+  handleDocumentFilterChange
+}) => {
   const {
-    countryParam,
+    key,
     countryValue,
     contriesOptions,
-    documentParam,
     documentValue,
     documentOptions
   } = data;
@@ -33,19 +37,19 @@ const FiltersGroup = ({ data, countryPlaceholder, handleFilterChange }) => {
   return (
     <div className={styles.filter}>
       <Dropdown
-        key={`${countryParam}-filter`}
+        key={`${key}-country`}
         className={styles.dropdown}
         options={contriesOptions}
-        onValueChange={({ value }) => handleFilterChange(countryParam, value)}
+        onValueChange={({ value }) => handleCountryFilterChange(key, value)}
         value={countryValue}
         placeholder={countryPlaceholder}
         hideResetButton
         noAutoSort
       />
       <Dropdown
-        key={`${documentParam}-filter`}
+        key={`${key}-document`}
         options={documentOptions}
-        onValueChange={({ value }) => handleFilterChange(documentParam, value)}
+        onValueChange={({ value }) => handleDocumentFilterChange(key, value)}
         value={documentValue}
         placeholder="Choose a submission"
         hideResetButton
@@ -56,13 +60,20 @@ const FiltersGroup = ({ data, countryPlaceholder, handleFilterChange }) => {
 };
 
 const CustomComparisonComponent = props => {
-  const { route, anchorLinks, handleFilterChange, filtersData } = props;
+  const {
+    route,
+    anchorLinks,
+    handleCountryFilterChange,
+    handleDocumentFilterChange,
+    filtersData,
+    backButtonLink
+  } = props;
   return (
     <div>
       <Header route={route}>
         <div className={cx(layout.content, styles.header)}>
           <BackButton
-            pathname="/compare-all-targets"
+            pathname={backButtonLink}
             backLabel="compare all targets"
           />
           <div className={styles.title}>
@@ -87,7 +98,8 @@ const CustomComparisonComponent = props => {
                   key={data.key}
                   data={data}
                   countryPlaceholder={COUNTRY_PLACEHOLDERS[i]}
-                  handleFilterChange={handleFilterChange}
+                  handleCountryFilterChange={handleCountryFilterChange}
+                  handleDocumentFilterChange={handleDocumentFilterChange}
                 />
               ))}
           </div>
@@ -127,14 +139,17 @@ FiltersGroup.propTypes = {
     )
   }),
   countryPlaceholder: PropTypes.string,
-  handleFilterChange: PropTypes.func
+  handleCountryFilterChange: PropTypes.func,
+  handleDocumentFilterChange: PropTypes.func
 };
 
 CustomComparisonComponent.propTypes = {
   route: PropTypes.object.isRequired,
   anchorLinks: PropTypes.array,
   filtersData: PropTypes.array,
-  handleFilterChange: PropTypes.func
+  handleCountryFilterChange: PropTypes.func,
+  handleDocumentFilterChange: PropTypes.func,
+  backButtonLink: PropTypes.string
 };
 
 export default CustomComparisonComponent;

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -27,35 +27,17 @@ const getCountryOptions = createSelector([getCountries], countries => {
   }));
 });
 
-export const getSelectedTargets = createSelector([getQuery], query => {
-  if (!query) return null;
-  const queryTargets = query.targets ? query.targets.split(',') : [];
-  return [1, 2, 3].map((value, i) => {
-    // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
-    const target =
-      queryTargets && queryTargets[i] && queryTargets[i].split('-');
-    const country = target && target[0];
-    const document = target && target[1];
-    return { key: `target${i}`, country, document };
-  });
-});
-
-const getDocumentsOptionsByCountry = createSelector(
-  [getSelectedTargets, getIndicatorsData],
-  (selectedTargets, indicators) => {
-    if (
-      !selectedTargets ||
-      !selectedTargets.length ||
-      !indicators ||
-      !indicators.length
-    ) {
+export const getDocumentsOptionsByCountry = createSelector(
+  [getCountryOptions, getIndicatorsData],
+  (countries, indicators) => {
+    if (!countries || !countries.length || !indicators || !indicators.length) {
       return null;
     }
 
     const ndcIndicator = indicators.find(i => i.slug === 'submission');
     const ltsIndicator = indicators.find(i => i.slug === 'lts_submission');
 
-    const rows = selectedTargets.reduce((acc, { country }) => {
+    const rows = countries.reduce((acc, { value: country }) => {
       if (!country) return acc;
 
       const countryNDC = ndcIndicator.locations[country] || {};
@@ -84,6 +66,19 @@ const getDocumentsOptionsByCountry = createSelector(
     return rows;
   }
 );
+
+export const getSelectedTargets = createSelector([getQuery], query => {
+  if (!query) return null;
+  const queryTargets = query.targets ? query.targets.split(',') : [];
+  return [1, 2, 3].map((value, i) => {
+    // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
+    const target =
+      queryTargets && queryTargets[i] && queryTargets[i].split('-');
+    const country = target && target[0];
+    const document = target && target[1];
+    return { key: `target${i}`, country, document };
+  });
+});
 
 export const getFiltersData = createSelector(
   [getCountryOptions, getDocumentsOptionsByCountry, getSelectedTargets],

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -29,11 +29,11 @@ const getCountryOptions = createSelector([getCountries], countries => {
 
 export const getSelectedTargets = createSelector([getQuery], query => {
   if (!query) return null;
-  const queryTargets = query.targets.split(',');
+  const queryTargets = query.targets ? query.targets.split(',') : [];
   return [1, 2, 3].map((value, i) => {
-    const targets = queryTargets[i] && queryTargets[i].split('-');
-    const country = targets && targets.length && targets[0];
-    const document = targets && targets.length > 1 && targets[1];
+    const target = queryTargets[i] && queryTargets[i].split('-'); // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
+    const country = target && target.length > 0 && target[0];
+    const document = target && target.length > 1 && target[1];
     return { key: `target${i}`, country, document };
   });
 });
@@ -46,7 +46,9 @@ const getDocumentsOptionsByCountry = createSelector(
       !selectedTargets.length ||
       !indicators ||
       !indicators.length
-    ) { return null; }
+    ) {
+      return null;
+    }
 
     const ndcIndicator = indicators.find(i => i.slug === 'submission');
     const ltsIndicator = indicators.find(i => i.slug === 'lts_submission');
@@ -54,8 +56,8 @@ const getDocumentsOptionsByCountry = createSelector(
     const rows = selectedTargets.reduce((acc, { country }) => {
       if (!country) return acc;
 
-      const countryNDC = ndcIndicator.locations[country];
-      const countryLTS = ltsIndicator.locations[country];
+      const countryNDC = ndcIndicator.locations[country] || {};
+      const countryLTS = ltsIndicator.locations[country] || {};
 
       let documents = [];
 

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -11,7 +11,7 @@ const getIndicatorsData = state =>
 const getQuery = (state, { search }) => search || '';
 
 export const getBackButtonLink = createSelector([getQuery], query => {
-  if (!query) return '';
+  if (!query) return '/compare-all-targets';
   const targetParams = query.targets ? query.targets.split(',') : [];
   const documentParams = uniq(
     targetParams.filter(target => !target.endsWith('-'))

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -34,8 +34,8 @@ export const getSelectedTargets = createSelector([getQuery], query => {
     // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
     const target =
       queryTargets && queryTargets[i] && queryTargets[i].split('-');
-    const country = target && target.length > 0 && target[0];
-    const document = target && target.length > 1 && target[1];
+    const country = target && target[0];
+    const document = target && target[1];
     return { key: `target${i}`, country, document };
   });
 });

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -31,7 +31,9 @@ export const getSelectedTargets = createSelector([getQuery], query => {
   if (!query) return null;
   const queryTargets = query.targets ? query.targets.split(',') : [];
   return [1, 2, 3].map((value, i) => {
-    const target = queryTargets[i] && queryTargets[i].split('-'); // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
+    // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
+    const target =
+      queryTargets && queryTargets[i] && queryTargets[i].split('-');
     const country = target && target.length > 0 && target[0];
     const document = target && target.length > 1 && target[1];
     return { key: `target${i}`, country, document };
@@ -106,7 +108,6 @@ export const getFiltersData = createSelector(
         documentOptions[country].find(({ value }) => value === document),
       documentOptions: documentOptions ? documentOptions[country] : []
     }));
-
     return filtersData;
   }
 );

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -21,7 +21,7 @@ const getSelectedCountries = createSelector(
   [getCountryOptions, getQuery],
   (countriesData, query) => {
     if (!countriesData && !countriesData.length && !query) return null;
-    const { country0, country1, country2 } = query;
+    cosnt selectedCountries = query.targets.split(',');
     return {
       country0,
       country1,

--- a/app/javascript/app/pages/custom-compare/custom-compare.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare.js
@@ -10,8 +10,11 @@ import {
   getAnchorLinks,
   getFiltersData,
   getSelectedTargets,
-  getBackButtonLink
+  getBackButtonLink,
+  getDocumentsOptionsByCountry
 } from './custom-compare-selectors';
+
+const DEFAULT_DOCUMENT = 'NDC';
 
 const mapStateToProps = (state, { location, route }) => {
   const search = qs.parse(location.search);
@@ -24,7 +27,8 @@ const mapStateToProps = (state, { location, route }) => {
     anchorLinks: getAnchorLinks(routeData),
     filtersData: getFiltersData(state, { search }),
     selectedTargets: getSelectedTargets(state, { search }),
-    backButtonLink: getBackButtonLink(null, { search })
+    backButtonLink: getBackButtonLink(null, { search }),
+    documentsByCountry: getDocumentsOptionsByCountry(state, { search })
   };
 };
 
@@ -40,11 +44,20 @@ const CustomCompare = props => {
   };
 
   const handleCountryFilterChange = (targetKey, newCountry) => {
-    const { selectedTargets } = props;
+    const { selectedTargets, documentsByCountry } = props;
     const newTargetParams = [];
-    selectedTargets.forEach(({ key, country, document = '' }) => {
-      if (key === targetKey) newTargetParams.push(`${newCountry}-`);
-      else if (country) newTargetParams.push(`${country}-${document}`);
+
+    const newCountryDocuments =
+      documentsByCountry && documentsByCountry[newCountry]
+        ? documentsByCountry[newCountry].map(({ value }) => value)
+        : [];
+    const defaultDocument =
+      newCountryDocuments && newCountryDocuments.includes(DEFAULT_DOCUMENT)
+        ? DEFAULT_DOCUMENT
+        : newCountryDocuments[0];
+
+    selectedTargets.forEach(({ key, country, document }) => {
+      if (key === targetKey) { newTargetParams.push(`${newCountry}-${defaultDocument || ''}`); } else if (country) newTargetParams.push(`${country}-${document}`);
     });
 
     updateTargetParams(newTargetParams);

--- a/app/javascript/app/pages/custom-compare/custom-compare.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare.js
@@ -6,7 +6,12 @@ import { getLocationParamUpdated } from 'utils/navigation';
 import PropTypes from 'prop-types';
 
 import Component from './custom-compare-component';
-import { getAnchorLinks, getFiltersData } from './custom-compare-selectors';
+import {
+  getAnchorLinks,
+  getFiltersData,
+  getSelectedTargets,
+  getBackButtonLink
+} from './custom-compare-selectors';
 
 const mapStateToProps = (state, { location, route }) => {
   const search = qs.parse(location.search);
@@ -17,19 +22,54 @@ const mapStateToProps = (state, { location, route }) => {
 
   return {
     anchorLinks: getAnchorLinks(routeData),
-    filtersData: getFiltersData(state, { search })
+    filtersData: getFiltersData(state, { search }),
+    selectedTargets: getSelectedTargets(state, { search }),
+    backButtonLink: getBackButtonLink(null, { search })
   };
 };
 
 const CustomCompare = props => {
   const { history } = props;
 
-  const handleFilterChange = (name, value) => {
-    const params = { name, value };
+  const updateTargetParams = newTargets => {
+    const params = {
+      name: 'targets',
+      value: newTargets.toString()
+    };
     history.replace(getLocationParamUpdated(location, params));
   };
 
-  return <Component {...props} handleFilterChange={handleFilterChange} />;
+  const handleCountryFilterChange = (targetKey, newCountry) => {
+    const { selectedTargets } = props;
+    const newTargetParams = selectedTargets.map(
+      ({ key, country, document }) => {
+        if (key === targetKey) return `${newCountry}-`;
+        return `${country}-${document}`;
+      }
+    );
+
+    updateTargetParams(newTargetParams);
+  };
+
+  const handleDocumentFilterChange = (targetKey, newDocument) => {
+    const { selectedTargets } = props;
+    const newTargetParams = selectedTargets.map(
+      ({ key, country, document }) => {
+        if (key === targetKey) return `${country}-${newDocument}`;
+        return `${country}-${document}`;
+      }
+    );
+
+    updateTargetParams(newTargetParams);
+  };
+
+  return (
+    <Component
+      {...props}
+      handleCountryFilterChange={handleCountryFilterChange}
+      handleDocumentFilterChange={handleDocumentFilterChange}
+    />
+  );
 };
 
 CustomCompare.propTypes = {

--- a/app/javascript/app/pages/custom-compare/custom-compare.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare.js
@@ -41,24 +41,22 @@ const CustomCompare = props => {
 
   const handleCountryFilterChange = (targetKey, newCountry) => {
     const { selectedTargets } = props;
-    const newTargetParams = selectedTargets.map(
-      ({ key, country, document }) => {
-        if (key === targetKey) return `${newCountry}-`;
-        return `${country}-${document}`;
-      }
-    );
+    const newTargetParams = [];
+    selectedTargets.forEach(({ key, country, document = '' }) => {
+      if (key === targetKey) newTargetParams.push(`${newCountry}-`);
+      else if (country) newTargetParams.push(`${country}-${document}`);
+    });
 
     updateTargetParams(newTargetParams);
   };
 
   const handleDocumentFilterChange = (targetKey, newDocument) => {
     const { selectedTargets } = props;
-    const newTargetParams = selectedTargets.map(
-      ({ key, country, document }) => {
-        if (key === targetKey) return `${country}-${newDocument}`;
-        return `${country}-${document}`;
-      }
-    );
+    const newTargetParams = [];
+    selectedTargets.forEach(({ key, country, document = '' }) => {
+      if (key === targetKey) newTargetParams.push(`${country}-${newDocument}`);
+      else if (country) newTargetParams.push(`${country}-${document}`);
+    });
 
     updateTargetParams(newTargetParams);
   };

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'components/button';
 import Header from 'components/header';
@@ -68,9 +68,10 @@ const NDCCompareAllTargets = props => {
     tableData,
     noContentMsg,
     columns,
-    setColumnWidth
+    setColumnWidth,
+    handleTargetsChange,
+    selectedTargets
   } = props;
-  const [selectedTargets, setSelectedTargets] = useState([]);
   return (
     <React.Fragment>
       <MetaDescription
@@ -101,7 +102,7 @@ const NDCCompareAllTargets = props => {
           <div className={styles.legendAndActions}>
             {renderLegend()}
             <div className={styles.buttonAndSearch}>
-              <Button
+              {/* <Button
                 variant="primary"
                 className={styles.compareButton}
                 disabled={selectedTargets.length === 0}
@@ -114,7 +115,7 @@ const NDCCompareAllTargets = props => {
                     ? ''
                     : ` (${selectedTargets.length})`
                 }`}
-              </Button>
+              </Button> */}
               {!loading && (
                 <div className={styles.filtersLayout}>
                   {renderSearch(handleSearchChange, query)}
@@ -129,7 +130,7 @@ const NDCCompareAllTargets = props => {
             columns={columns}
             setColumnWidth={setColumnWidth}
             selectedTargets={selectedTargets}
-            setSelectedTargets={setSelectedTargets}
+            setSelectedTargets={handleTargetsChange}
           />
         </div>
       </div>
@@ -144,10 +145,12 @@ NDCCompareAllTargets.propTypes = {
   tableData: PropTypes.array,
   query: PropTypes.string,
   handleSearchChange: PropTypes.func.isRequired,
+  handleTargetsChange: PropTypes.func.isRequired,
   noContentMsg: PropTypes.string,
   columns: PropTypes.array,
   setColumnWidth: PropTypes.func.isRequired,
-  location: PropTypes.object
+  location: PropTypes.object,
+  selectedTargets: PropTypes.array
 };
 
 export default NDCCompareAllTargets;

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
@@ -46,16 +46,16 @@ const renderSearch = (searchHandler, query) => (
 );
 
 const getLinkToCustomCompare = selectedTargets => {
-  let linkToCustomCompare = {};
-  selectedTargets.forEach((t, i) => {
-    const [country, document] = t.split('-');
-    linkToCustomCompare = {
-      ...linkToCustomCompare,
-      [`country${i}`]: country,
-      [`document${i}`]: document
-    };
-  });
-  return qs.stringify(linkToCustomCompare);
+  // let linkToCustomCompare = {};
+  // selectedTargets.forEach((t, i) => {
+  //   const [country, document] = t.split('-');
+  //   linkToCustomCompare = {
+  //     ...linkToCustomCompare,
+  //     [`country${i}`]: country,
+  //     [`document${i}`]: document
+  //   };
+  // });
+  return `targets=${qs.stringify(selectedTargets)}`;
 };
 
 const NDCCompareAllTargets = props => {
@@ -70,7 +70,8 @@ const NDCCompareAllTargets = props => {
     columns,
     setColumnWidth,
     handleTargetsChange,
-    selectedTargets
+    selectedTargets,
+    queryParams
   } = props;
   return (
     <React.Fragment>
@@ -102,20 +103,18 @@ const NDCCompareAllTargets = props => {
           <div className={styles.legendAndActions}>
             {renderLegend()}
             <div className={styles.buttonAndSearch}>
-              {/* <Button
+              <Button
                 variant="primary"
                 className={styles.compareButton}
                 disabled={selectedTargets.length === 0}
-                link={`/custom-compare?${getLinkToCustomCompare(
-                  selectedTargets
-                )}`}
+                link={`/custom-compare?targets=${selectedTargets.join('%2')}`}
               >
                 {`Compare${
                   selectedTargets.length === 0
                     ? ''
                     : ` (${selectedTargets.length})`
                 }`}
-              </Button> */}
+              </Button>
               {!loading && (
                 <div className={styles.filtersLayout}>
                   {renderSearch(handleSearchChange, query)}

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
@@ -15,7 +15,6 @@ import Search from 'components/search';
 import { NCS_COMPARE_ALL } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import NdcCompareAllTargetsProvider from 'providers/ndc-compare-all-targets-provider';
-import qs from 'query-string';
 import CompareAllTable from './ndc-compare-all-targets-table/ndc-compare-all-targets-table';
 import styles from './ndc-compare-all-targets-styles.scss';
 
@@ -45,19 +44,6 @@ const renderSearch = (searchHandler, query) => (
   />
 );
 
-const getLinkToCustomCompare = selectedTargets => {
-  // let linkToCustomCompare = {};
-  // selectedTargets.forEach((t, i) => {
-  //   const [country, document] = t.split('-');
-  //   linkToCustomCompare = {
-  //     ...linkToCustomCompare,
-  //     [`country${i}`]: country,
-  //     [`document${i}`]: document
-  //   };
-  // });
-  return `targets=${qs.stringify(selectedTargets)}`;
-};
-
 const NDCCompareAllTargets = props => {
   const {
     loading,
@@ -70,8 +56,7 @@ const NDCCompareAllTargets = props => {
     columns,
     setColumnWidth,
     handleTargetsChange,
-    selectedTargets,
-    queryParams
+    selectedTargets
   } = props;
   return (
     <React.Fragment>
@@ -107,7 +92,7 @@ const NDCCompareAllTargets = props => {
                 variant="primary"
                 className={styles.compareButton}
                 disabled={selectedTargets.length === 0}
-                link={`/custom-compare?targets=${selectedTargets.join('%2')}`}
+                link={`/custom-compare?targets=${selectedTargets.join(',')}`}
               >
                 {`Compare${
                   selectedTargets.length === 0

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -7,7 +7,8 @@ const getCountries = state => (state.countries && state.countries.data) || null;
 const getIndicatorsData = state =>
   (state.compareAll.data && state.compareAll.data.indicators) || null;
 export const getLoading = state => state.compareAll.loading || null;
-export const getQuery = (state, { search }) => deburr(search.search) || '';
+export const getSearch = (state, { search }) => deburr(search.search) || '';
+const getQuery = (state, { search }) => search || '';
 
 const getData = createSelector(
   [getCountries, getIndicatorsData],
@@ -62,9 +63,18 @@ export const getColumns = createSelector([getData], rows => {
 });
 
 export const getFilteredDataBySearch = createSelector(
-  [getData, getQuery],
-  (data, query) => {
+  [getData, getSearch],
+  (data, search) => {
     if (!data || isEmpty(data)) return null;
-    return filterQuery(data, query, [], { Country: 'name' });
+    return filterQuery(data, search, [], { Country: 'name' });
+  }
+);
+
+export const getSelectedTargets = createSelector(
+  [getQuery],
+  (query) => {
+    if (!query || !query.targets) return [];
+    const selectedTargets = query.targets.split(',');
+    return selectedTargets;
   }
 );

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -8,7 +8,7 @@ const getIndicatorsData = state =>
   (state.compareAll.data && state.compareAll.data.indicators) || null;
 export const getLoading = state => state.compareAll.loading || null;
 export const getSearch = (state, { search }) => deburr(search.search) || '';
-const getQuery = (state, { search }) => search || '';
+export const getQuery = (state, { search }) => search || '';
 
 const getData = createSelector(
   [getCountries, getIndicatorsData],
@@ -70,11 +70,8 @@ export const getFilteredDataBySearch = createSelector(
   }
 );
 
-export const getSelectedTargets = createSelector(
-  [getQuery],
-  (query) => {
-    if (!query || !query.targets) return [];
-    const selectedTargets = query.targets.split(',');
-    return selectedTargets;
-  }
-);
+export const getSelectedTargets = createSelector([getQuery], query => {
+  if (!query || !query.targets) return [];
+  const selectedTargets = query.targets.split(',');
+  return selectedTargets;
+});

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -12,7 +12,8 @@ import {
   getColumns,
   getLoading,
   getSearch,
-  getSelectedTargets
+  getSelectedTargets,
+  getQuery
 } from './ndc-compare-all-targets-selectors';
 
 const mapStateToProps = (state, { location }) => {
@@ -24,7 +25,8 @@ const mapStateToProps = (state, { location }) => {
     columns: getColumns(state, {
       search
     }),
-    selectedTargets: getSelectedTargets(state, { search })
+    selectedTargets: getSelectedTargets(state, { search }),
+    queryParams: getQuery(state, { search })
   };
 };
 

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -11,18 +11,20 @@ import {
   getFilteredDataBySearch,
   getColumns,
   getLoading,
-  getQuery
+  getSearch,
+  getSelectedTargets
 } from './ndc-compare-all-targets-selectors';
 
 const mapStateToProps = (state, { location }) => {
   const search = qs.parse(location.search);
   return {
     loading: getLoading(state),
-    query: getQuery(state, { search }),
+    query: getSearch(state, { search }),
     tableData: getFilteredDataBySearch(state, { search }),
     columns: getColumns(state, {
       search
-    })
+    }),
+    selectedTargets: getSelectedTargets(state, { search })
   };
 };
 
@@ -50,6 +52,14 @@ const NDCCompareAllContainer = props => {
       value
     });
   };
+
+  const handleTargetsChange = value => {
+    updateUrlParam({
+      name: 'targets',
+      value: value.toString()
+    });
+  };
+
   const noContentMsg = query ? 'No data for this search' : 'No data';
 
   return createElement(NDCCompareAllComponent, {
@@ -57,7 +67,8 @@ const NDCCompareAllContainer = props => {
     noContentMsg,
     handleSearchChange,
     tableData,
-    setColumnWidth
+    setColumnWidth,
+    handleTargetsChange
   });
 };
 

--- a/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
+++ b/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
@@ -48,11 +48,6 @@ export default [
     label: 'NDC Search',
     activeId
   },
-  (FEATURE_ALL_COMMITMENTS_MENU_ITEMS || FEATURE_COMMITMENTS_OVERVIEW) && {
-    path: '/custom-compare',
-    label: 'Custom compare',
-    activeId
-  },
   {
     path: '/ndcs-sdg',
     label: 'EXPLORE NDC-SDG LINKAGES',


### PR DESCRIPTION
This PR saves the document selection in the URL as a `targets` param on `Compare all targets`  and  `Custom compare` pages. Navigation through `Go to compare all targets` button passes the `targets` params to the `Compare all targets` page. It also removes the `Custom compare` option from the `Commitments` menu.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171315679)

![mc1l1-38xzt](https://user-images.githubusercontent.com/15097138/75056149-4ec8cc80-54ce-11ea-837c-b93dd323a7d3.gif)

I hope that this solution is not overcomplicated, let me know what do you think ;)