### PR TITLE
Feature/lts explore feedback

### DIFF
--- a/app/javascript/app/components/dropdown/dropdown-component.jsx
+++ b/app/javascript/app/components/dropdown/dropdown-component.jsx
@@ -1,10 +1,12 @@
 import React, { PureComponent } from 'react';
 import { SimpleSelect } from 'react-selectize'; // eslint-disable-line
 import PropTypes from 'prop-types';
+import ReactTooltip from 'react-tooltip';
 import Icon from 'components/icon';
 import { themr } from 'react-css-themr';
 import cx from 'classnames';
 import Loading from 'components/loading';
+import get from 'lodash/get';
 
 import dropdownArrow from 'assets/icons/dropdown-arrow.svg';
 import infoIcon from 'assets/icons/info.svg';
@@ -17,6 +19,7 @@ class Dropdown extends PureComponent {
   componentDidUpdate() {
     this.selectorElement.highlightFirstSelectableOption();
   }
+
   render() {
     const {
       white,
@@ -34,11 +37,26 @@ class Dropdown extends PureComponent {
       required,
       optional,
       disclaimer,
-      hasSearch
+      hasSearch,
+      value,
+      showTooltip
     } = this.props;
     const arrow = this.props.white ? dropdownArrowWhite : dropdownArrow;
     const hasNotValue = this.props.value && !this.props.value.value;
     const isRequired = hasNotValue && required;
+
+    const tooltipId = `multiselectOptionsTooltip${label}`;
+
+    const setTooltip = (element, selectedOption, id) => {
+      const controlElement = get(element, 'refs.select.refs.control');
+
+      if (controlElement && selectedOption) {
+        controlElement.setAttribute('data-tip', selectedOption.label);
+        controlElement.setAttribute('data-for', id);
+        ReactTooltip.rebuild();
+      }
+    };
+
     return (
       <div
         className={cx(
@@ -82,6 +100,9 @@ class Dropdown extends PureComponent {
             <SimpleSelect
               ref={el => {
                 this.selectorElement = el;
+                if (showTooltip) {
+                  setTooltip(el, value, tooltipId);
+                }
               }}
               className={cx(className, disabled, {
                 [styles.withDot]: colorDot
@@ -100,9 +121,11 @@ class Dropdown extends PureComponent {
               )}
               {...this.props}
             />
+
             {disclaimer && <p className={styles.disclaimer}>{disclaimer}</p>}
           </div>
         </div>
+        {showTooltip && <ReactTooltip id={tooltipId} effect="solid" />}
       </div>
     );
   }
@@ -129,7 +152,8 @@ Dropdown.propTypes = {
   required: PropTypes.bool,
   optional: PropTypes.bool,
   value: PropTypes.object,
-  disclaimer: PropTypes.string
+  disclaimer: PropTypes.string,
+  showTooltip: PropTypes.bool
 };
 
 export default themr('Dropdown', styles)(Dropdown);

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -150,7 +150,9 @@ function LTSExploreMap(props) {
                         value={selectedCategory}
                         hideResetButton
                         plain
-                        showTooltip
+                        showTooltip={
+                          selectedCategory && selectedCategory.label.length > 14
+                        }
                       />
                       <Dropdown
                         label="Indicator"
@@ -159,7 +161,10 @@ function LTSExploreMap(props) {
                         value={selectedIndicator}
                         hideResetButton
                         plain
-                        showTooltip
+                        showTooltip={
+                          selectedIndicator &&
+                          selectedIndicator.label.length > 14
+                        }
                       />
                     </div>
                     {isTablet &&

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -150,6 +150,7 @@ function LTSExploreMap(props) {
                         value={selectedCategory}
                         hideResetButton
                         plain
+                        showTooltip
                       />
                       <Dropdown
                         label="Indicator"
@@ -158,6 +159,7 @@ function LTSExploreMap(props) {
                         value={selectedIndicator}
                         hideResetButton
                         plain
+                        showTooltip
                       />
                     </div>
                     {isTablet &&
@@ -179,10 +181,7 @@ function LTSExploreMap(props) {
                         <React.Fragment>
                           {summaryCardData && renderSummary(summaryCardData)}
                           {emissionsCardData &&
-                            renderDonutChart(
-                              emissionsCardData,
-                              isEUUSubmitted
-                            )}
+                            renderDonutChart(emissionsCardData, isEUUSubmitted)}
                           {legendData &&
                             renderLegend(legendData, isEUUSubmitted)}
                         </React.Fragment>

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -47,7 +47,8 @@ export const getIsEUUSubmitted = createSelector(
 
 export const getMaximumCountries = createSelector(
   [getCountries, getIsEUUSubmitted],
-  (countries, isEUUsubmitted) => (isEUUsubmitted ? countries.length + 1 : countries.length)
+  (countries, isEUUsubmitted) =>
+    (isEUUsubmitted ? countries.length + 1 : countries.length)
 );
 
 export const getISOCountries = createSelector([getCountries], countries =>
@@ -238,16 +239,12 @@ export const getTooltipCountryValues = createSelector(
       updatedSelectedIndicator = indicators.find(i => i.slug === 'lts_target');
     }
 
-    const emissionsIndicator = indicators.find(i => i.slug === 'lts_ghg');
     const tooltipCountryValues = {};
     Object.keys(updatedSelectedIndicator.locations).forEach(iso => {
       tooltipCountryValues[iso] = {
         value:
           updatedSelectedIndicator.locations[iso] &&
-          updatedSelectedIndicator.locations[iso].value,
-        emissionsValue:
-          emissionsIndicator.locations[iso] &&
-          emissionsIndicator.locations[iso].value
+          updatedSelectedIndicator.locations[iso].value
       };
     });
     return tooltipCountryValues;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
@@ -7,6 +7,7 @@
 
 .map {
   height: 100%;
+  cursor: pointer;
 
   > svg {
     height: 100%;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -103,10 +103,6 @@ class LTSExploreMapContainer extends PureComponent {
         tooltipCountryValues && tooltipCountryValues[iso]
           ? tooltipCountryValues[iso].value
           : 'No Document Submitted',
-      emissionsValue:
-        tooltipCountryValues &&
-        tooltipCountryValues[iso] &&
-        tooltipCountryValues[iso].emissionsValue,
       countryName: geography.properties && geography.properties.name
     };
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -149,6 +149,7 @@ function NDCSExploreMap(props) {
                         value={selectedCategory}
                         hideResetButton
                         plain
+                        showTooltip
                       />
                       <Dropdown
                         label="Indicator"
@@ -157,6 +158,7 @@ function NDCSExploreMap(props) {
                         value={selectedIndicator}
                         hideResetButton
                         plain
+                        showTooltip
                       />
                     </div>
                     {isTablet &&

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -149,7 +149,9 @@ function NDCSExploreMap(props) {
                         value={selectedCategory}
                         hideResetButton
                         plain
-                        showTooltip
+                        showTooltip={
+                          selectedCategory && selectedCategory.label.length > 14
+                        }
                       />
                       <Dropdown
                         label="Indicator"
@@ -158,7 +160,10 @@ function NDCSExploreMap(props) {
                         value={selectedIndicator}
                         hideResetButton
                         plain
-                        showTooltip
+                        showTooltip={
+                          selectedIndicator &&
+                          selectedIndicator.label.length > 14
+                        }
                       />
                     </div>
                     {isTablet &&

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -213,17 +213,12 @@ export const getTooltipCountryValues = createSelector(
     if (!indicators || !selectedIndicator) {
       return null;
     }
-    const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
     const tooltipCountryValues = {};
     Object.keys(selectedIndicator.locations).forEach(iso => {
       tooltipCountryValues[iso] = {
         value:
           selectedIndicator.locations[iso] &&
-          selectedIndicator.locations[iso].value,
-        emissionsValue:
-          emissionsIndicator &&
-          emissionsIndicator.locations[iso] &&
-          emissionsIndicator.locations[iso].value
+          selectedIndicator.locations[iso].value
       };
     });
     return tooltipCountryValues;

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
@@ -7,6 +7,7 @@
 
 .map {
   height: 100%;
+  cursor: pointer;
 
   > svg {
     height: 100%;

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -111,10 +111,6 @@ class NDCSExploreMapContainer extends PureComponent {
         tooltipCountryValues && tooltipCountryValues[iso]
           ? tooltipCountryValues[iso].value
           : 'Not Applicable',
-      emissionsValue:
-        tooltipCountryValues &&
-        tooltipCountryValues[iso] &&
-        tooltipCountryValues[iso].emissionsValue,
       countryName: geography.properties && geography.properties.name
     };
 

--- a/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip-styles.scss
+++ b/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip-styles.scss
@@ -13,5 +13,4 @@
 
 .tooltipValue {
   font-size: $font-size-sm;
-  margin-bottom: 10px;
 }

--- a/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/explore-map-tooltip/explore-map-tooltip.jsx
@@ -26,11 +26,6 @@ const ExploreMapTooltip = props => {
             {tooltipValues.countryName}
           </div>
           <div className={styles.tooltipValue}>{tooltipValues.value}</div>
-          {tooltipValues.emissionsValue && (
-            <div className={styles.tooltipValue}>
-              {tooltipValues.emissionsValue} of global emissions
-            </div>
-          )}
         </div>
       </Button>
     </ReactTooltip>


### PR DESCRIPTION
This PR solves three issues from the client's feedback:

- Remove emissions value from map tooltip:
[PIVOTAL](https://www.pivotaltracker.com/story/show/171926847)
![image](https://user-images.githubusercontent.com/15097138/77786893-8e974c80-7056-11ea-9546-ae8f018b6803.png)

- Add tooltips to the dropdown filters:
[PIVOTAL](https://www.pivotaltracker.com/story/show/171926835)
![Screenshot from 2020-03-27 18 09 43](https://user-images.githubusercontent.com/15097138/77786978-af5fa200-7056-11ea-81c9-0190a67d2228.png)

- Changes the type of the cursor displayed on the map, from `grab` to `pointer`
[PIVOTAL](https://www.pivotaltracker.com/story/show/171926787)
![za811-7kqmq-001](https://user-images.githubusercontent.com/15097138/77787425-6eb45880-7057-11ea-8817-7117fb037e0d.jpg)

Each of these changes has been applied to both Explore pages, LTS and NDCs.