### PR TITLE
Feature/update indc importers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: ruby
 rvm:
 - 2.5.1
 addons:
-  postgresql: 12
+  postgresql: 9.6
 before_script:
   - bundle exec rake db:create db:structure:load RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: ruby
 rvm:
 - 2.5.1
 addons:
-  postgresql: 9.6
+  postgresql: 12
 before_script:
   - bundle exec rake db:create db:structure:load RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/app/controllers/api/v1/data/ndc_content/documents_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/documents_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    module Data
+      module NdcContent
+        class DocumentsController < Api::V1::Data::ApiController
+          def index
+            documents = ::Indc::Document.order(:ordering)
+            render json: documents,
+                   adapter: :json,
+                   each_serializer: Api::V1::Data::NdcContent::DocumentSerializer,
+                   root: :data
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/ndc_documents_controller.rb
+++ b/app/controllers/api/v1/ndc_documents_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    CountriesDocuments = Struct.new(:data) do
+      alias_method :read_attribute_for_serialization, :send
+    end
+    class NdcDocumentsController < ApiController
+      def index
+        render json: CountriesDocuments.new(set_locations(params)),
+               serializer: Api::V1::Indc::CountriesDocumentsSerializer
+      end
+
+      private
+
+      def set_locations(params)
+        locs = Location.order(:wri_standard_name)
+
+        if params[:location]
+          locs = locs.where(iso_code3: params[:location])
+        end
+
+        locs
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -49,6 +49,7 @@ module Api
           includes(:category_type).
           order(:order)
 
+        # params[:filter] -> ['map', 'table']
         if params[:filter]
           categories = categories.where(
             indc_category_types: {name: params[:filter]}
@@ -56,10 +57,9 @@ module Api
         end
 
         indicators = ::Indc::Indicator.
-          includes(
-            :labels, :source, :categories,
-            values: [:sector, :label, :location]
-        ).order(:order)
+          includes(:labels, :source, :categories,
+                   values: [:sector, :label, :location, :document]).
+          order(:order)
 
         # params[:source] -> one of ["CAIT", "LTS", "WB", "NDC Explorer"]
         if params[:source]
@@ -87,6 +87,11 @@ module Api
           indicators = indicators.where(
             values: {locations: {iso_code3: location_list}}
           )
+        end
+
+        if params[:document]
+          indicators = indicators.
+            where(values: {indc_documents: {slug: params[:document]}})
         end
 
         render json: NdcIndicators.new(indicators, categories, sectors),

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -91,7 +91,7 @@ module Api
 
         if params[:document]
           indicators = indicators.
-            where(values: {indc_documents: {slug: params[:document]}})
+            where(values: {indc_documents: {slug: [params[:document], nil]}})
         end
 
         render json: NdcIndicators.new(indicators, categories, sectors),
@@ -121,10 +121,10 @@ module Api
 
         if params[:document]
           values = values.joins(:document).
-            where(indc_documents: {slug: params[:document]})
+            where(indc_documents: {slug: [params[:document], nil]})
 
           sectors = sectors.joins(values: :document).
-            where(indc_documents: {slug: params[:document]})
+            where(indc_documents: {slug: [params[:document], nil]})
         end
        sectors = sectors.order('indc_indicators.name').pluck(:name)
 

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -117,8 +117,17 @@ module Api
           joins(:values).
           where(slug: SECTORS_INDICATORS).
           where(indc_values: {location_id: location.id}).
-          where.not(indc_values: {value: "No specified measure"}).
-          order('indc_indicators.name').pluck(:name)
+          where.not(indc_values: {value: "No specified measure"})
+
+        if params[:document]
+          values = values.joins(:document).
+            where(indc_documents: {slug: params[:document]})
+
+          sectors = sectors.joins(values: :document).
+            where(indc_documents: {slug: params[:document]})
+        end
+       sectors = sectors.order('indc_indicators.name').pluck(:name)
+
 
         render json: NdcOverview.new(values, sectors),
                serializer: Api::V1::Indc::OverviewSerializer

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -221,6 +221,7 @@ export const getTooltipCountryValues = createSelector(
           selectedIndicator.locations[iso] &&
           selectedIndicator.locations[iso].value,
         emissionsValue:
+          emissionsIndicator &&
           emissionsIndicator.locations[iso] &&
           emissionsIndicator.locations[iso].value
       };
@@ -236,6 +237,7 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
     const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
+    if (!emissionsIndicator) return null;
     const data = getIndicatorEmissionsData(
       emissionsIndicator,
       selectedIndicator,

--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,0 +1,2 @@
+class Indc::Document < ApplicationRecord
+end

--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,3 +1,7 @@
 class Indc::Document < ApplicationRecord
   has_many :values, class_name: 'Indc::Value'
+
+  def as_json _={}
+    super(except: [:created_at, :updated_at])
+  end
 end

--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,7 +1,7 @@
 class Indc::Document < ApplicationRecord
   has_many :values, class_name: 'Indc::Value'
 
-  def as_json _={}
+  def as_json(_={})
     super(except: [:created_at, :updated_at])
   end
 end

--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,2 +1,3 @@
 class Indc::Document < ApplicationRecord
+  has_many :values, class_name: 'Indc::Value'
 end

--- a/app/models/indc/value.rb
+++ b/app/models/indc/value.rb
@@ -4,6 +4,7 @@ module Indc
     belongs_to :indicator, class_name: 'Indc::Indicator'
     belongs_to :label, class_name: 'Indc::Label', optional: true
     belongs_to :sector, class_name: 'Indc::Sector', optional: true
+    belongs_to :document, class_name: 'Indc::Document', optional: true
 
     validates :value, presence: true
   end

--- a/app/serializers/api/v1/data/ndc_content/document_serializer.rb
+++ b/app/serializers/api/v1/data/ndc_content/document_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    module Data
+      module NdcContent
+        class DocumentSerializer < ActiveModel::Serializer
+          attributes :id, :ordering, :slug, :long_name, :description
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    module Indc
+      class CountriesDocumentsSerializer < ActiveModel::Serializer
+        has_many :data, serializer: CountryDocumentSerializer
+
+        attributes :documents, :laws, :policies
+
+        def documents
+          ::Indc::Document.order(:ordering)
+        end
+
+        def laws
+          {}
+        end
+
+        def policies
+          {}
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/indc/country_document_serializer.rb
+++ b/app/serializers/api/v1/indc/country_document_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    module Indc
+      class CountryDocumentSerializer < ActiveModel::Serializer
+        attributes :iso_code3, :slugs
+
+        def slugs
+          ::Indc::Document.joins(values: :location).
+            where(locations: {iso_code3: object.iso_code3}).
+            order(:ordering).distinct
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/indc/value_serializer.rb
+++ b/app/serializers/api/v1/indc/value_serializer.rb
@@ -6,9 +6,14 @@ module Api
         attribute :label_id, if: -> { object.label_id }
         attribute :label_slug, if: -> { object.label&.slug }
         attribute :sector_id, if: -> { object.sector_id }
+        attribute :document_slug
 
         def label_slug
           object.label&.slug
+        end
+
+        def document_slug
+          object.document&.slug
         end
       end
     end

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -1,21 +1,23 @@
 # rubocop:disable ClassLength
 class ImportIndc
-  DATA_CAIT_FILEPATH =
-    "#{CW_FILES_PREFIX}indc/NDC_CAIT_data.csv".freeze
-  LEGEND_CAIT_FILEPATH =
-    "#{CW_FILES_PREFIX}indc/NDC_CAIT_legend.csv".freeze
+  DATA_FILEPATH =
+    "#{CW_FILES_PREFIX}indc/NDC_data.csv".freeze
+  SINGLE_VERSION_FILEPATH =
+    "#{CW_FILES_PREFIX}indc/NDC_single_version.csv".freeze
+  LEGEND_FILEPATH =
+    "#{CW_FILES_PREFIX}indc/NDC_legend.csv".freeze
   DATA_LTS_FILEPATH =
     "#{CW_FILES_PREFIX}indc/NDC_LTS_data.csv".freeze
   DATA_LTS_SECTORAL_FILEPATH =
     "#{CW_FILES_PREFIX}indc/NDC_LTS_data_sectoral.csv".freeze
-  DATA_WB_WIDE_FILEPATH =
-    "#{CW_FILES_PREFIX}indc/NDC_WB_data_wide.csv".freeze
   DATA_WB_SECTORAL_FILEPATH =
-    "#{CW_FILES_PREFIX}indc/NDC_WB_data_sectoral.csv".freeze
+    "#{CW_FILES_PREFIX}indc/NDC_WB_data_sectoral_all.csv".freeze
   SUBMISSIONS_FILEPATH =
     "#{CW_FILES_PREFIX}indc/NDC_submission.csv".freeze
   METADATA_FILEPATH =
     "#{CW_FILES_PREFIX}indc/NDC_metadata.csv".freeze
+  DOCUMENTS_FILEPATH =
+    "#{CW_FILES_PREFIX}indc/NDC_documents.csv".freeze
 
   def call
     ActiveRecord::Base.transaction do
@@ -24,6 +26,7 @@ class ImportIndc
       load_csvs
       load_locations
 
+      import_documents
       import_sources
       import_category_types
       import_categories
@@ -31,7 +34,7 @@ class ImportIndc
       import_indicators
       import_indicators_categories
       import_labels
-      import_values_cait
+      import_values_ndc
 
       import_sectors_lts
       import_values_lts
@@ -57,6 +60,7 @@ class ImportIndc
     Indc::Indicator.delete_all
     Indc::Source.delete_all
     Indc::Submission.delete_all
+    Indc::Document.delete_all
   end
 
   def load_csvs
@@ -64,15 +68,14 @@ class ImportIndc
     symbol_converter = lambda { |h|
       h.downcase.gsub(/[^\s\w-]+/, '').strip.gsub(/\s+/, '_').to_sym
     }
-    @cait_data = S3CSVReader.read(
-      DATA_CAIT_FILEPATH, [symbol_converter]
-    ).map(&:to_h)
-    @cait_labels = S3CSVReader.read(LEGEND_CAIT_FILEPATH).map(&:to_h)
+    @documents = S3CSVReader.read(DOCUMENTS_FILEPATH, [symbol_converter]).map(&:to_h)
+    @ndc_data = S3CSVReader.read(DATA_FILEPATH, [symbol_converter]).map(&:to_h)
+    @single_version_data = S3CSVReader.read(SINGLE_VERSION_FILEPATH, [symbol_converter]).map(&:to_h)
+    @labels = S3CSVReader.read(LEGEND_FILEPATH).map(&:to_h)
     @lts_data = S3CSVReader.read(
       DATA_LTS_FILEPATH, [symbol_converter]
     ).map(&:to_h)
     @lts_sectoral_data = S3CSVReader.read(DATA_LTS_SECTORAL_FILEPATH).map(&:to_h)
-    @wb_wide_data = S3CSVReader.read(DATA_WB_WIDE_FILEPATH).map(&:to_h)
     @wb_sectoral_data = S3CSVReader.read(DATA_WB_SECTORAL_FILEPATH).map(&:to_h)
     @metadata = S3CSVReader.read(METADATA_FILEPATH).map(&:to_h)
     @submissions = S3CSVReader.read(SUBMISSIONS_FILEPATH).map(&:to_h)
@@ -105,11 +108,12 @@ class ImportIndc
       slug: indicator[:column_name],
       description: indicator[:definition],
       source: @sources_index[indicator[:source]],
-      order: index * 10
+      order: index * 10,
+      multiple_versions: indicator[:multiple_version]
     }
   end
 
-  def value_cait_attributes(row, location, indicator)
+  def value_ndc_attributes(row, location, indicator)
     {
       location: location,
       indicator: indicator,
@@ -117,7 +121,8 @@ class ImportIndc
         value: row[:"#{indicator.slug}_label"],
         indicator: indicator
       ),
-      value: row[:"#{indicator.slug}"]
+      value: row[:"#{indicator.slug}"],
+      document: Indc::Document.find_by(slug: row[:document]&.parameterize)
     }
   end
 
@@ -126,7 +131,17 @@ class ImportIndc
       location: location,
       indicator: indicator,
       sector: @sectors_index[row[:subsector]],
-      value: row[:responsetext]
+      value: row[:responsetext],
+      document: Indc::Document.find_by(slug: row[:document]&.parameterize)
+    }
+  end
+
+  def document_attributes(doc)
+    {
+      ordering: doc[:order_number],
+      slug: doc[:slug].parameterize,
+      long_name: doc[:long_name],
+      description: doc[:description]
     }
   end
 
@@ -252,7 +267,7 @@ class ImportIndc
   end
 
   def import_labels
-    indicators = @cait_labels.group_by { |l| l[:indicator_name] }.
+    indicators = @labels.group_by { |l| l[:indicator_name] }.
       map { |k, v| [k, v.map { |i| {label: i[:legend_item], slug: i[:slug]} }] }.
       to_h
 
@@ -283,11 +298,11 @@ class ImportIndc
     end
   end
 
-  def import_values_cait
+  def import_values_ndc
     Indc::Indicator.
-      where(source: [@sources_index['CAIT'], @sources_index['NDC Explorer']]).
+      where(source: [@sources_index['CAIT'], @sources_index['NDC Explorer'], @sources_index['WB']]).
       each do |indicator|
-      @cait_data.each do |r|
+      (@single_version_data + @ndc_data).each do |r|
         location = @locations_by_iso3[r[:iso]]
         unless location
           Rails.logger.error "location #{r[:country]} not found. Skipping."
@@ -297,7 +312,7 @@ class ImportIndc
         next unless r[:"#{indicator.slug}"].present?
 
         Indc::Value.create!(
-          value_cait_attributes(r, location, indicator)
+          value_ndc_attributes(r, location, indicator)
         )
       end
     end
@@ -316,7 +331,7 @@ class ImportIndc
         next unless r[:"#{indicator.slug}"].present?
 
         Indc::Value.create!(
-          value_cait_attributes(r, location, indicator)
+          value_ndc_attributes(r, location, indicator)
         )
       end
     end
@@ -395,7 +410,7 @@ class ImportIndc
       map { |k, v| [k, v.first] }.
       to_h
 
-    (@wb_wide_data + @wb_sectoral_data).each do |r|
+    @wb_sectoral_data.each do |r|
       location = @locations_by_iso2[r[:countrycode]]
       unless location
         Rails.logger.error "location #{r[:countrycode]} not found. Skipping."
@@ -416,11 +431,20 @@ class ImportIndc
     end
   end
 
+  def import_documents
+    @documents.each do |doc|
+      Indc::Document.create!(document_attributes(doc))
+    end
+  end
+
   def import_submissions
     @submissions.each do |sub|
       location = Location.find_by(iso_code3: sub[:iso])
       next unless location
-      Indc::Submission.create!(submission_attributes(location, sub))
+      begin
+        Indc::Submission.create!(submission_attributes(location, sub))
+      rescue
+      end
     end
   end
 

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -42,14 +42,14 @@ platforms:
       - name: indc
         importer: ImportIndc
         datasets:
-          - NDC_CAIT_data
-          - NDC_CAIT_legend
+          - NDC_data
+          - NDC_legend
           - NDC_LTS_data
           - NDC_LTS_data_sectoral
-          - NDC_WB_data_wide
-          - NDC_WB_data_sectoral
+          - NDC_WB_data_sectoral_all
           - NDC_submission
           - NDC_metadata
+          - NDC_single_version
       - name: locations
         importer: ImportLocations
         datasets:

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -50,6 +50,7 @@ platforms:
           - NDC_submission
           - NDC_metadata
           - NDC_single_version
+          - NDC_documents
       - name: locations
         importer: ImportLocations
         datasets:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
           action: :content_overview
         get :linkages_dataset, on: :collection, controller: :ndc_sdgs,
           action: :linkages_dataset, defaults: { format: :csv }
+        get :countries_documents, on: :collection, controller: :ndc_documents, action: :index
       end
 
       resources :adaptations, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
           resources :categories, only: [:index]
           resources :labels, only: [:index]
           resources :sectors, only: [:index]
+          resources :documents, only: [:index]
         end
         resources :lts_content, only: [:index] do
           get :download, on: :collection, defaults: { format: 'zip' }

--- a/db/migrate/20200317204602_create_indc_documents.rb
+++ b/db/migrate/20200317204602_create_indc_documents.rb
@@ -1,0 +1,14 @@
+class CreateIndcDocuments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :indc_documents do |t|
+      t.integer :ordering
+      t.string :slug
+      t.string :long_name
+      t.text :description
+
+      t.timestamps
+    end
+    add_index :indc_documents, :ordering, unique: true
+    add_index :indc_documents, :slug, unique: true
+  end
+end

--- a/db/migrate/20200317210227_add_document_id_to_indc_values.rb
+++ b/db/migrate/20200317210227_add_document_id_to_indc_values.rb
@@ -1,0 +1,5 @@
+class AddDocumentIdToIndcValues < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :indc_values, :document, foreign_key: { to_table: :indc_documents }
+  end
+end

--- a/db/migrate/20200317210928_add_multiple_versions_to_indc_indicators.rb
+++ b/db/migrate/20200317210928_add_multiple_versions_to_indc_indicators.rb
@@ -1,0 +1,5 @@
+class AddMultipleVersionsToIndcIndicators < ActiveRecord::Migration[5.2]
+  def change
+    add_column :indc_indicators, :multiple_versions, :boolean
+  end
+end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -5,26 +5,13 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,22 +5,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: emissions_filter_by_year_range(jsonb, integer, integer); Type: FUNCTION; Schema: public; Owner: -
@@ -43,7 +30,7 @@ CREATE FUNCTION public.emissions_filter_by_year_range(emissions jsonb, start_yea
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
@@ -925,6 +912,40 @@ ALTER SEQUENCE public.indc_category_types_id_seq OWNED BY public.indc_category_t
 
 
 --
+-- Name: indc_documents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.indc_documents (
+    id bigint NOT NULL,
+    ordering integer,
+    slug character varying,
+    long_name character varying,
+    description text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: indc_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.indc_documents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: indc_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.indc_documents_id_seq OWNED BY public.indc_documents.id;
+
+
+--
 -- Name: indc_indicators; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -936,7 +957,8 @@ CREATE TABLE public.indc_indicators (
     description text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    "order" integer
+    "order" integer,
+    multiple_versions boolean
 );
 
 
@@ -1135,7 +1157,8 @@ CREATE TABLE public.indc_values (
     label_id bigint,
     value text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    document_id bigint
 );
 
 
@@ -2218,6 +2241,13 @@ ALTER TABLE ONLY public.indc_category_types ALTER COLUMN id SET DEFAULT nextval(
 
 
 --
+-- Name: indc_documents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.indc_documents ALTER COLUMN id SET DEFAULT nextval('public.indc_documents_id_seq'::regclass);
+
+
+--
 -- Name: indc_indicators id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2718,6 +2748,14 @@ ALTER TABLE ONLY public.indc_categories
 
 ALTER TABLE ONLY public.indc_category_types
     ADD CONSTRAINT indc_category_types_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: indc_documents indc_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.indc_documents
+    ADD CONSTRAINT indc_documents_pkey PRIMARY KEY (id);
 
 
 --
@@ -3254,6 +3292,20 @@ CREATE UNIQUE INDEX index_indc_category_types_on_name ON public.indc_category_ty
 
 
 --
+-- Name: index_indc_documents_on_ordering; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_indc_documents_on_ordering ON public.indc_documents USING btree (ordering);
+
+
+--
+-- Name: index_indc_documents_on_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_indc_documents_on_slug ON public.indc_documents USING btree (slug);
+
+
+--
 -- Name: index_indc_indicators_categories_on_category_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3349,6 +3401,13 @@ CREATE UNIQUE INDEX index_indc_sources_on_name ON public.indc_sources USING btre
 --
 
 CREATE INDEX index_indc_submissions_on_location_id ON public.indc_submissions USING btree (location_id);
+
+
+--
+-- Name: index_indc_values_on_document_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_indc_values_on_document_id ON public.indc_values USING btree (document_id);
 
 
 --
@@ -3745,6 +3804,14 @@ ALTER TABLE ONLY public.agriculture_profile_country_contexts
 
 ALTER TABLE ONLY public.datasets
     ADD CONSTRAINT fk_rails_4cf1467767 FOREIGN KEY (section_id) REFERENCES public.sections(id);
+
+
+--
+-- Name: indc_values fk_rails_5b8cda325b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.indc_values
+    ADD CONSTRAINT fk_rails_5b8cda325b FOREIGN KEY (document_id) REFERENCES public.indc_documents(id);
 
 
 --
@@ -4168,6 +4235,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190207144949'),
 ('20190219190427'),
 ('20190405154306'),
-('20190725143552');
+('20190725143552'),
+('20200317204602'),
+('20200317210227'),
+('20200317210928');
 
 

--- a/spec/factories/indc_documents.rb
+++ b/spec/factories/indc_documents.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :indc_document, class: 'Indc::Document' do
+    ordering { "" }
+    slug { "MyString" }
+    long_name { "MyString" }
+    description { "MyText" }
+  end
+end

--- a/spec/models/indc/document_spec.rb
+++ b/spec/models/indc/document_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Indc::Document, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/import_indc_spec.rb
+++ b/spec/services/import_indc_spec.rb
@@ -2,19 +2,21 @@ require 'rails_helper'
 
 object_contents = {
   "#{CW_FILES_PREFIX}indc/NDC_metadata.csv" => <<~END,
-    global_category,main_category,map_category,column_name,long_name,Definition,Source
-    Overview,UNFCCC Process,Other,domestic_approval,Domestic Approval Processes Category,,CAIT
-    Mitigation,Target,,M_TarYr,Target year,The year by which mitigation objectives are expected to be achieved,WB
-    Mitigation,Target,,M_TarYr_2,Second target year,Whether the NDC has a second-year target,WB
-    Adaptation,Adaptation Target,,A_Tg_AdInclu,Adaptation Included in INDC (Yes/No),Whether or not the NDC includes adaptation,WB
-    Adaptation,Adaptation Target,,A_Tg_TarYr,Target Year for Adaptation,The year by which adaptation objectives are expected to be achieved,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConAct,Sectorial Conditional Actions,Condition actions of the sectoral level,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActP,Page Number for Sectorial Conditional Actions,Link to the page reference for the sectoral condition actions,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActImp,Implementing Agency for Sectorial Conditonal Actions,The agency responsible for implementing the sectoral conditional action,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActDon,Funders for Sectorial Conditional Actions,The funders for sectoral conditional actions,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActCost,Estimated Cost for Sectorial Conditional Actions ,The estimated costs for sectoral conditional actions,WB
-    Sectoral Information,,,A_Sc_ConActCostH,Estimated Cost for Sectorial Conditional Actions (Harmonized in Million USD),,WB
-    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_CapBud,Capacity Building Needs for Sectorial Implementation,Capacity building needs for sectorial implementation,WB
+    global_category,main_category,map_category,column_name,long_name,Definition,Source,multiple_version
+    Overview,UNFCCC Process,Other,domestic_approval,Domestic Approval Processes Category,,CAIT,TRUE
+    Mitigation,Target,,M_TarYr,Target year,The year by which mitigation objectives are expected to be achieved,WB,TRUE
+    Mitigation,Target,,M_TarYr_2,Second target year,Whether the NDC has a second-year target,WB,TRUE
+    Adaptation,Adaptation Target,,A_Tg_AdInclu,Adaptation Included in INDC (Yes/No),Whether or not the NDC includes adaptation,WB,TRUE
+    Adaptation,Adaptation Target,,A_Tg_TarYr,Target Year for Adaptation,The year by which adaptation objectives are expected to be achieved,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConAct,Sectorial Conditional Actions,Condition actions of the sectoral level,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActP,Page Number for Sectorial Conditional Actions,Link to the page reference for the sectoral condition actions,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActImp,Implementing Agency for Sectorial Conditonal Actions,The agency responsible for implementing the sectoral conditional action,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActDon,Funders for Sectorial Conditional Actions,The funders for sectoral conditional actions,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_ConActCost,Estimated Cost for Sectorial Conditional Actions ,The estimated costs for sectoral conditional actions,WB,TRUE
+    Sectoral Information,,,A_Sc_ConActCostH,Estimated Cost for Sectorial Conditional Actions (Harmonized in Million USD),,WB,TRUE
+    Sectoral Information,Sectoral Adaptation Commitments,,A_Sc_CapBud,Capacity Building Needs for Sectorial Implementation,Capacity building needs for sectorial implementation,WB,TRUE
+    Overview,UNFCCC Process,UNFCCC Process,submission,Latest submission,,CAIT,FALSE
+    Overview,UNFCCC Process,,submission_date,Latest submission date,,CAIT,FALSE
   END
 
   "#{CW_FILES_PREFIX}indc/NDC_submission.csv" => <<~END,
@@ -22,14 +24,28 @@ object_contents = {
     AFG,Afghanistan,INDC,English,10/13/2015,http://www4.unfccc.int/Submissions/INDC/Published Documents/Afghanistan/1/INDC_AFG_Paper_En_20150927_.docx FINAL.pdf
   END
 
-  "#{CW_FILES_PREFIX}indc/NDC_CAIT_data.csv" => <<~END,
-    country,ISO,domestic_approval,domestic_approval_label
-    Afghanistan,AFG,Executive + majority of two legislative bodies,Executive + majority of two legislative bodies/super-majority of one legislative body
-    Algeria,DZA,Executive,Executive
-    Andorra,AND,Not yet included in analysis
+  "#{CW_FILES_PREFIX}indc/NDC_documents.csv" => <<~END,
+    Order Number,Slug,Long name,Description
+      1,INDC,INDC,INDC Submission
+      2,First NDC,First NDC,First NDC Submission
+      3,Revised First NDC,Revised First NDC,Revised First NDC Submission
+      4,Second NDC,Second NDC,Second NDC Submission
   END
 
-  "#{CW_FILES_PREFIX}indc/NDC_CAIT_legend.csv" => <<~END,
+  "#{CW_FILES_PREFIX}indc/NDC_data.csv" => <<~END,
+    country,ISO,document, domestic_approval,domestic_approval_label
+    Afghanistan,AFG,indc, Executive + majority of two legislative bodies,Executive + majority of two legislative bodies/super-majority of one legislative body
+    Algeria,DZA,indc, Executive,Executive
+    Andorra,AND,indc, Not yet included in analysis
+  END
+
+  "#{CW_FILES_PREFIX}indc/NDC_single_version.csv" => <<~END,
+    Country,ISO,submission,submission_label,submission_date
+    Afghanistan,AFG,First NDC Submitted,First NDC Submitted,11/23/2016
+    Albania,ALB,First NDC Submitted,First NDC Submitted,9/21/2016
+  END
+
+  "#{CW_FILES_PREFIX}indc/NDC_legend.csv" => <<~END,
     indicator_name,legend_item,chart_title
     domestic_approval,Executive,Domestic Approval Process
     domestic_approval,Executive + notify legislature,Domestic Approval Process
@@ -39,20 +55,10 @@ object_contents = {
     domestic_approval,Not yet included in analysis,Domestic Approval Process
   END
 
-  "#{CW_FILES_PREFIX}indc/NDC_WB_data_sectoral.csv" => <<~END,
-    CountryCode,Sector,SubSector,QuestionCode,ResponseText
-    AF,Water,Water Infrastructure,A_Sc_CapBud,Ecological engineering and spatial planning for water resources
-    AF,Water,Water Infrastructure,A_Sc_ConAct,"Development of water resources through rehabilitation and reconstruction of small-, medium-, and large-scale infrastructure"
-  END
-
-  "#{CW_FILES_PREFIX}indc/NDC_WB_data_wide.csv" => <<~END,
-    CountryCode,QuestionCode,ResponseText
-    AF,A_Tg_AdInclu,Yes
-    AF,A_Tg_TarYr,2030
-    AF,M_TarYr,2030
-    DZ,A_Tg_AdInclu,Yes
-    DZ,A_Tg_TarYr,2030
-    DZ,M_TarYr,2030
+  "#{CW_FILES_PREFIX}indc/NDC_WB_data_sectoral_all.csv" => <<~END,
+    CountryCode,Document, Sector,SubSector,QuestionCode,ResponseText
+    AF,indc,Water,Water Infrastructure,A_Sc_CapBud,Ecological engineering and spatial planning for water resources
+    AF,indc,Water,Water Infrastructure,A_Sc_ConAct,"Development of water resources through rehabilitation and reconstruction of small-, medium-, and large-scale infrastructure"
   END
 
 }
@@ -99,11 +105,11 @@ describe ImportIndc do
   end
 
   it 'Creates new INDC category records' do
-    expect { subject }.to change { Indc::Category.count }.by(9)
+    expect { subject }.to change { Indc::Category.count }.by(10)
   end
 
   it 'Creates new INDC indicator records' do
-    expect { subject }.to change { Indc::Indicator.count }.by(12)
+    expect { subject }.to change { Indc::Indicator.count }.by(13)
   end
 
   it 'Creates new INDC sector records' do
@@ -111,7 +117,7 @@ describe ImportIndc do
   end
 
   it 'Creates new INDC value records' do
-    expect { subject }.to change { Indc::Value.count }.by(11)
+    expect { subject }.to change { Indc::Value.count }.by(6)
   end
 
   it 'Creates new INDC submission records' do


### PR DESCRIPTION
This PR updates the INDC importers and endpoints to allow us to store indicators per document: INDC, first NDC, second NDC, etctera NDC.

To test this PR you will need to run the following tasks:

```
bundle exec rails db:migrate
bundle exec rails db:admin_boilerplate:create 
bundle exec rails indc:import
```
That last command will import the updated data from the staging bucket and as normally it will take a bit.

In this PR the main changes are:

- Adding a new Indc::Document table to collect information on the different documents submitted by the countries;
- Updating the import scripts to link different country-indicator-value combinations to documents, so that we can query specific submission values;
- Adding a new importer for indicators that are not document specific to be used in the Overview page for instance, but in other places as well;
- Adding a new filtering param for the `/api/v1/ndcs` and `/api/v1/ndcs/:iso/content_overview` endpoints. The new param is called `document` and the values to be used are the slugs of the submitted documents. For now these are available in: `api/v1/data/ndc_content/documents`.

These changes will allow us to update the NDC Explore Country page with the Documents dropdown and then filtering per document the indicators shown. And also the Compare All Flow.

The missing endpoint that I would like to discuss with you @Bluesmile82 is how to pass to the front end the information about the documents available to each country, should we add a filter to that documents endpoint, or provide you a full list of Country: [Documents] information? Let me know!