### PR TITLE
Fix numbers on legend

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -65,7 +65,8 @@ const renderLegend = legendData => (
           <LegendItem
             key={l.name}
             name={l.name}
-            partiesNumber={l.partiesNumber}
+            itemsName={['country', 'countries']}
+            number={l.countriesNumber}
             value={l.value}
             color={l.color}
           />

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -67,7 +67,7 @@ const renderLegend = legendData => (
           <LegendItem
             key={l.name}
             name={l.name}
-            partiesNumber={l.partiesNumber}
+            number={l.partiesNumber}
             value={l.value}
             color={l.color}
           />

--- a/app/javascript/app/components/ndcs/shared/legend-item/legend-item.jsx
+++ b/app/javascript/app/components/ndcs/shared/legend-item/legend-item.jsx
@@ -3,7 +3,7 @@ import Progress from 'components/progress';
 import PropTypes from 'prop-types';
 import styles from './legend-item-styles.scss';
 
-const LegendItem = ({ name, partiesNumber, value, color }) => (
+const LegendItem = ({ name, number, value, color, itemsName }) => (
   <div className={styles.legendItem}>
     <div>
       <span className={styles.legendDot} style={{ backgroundColor: color }} />
@@ -12,7 +12,7 @@ const LegendItem = ({ name, partiesNumber, value, color }) => (
     <div className={styles.progressContainer}>
       <Progress value={value} className={styles.progressBar} color={color} />
       <div className={styles.partiesNumber}>
-        {partiesNumber} {partiesNumber === 1 ? 'party' : 'parties'}
+        {number} {number === 1 ? itemsName[0] : itemsName[1]}
       </div>
     </div>
   </div>
@@ -20,9 +20,14 @@ const LegendItem = ({ name, partiesNumber, value, color }) => (
 
 LegendItem.propTypes = {
   name: PropTypes.string,
-  partiesNumber: PropTypes.number,
+  number: PropTypes.number,
+  itemsName: PropTypes.array,
   value: PropTypes.number,
   color: PropTypes.string
+};
+
+LegendItem.defaultProps = {
+  itemsName: ['party', 'parties']
 };
 
 export default LegendItem;


### PR DESCRIPTION
Numbers on LTS explore legend were not showing on staging
- Fix the names of the LegendItem component props and use 'country' and 'countries' for LTS explore only

![image](https://user-images.githubusercontent.com/9701591/75890994-72293b00-5e2f-11ea-8f8d-1d20c14e7ac4.png)
