### PR TITLE
Get document options from document endpoint

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-actions.js
@@ -1,0 +1,36 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import isEmpty from 'lodash/isEmpty';
+
+const fetchNDCSDocumentsInit = createAction('fetchNDCSDocumentsInit');
+const fetchNDCSDocumentsReady = createAction('fetchNDCSDocumentsReady');
+const fetchNDCSDocumentsFail = createAction('fetchNDCSDocumentsFail');
+
+const fetchNDCSDocuments = createThunkAction(
+  'fetchNDCSDocuments',
+  () => (dispatch, state) => {
+    const { documents } = state();
+    if (documents && isEmpty(documents.data) && !documents.loading) {
+      dispatch(fetchNDCSDocumentsInit());
+      fetch('api/v1/data/ndc_content/documents')
+        .then(response => {
+          if (response.ok) return response.json();
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          dispatch(fetchNDCSDocumentsReady(data.data));
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchNDCSDocumentsFail());
+        });
+    }
+  }
+);
+
+export default {
+  fetchNDCSDocuments,
+  fetchNDCSDocumentsInit,
+  fetchNDCSDocumentsReady,
+  fetchNDCSDocumentsFail
+};

--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-component.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import cx from 'classnames';
-import { NDC_DOCUMENT_OPTIONS } from 'data/constants';
 
 import NdcsSdgsMetaProvider from 'providers/ndcs-sdgs-meta-provider';
 import NdcsSdgsDataProvider from 'providers/ndcs-sdgs-data-provider';
@@ -21,6 +20,7 @@ class NdcsAutocompleteSearch extends PureComponent {
       groups,
       document,
       optionSelected,
+      documentOptions,
       documentSelected,
       label,
       global,
@@ -43,7 +43,7 @@ class NdcsAutocompleteSearch extends PureComponent {
           )}
           {documentSelector && (
             <Dropdown
-              options={NDC_DOCUMENT_OPTIONS}
+              options={documentOptions}
               onValueChange={onDocumentChange}
               value={documentSelected}
               hideResetButton
@@ -79,6 +79,7 @@ NdcsAutocompleteSearch.propTypes = {
   onSearchChange: Proptypes.func.isRequired,
   onDocumentChange: Proptypes.func.isRequired,
   documentSelected: Proptypes.object,
+  documentOptions: Proptypes.array,
   searchList: Proptypes.array,
   groups: Proptypes.array,
   document: Proptypes.string,

--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-reducers.js
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-reducers.js
@@ -1,0 +1,29 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  error: false,
+  data: null
+};
+
+const setLoading = (state, loading) => ({ ...state, loading });
+const setError = (state, error) => ({ ...state, error });
+const setLoaded = (state, loaded) => ({ ...state, loaded });
+
+export default {
+  fetchNDCSDocumentsInit: state => setLoading(state, true),
+  fetchNDCSDocumentsReady: (state, { payload }) =>
+    setLoaded(
+      setLoading(
+        {
+          ...state,
+          data: {
+            ...state.data,
+            ...payload
+          }
+        },
+        false
+      ),
+      true
+    ),
+  fetchNDCSDocumentsFail: state => setError(state, true)
+};

--- a/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-autocomplete-search/ndcs-autocomplete-search-selectors.js
@@ -1,12 +1,35 @@
 import { createSelector } from 'reselect';
 import { compareIndexByKey } from 'utils/utils';
-import { NDC_DOCUMENT_OPTIONS } from 'data/constants';
 
+const getSearch = (state, search) => search || null;
 const getSDGs = state => state.sdgs || null;
 const getTargets = state => state.data.targets || null;
 const getGoals = state => state.data.goals || null;
-const getSearch = state => state.search || null;
-const getDocSelected = state => state.search.document || null;
+const getDocuments = state => state.documents && state.documents.data;
+
+export const getDocumentOptions = createSelector([getDocuments], documents => {
+  const allDocumentOption = [
+    {
+      label: 'All documents',
+      value: 'all'
+    }
+  ];
+  if (!documents) return allDocumentOption;
+  const documentsOptions = Object.values(documents).map(d => ({
+    label: d.long_name,
+    value: d.slug
+  }));
+  return [...allDocumentOption, ...documentsOptions];
+});
+
+export const getDocumentSelected = createSelector(
+  [getDocumentOptions, getSearch],
+  (documentOptions, search) => {
+    const { document: documentSelected } = search || {};
+    if (!documentSelected) return documentOptions[0];
+    return documentOptions.find(d => d.value === documentSelected);
+  }
+);
 
 export const getGoalsMapped = createSelector([getSDGs], sdgs => {
   if (!sdgs) return null;
@@ -77,14 +100,6 @@ export const getOptionSelectedMeta = createSelector(
     if (!options || !search) return null;
     if (search.searchBy === 'query') return null;
     return options.find(option => option.value === search.query);
-  }
-);
-
-export const getDocumentSelected = createSelector(
-  [getDocSelected],
-  documentSelected => {
-    if (!documentSelected) return NDC_DOCUMENT_OPTIONS[0];
-    return NDC_DOCUMENT_OPTIONS.find(d => d.value === documentSelected);
   }
 );
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -201,25 +201,6 @@ export const CLIMATE_VULNERABILITY_DEFINITIONS = {
 
 export const DISCLAIMER_SHOWN = 'disclaimerShown';
 
-export const NDC_DOCUMENT_OPTIONS = [
-  {
-    label: 'All documents',
-    value: 'all'
-  },
-  {
-    label: 'NDC',
-    value: 'ndc'
-  },
-  {
-    label: 'INDC',
-    value: 'indc'
-  },
-  {
-    label: 'Second NDC',
-    value: 'ndc2'
-  }
-];
-
 export const CONTAINED_PATHNAME = 'contained';
 
 export const LENSES_SELECTOR_INFO = {

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -99,6 +99,7 @@ const pagesReducers = {
 // Components
 import * as mapComponent from 'components/map';
 import * as autocompleteSearchComponent from 'components/autocomplete-search';
+import * as ndcsAutocompleteSearchComponent from 'components/ndcs/ndcs-autocomplete-search';
 import * as countrySelectComponent from 'components/countries-select';
 import * as modalDownloadComponent from 'components/modal-download';
 import * as modalMetadataComponent from 'components/modal-metadata';
@@ -119,6 +120,7 @@ import * as AnchorNavComponent from 'components/anchor-nav';
 const componentsReducers = {
   map: handleActions(mapComponent),
   autocompleteSearch: handleActions(autocompleteSearchComponent),
+  documents: handleActions(ndcsAutocompleteSearchComponent),
   countrySelect: handleActions(countrySelectComponent),
   modalDownload: handleActions(modalDownloadComponent),
   modalMetadata: handleActions(modalMetadataComponent),


### PR DESCRIPTION
This PR adds the document options from the new endpoint to the NDC search page instead of hardcoding them. 

Try: Go to NDC search and check the documents dropdown filter.

Note: The document names on the documents are different than the slugs on the document endpoint so we won't be able to filter by first-ndc, ... Only indc filter should work. This should be fixed on the data