### PR TITLE
Fix/last feedback lts

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -59,7 +59,7 @@ const renderSummary = summaryData => (
   </div>
 );
 
-const renderLegend = legendData => (
+const renderLegend = (legendData, isEUUSubmitted) => (
   <div className={styles.legendCardContainer}>
     <div className={styles.legendContainer}>
       {legendData &&
@@ -67,7 +67,7 @@ const renderLegend = legendData => (
           <LegendItem
             key={l.name}
             name={l.name}
-            itemsName={['country', 'countries']}
+            itemsName={isEUUSubmitted ? undefined : ['country', 'countries']}
             number={l.countriesNumber}
             value={l.value}
             color={l.color}
@@ -81,7 +81,7 @@ function LTSExploreMap(props) {
   const tooltipParentRef = useRef(null);
   const pieChartRef = useRef(null);
   const [stickyStatus, setStickyStatus] = useState(Sticky.STATUS_ORIGINAL);
-  const renderDonutChart = emissionsCardData => (
+  const renderDonutChart = (emissionsCardData, isEUUSubmitted) => (
     <div className={styles.donutContainer} ref={pieChartRef}>
       <PieChart
         data={emissionsCardData.data}
@@ -92,6 +92,7 @@ function LTSExploreMap(props) {
             reference={tooltipParentRef.current}
             chartReference={pieChartRef.current}
             data={emissionsCardData.data}
+            itemName={isEUUSubmitted ? 'Parties' : undefined}
           />
         }
         customInnerHoverLabel={CustomInnerHoverLabel}
@@ -117,7 +118,8 @@ function LTSExploreMap(props) {
     handleCategoryChange,
     selectedCategory,
     handleIndicatorChange,
-    tooltipValues
+    tooltipValues,
+    isEUUSubmitted
   } = props;
 
   const TOOLTIP_ID = 'lts-map-tooltip';
@@ -177,8 +179,12 @@ function LTSExploreMap(props) {
                         <React.Fragment>
                           {summaryCardData && renderSummary(summaryCardData)}
                           {emissionsCardData &&
-                            renderDonutChart(emissionsCardData)}
-                          {legendData && renderLegend(legendData)}
+                            renderDonutChart(
+                              emissionsCardData,
+                              isEUUSubmitted
+                            )}
+                          {legendData &&
+                            renderLegend(legendData, isEUUSubmitted)}
                         </React.Fragment>
                       )}
                     </div>
@@ -240,7 +246,8 @@ LTSExploreMap.propTypes = {
   handleCategoryChange: PropTypes.func,
   selectedCategory: PropTypes.object,
   tooltipValues: PropTypes.object,
-  handleIndicatorChange: PropTypes.func
+  handleIndicatorChange: PropTypes.func,
+  isEUUSubmitted: PropTypes.bool
 };
 
 export default LTSExploreMap;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -22,7 +22,8 @@ import {
   getCategories,
   getCategoryIndicators,
   getSelectedCategory,
-  getTooltipCountryValues
+  getTooltipCountryValues,
+  getIsEUUSubmitted
 } from './lts-explore-map-selectors';
 
 const actions = { ...fetchActions, ...modalActions };
@@ -49,6 +50,7 @@ const mapStateToProps = (state, { location }) => {
     query: LTSWithSelection.query,
     paths: getPathsWithStyles(LTSWithSelection),
     isoCountries: getISOCountries(LTSWithSelection),
+    isEUUSubmitted: getIsEUUSubmitted(LTSWithSelection),
     selectedIndicator: getMapIndicator(LTSWithSelection),
     emissionsCardData: getEmissionsCardData(LTSWithSelection),
     tooltipCountryValues: getTooltipCountryValues(LTSWithSelection),

--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -9,7 +9,8 @@ const DonutTooltip = props => {
   const {
     reference,
     chartReference,
-    content: { payload, coordinate }
+    content: { payload, coordinate },
+    itemName
   } = props;
   if (!payload || !payload[0]) return null;
 
@@ -26,7 +27,7 @@ const DonutTooltip = props => {
   if (top < 340 && left < 190) top += 80;
   return ReactDOM.createPortal(
     <div className={styles.tooltip} style={{ left, top }}>
-      {`Countries with ${legendItemName} represent ${percentage}% of global emissions`}
+      {`${itemName} with ${legendItemName} represent ${percentage}% of global emissions`}
     </div>,
     reference
   );
@@ -35,7 +36,12 @@ const DonutTooltip = props => {
 DonutTooltip.propTypes = {
   content: PropTypes.object,
   reference: PropTypes.object,
-  chartReference: PropTypes.object
+  chartReference: PropTypes.object,
+  itemName: PropTypes.string
+};
+
+DonutTooltip.defaultProps = {
+  itemName: 'Countries'
 };
 
 export default DonutTooltip;

--- a/app/javascript/app/components/progress/progress-styles.scss
+++ b/app/javascript/app/components/progress/progress-styles.scss
@@ -13,10 +13,10 @@
     padding-right: 4px;
     position: relative;
 
-    &:after {
+    &::after {
       content: '';
       background: inherit;
-      border-radius: 0 10px 10px 0;
+      border-radius: 0 3px 3px 0;
       height: 8px;
       position: absolute;
       right: 0;

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -259,7 +259,7 @@ export const TOP_EMITTERS_OPTION = {
 
 export const GAS_AGGREGATES = {
   'All GHG': ['CH4', 'CO2', 'F-Gas', 'N2O'],
-  KYOTOGHG: ['CH4', 'CO2', 'HFCS', 'N2O', 'F-Gases'],
+  KYOTOGHG: ['CH4', 'CO2', 'HFCS', 'N2O', 'F-Gas'],
   'Aggregate GHGs': ['CH4', 'CO2', 'HFCs', 'N2O', 'PFCs', 'SF6'],
   'Aggregate F-gases': ['HFCs', 'PFCs', 'SF6']
 };

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -18,9 +18,11 @@ export const FIRST_TABLE_HEADERS = {
     'overview_category',
     'sector',
     'subsector',
-    'indicator_id',
     'indicator',
-    'value'
+    'value',
+    'source',
+    'indicator_name',
+    'indicator_id'
   ],
   'lts-content': [
     'country',
@@ -29,9 +31,11 @@ export const FIRST_TABLE_HEADERS = {
     'overview_category',
     'sector',
     'subsector',
-    'indicator_id',
     'indicator',
-    'value'
+    'value',
+    'source',
+    'indicator_name',
+    'indicator_id'
   ],
   'ndc-sdg-linkages': [
     'country',

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -13,7 +13,6 @@ import { Dropdown as CWDropdown } from 'cw-components';
 import { LTS_COUNTRY } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import { TabletPortrait, MobileOnly } from 'components/responsive';
-import NdcsDocumentsMetaProvider from 'providers/ndcs-documents-meta-provider';
 
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import countryDropdownTheme from 'styles/themes/dropdown/dropdown-country.scss';
@@ -21,18 +20,17 @@ import styles from './lts-country-styles.scss';
 
 class LTSCountry extends PureComponent {
   renderFullTextDropdown() {
-    const { match, documentsOptions } = this.props;
+    const { documentLink } = this.props;
     return (
-      documentsOptions && (
-        <Button
-          variant="secondary"
-          link={`/lts/country/${match.params.iso}/full`}
-          className={styles.viewDocumentButton}
-          disabled
-        >
-          View LTS Document
-        </Button>
-      )
+      <Button
+        variant="secondary"
+        href={documentLink}
+        className={styles.viewDocumentButton}
+        disabled={!documentLink}
+        target="_blank"
+      >
+        View LTS Document
+      </Button>
     );
   }
 
@@ -96,7 +94,6 @@ class LTSCountry extends PureComponent {
           descriptionContext={LTS_COUNTRY({ countryName })}
           href={location.href}
         />
-        <NdcsDocumentsMetaProvider />
         {country && (
           <Header route={route}>
             <div className={styles.header}>
@@ -158,7 +155,7 @@ LTSCountry.propTypes = {
   anchorLinks: PropTypes.array,
   notSummary: PropTypes.bool,
   match: PropTypes.object.isRequired,
-  documentsOptions: PropTypes.array,
+  documentLink: PropTypes.string,
   handleCountryLink: PropTypes.func.isRequired,
   countriesOptions: PropTypes.array
 };

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -4,6 +4,7 @@ import { renderRoutes } from 'react-router-config';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import Button from 'components/button';
+import Icon from 'components/icon';
 import BackButton from 'components/back-button';
 import Search from 'components/search';
 import cx from 'classnames';
@@ -13,6 +14,7 @@ import { Dropdown as CWDropdown } from 'cw-components';
 import { LTS_COUNTRY } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import { TabletPortrait, MobileOnly } from 'components/responsive';
+import externalLinkIcon from 'assets/icons/external-link.svg';
 
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
 import countryDropdownTheme from 'styles/themes/dropdown/dropdown-country.scss';
@@ -30,6 +32,7 @@ class LTSCountry extends PureComponent {
         target="_blank"
       >
         View LTS Document
+        <Icon className={styles.externalLinkIcon} icon={externalLinkIcon} />
       </Button>
     );
   }

--- a/app/javascript/app/pages/lts-country/lts-country-selectors.js
+++ b/app/javascript/app/pages/lts-country/lts-country-selectors.js
@@ -1,11 +1,10 @@
 import { createSelector } from 'reselect';
 import qs from 'query-string';
-import isEmpty from 'lodash/isEmpty';
-import upperCase from 'lodash/upperCase';
 
 const getCountries = state => state.countries || null;
 const getIso = state => state.iso || null;
-const getDocuments = state => state.data || null;
+const getIndicators = state =>
+  (state.LTS.data && state.LTS.data.indicators) || null;
 
 const getCountryByIso = (countries, iso) =>
   countries.find(country => country.iso_code3 === iso);
@@ -33,15 +32,16 @@ export const getAnchorLinks = createSelector(
   }
 );
 
-export const getDocumentsOptions = createSelector(
-  [getDocuments, getIso],
-  (documents, iso) => {
-    if (isEmpty(documents) || !iso || !documents[iso]) return null;
-    return documents[iso].map(doc => ({
-      label: `${upperCase(doc.document_type)}(${doc.language})`,
-      value: `${doc.document_type}(${doc.language})`,
-      path: `/lts/country/${iso}/full?document=${doc.document_type}-${doc.language}`
-    }));
+export const getDocumentLink = createSelector(
+  [getIndicators, getIso],
+  (indicators, iso) => {
+    if (!indicators || !iso) return null;
+    const documentIndicator = indicators.find(i => i.slug === 'lts_document');
+    if (!documentIndicator || !documentIndicator.locations[iso]) return null;
+    const parsedLinkMatch = documentIndicator.locations[iso].value.match(
+      /href="(.+)">/
+    );
+    return (parsedLinkMatch && parsedLinkMatch[1]) || null;
   }
 );
 

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -64,3 +64,9 @@
 .mobileActions {
   @include row();
 }
+
+.externalLinkIcon {
+  margin: 3px 0 0 5px;
+  width: 13px;
+  height: 13px;
+}

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -1,15 +1,16 @@
 import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Proptypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import actions from 'pages/lts-explore/lts-explore-actions';
 
 import LTSCountryComponent from './lts-country-component';
 import {
   getCountry,
   getAnchorLinks,
-  getDocumentsOptions,
+  getDocumentLink,
   addUrlToCountries
 } from './lts-country-selectors';
 
@@ -17,6 +18,7 @@ const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
   const search = qs.parse(location.search);
   const stateData = {
+    ...state,
     iso,
     location,
     route,
@@ -36,12 +38,16 @@ const mapStateToProps = (state, { match, location, route }) => {
     search: search.search,
     anchorLinks: getAnchorLinks(stateData),
     countriesOptions: addUrlToCountries(stateData),
-    documentsOptions: getDocumentsOptions(stateData),
+    documentLink: getDocumentLink(stateData),
     notSummary
   };
 };
 
 class LTSCountryContainer extends PureComponent {
+  componentWillMount() {
+    this.props.fetchLTS();
+  }
+
   onSearchChange = query => {
     this.updateUrlParam({ name: 'search', value: query });
   };
@@ -71,9 +77,12 @@ class LTSCountryContainer extends PureComponent {
 }
 
 LTSCountryContainer.propTypes = {
-  history: Proptypes.object.isRequired,
-  location: Proptypes.object.isRequired,
-  country: Proptypes.object
+  fetchLTS: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  country: PropTypes.object
 };
 
-export default withRouter(connect(mapStateToProps, null)(LTSCountryContainer));
+export default withRouter(
+  connect(mapStateToProps, actions)(LTSCountryContainer)
+);


### PR DESCRIPTION
Final feedback changes for LTS explore:

- Fix F-gas in KYOTO gases aggregates: Not sure why this was still wrong: Try source: PIK, Show data by: Gases in GHG emissions page.

![image](https://user-images.githubusercontent.com/9701591/76555158-696fdf00-6497-11ea-88d4-548a673d3da2.png)

- Move indicator id to the end of the table: In the data Explorer indicator_id should be on the last position for NDC and LTS

![image](https://user-images.githubusercontent.com/9701591/76555599-3a0da200-6498-11ea-9654-f4f5b9d7b678.png)


- Add document link in LTS country: In LTS explore country page the 'View LTS document' link button should open the external document pdf page

![image](https://user-images.githubusercontent.com/9701591/76556063-20208f00-6499-11ea-9f51-ac2b237f22c3.png)


- Change Parties text on tooltip and legend if EUU: If we have EUU available as a party in LTS we should show a different summary (First card) and legend and tooltips should be adapted

Without:
![image](https://user-images.githubusercontent.com/9701591/76555398-d84d3800-6497-11ea-8452-5a680351c4fa.png)

With:
![image](https://user-images.githubusercontent.com/9701591/76555409-dc795580-6497-11ea-9a46-b557454dfcb3.png)

- Change progress bars border-radius: Little change requested by WRI
![image](https://user-images.githubusercontent.com/9701591/76555547-1e0a0080-6498-11ea-860d-8a54f0f7a545.png)

