### PR TITLE
Enable parsing html in modals

### DIFF
--- a/app/javascript/app/components/metadata-text/metadata-text-component.jsx
+++ b/app/javascript/app/components/metadata-text/metadata-text-component.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import Disclaimer from 'components/disclaimer';
 import { toStartCase } from 'utils/utils';
 import { isArray } from 'util';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown/with-html';
 
 import styles from './metadata-text-styles.scss';
 
@@ -33,6 +33,7 @@ const MetadataProp = ({ title, data }) =>
         [styles.empty]: data === 'Not specified'
       })}
       source={`**${toStartCase(title)}**: ${data}`}
+      escapeHtml={false}
     />
   ));
 


### PR DESCRIPTION
This tiny PR enables parsing HTML tags in the metadata modal. It's the solution for the issue addressed in [this thread on Basecamp](https://basecamp.com/1756858/projects/13795275/todos/406051530). From now, we can simply use` <br>` tag to break a line.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171385874) | [REACT-MARKDOWN DOCUMENTATION](https://github.com/rexxars/react-markdown#parsing-html)