### PR TITLE
Add F-gases to KYOTOGHG gas aggregates

### DIFF
--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -259,7 +259,7 @@ export const TOP_EMITTERS_OPTION = {
 
 export const GAS_AGGREGATES = {
   'All GHG': ['CH4', 'CO2', 'F-Gas', 'N2O'],
-  KYOTOGHG: ['CH4', 'CO2', 'HFCS', 'N2O'],
+  KYOTOGHG: ['CH4', 'CO2', 'HFCS', 'N2O', 'F-Gases'],
   'Aggregate GHGs': ['CH4', 'CO2', 'HFCs', 'N2O', 'PFCs', 'SF6'],
   'Aggregate F-gases': ['HFCs', 'PFCs', 'SF6']
 };


### PR DESCRIPTION
F-gases needed to be added to the KYOTOGHG agglomeration
Try: Go to GHG emissions / Pick PIK source and Show data by Gases
F-gases should show
![image](https://user-images.githubusercontent.com/9701591/75548058-95697a00-5a2c-11ea-8105-1a9c4cca5320.png)
