### PR TITLE
Feature/ndc country document dropdown

### DIFF
--- a/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
+++ b/app/javascript/app/components/anchor-nav/anchor-nav-component.jsx
@@ -22,56 +22,57 @@ const AnchorNav = props => {
     <div>
       <div className={cx(styles.anchorContainer)}>
         <nav className={cx(className, theme.anchorNav)}>
-          {links.map((link, index) => {
-            const linkProps = {
-              key: link.label,
-              className: theme.link,
-              activeClassName: theme.linkActive,
-              to: {
-                search: link.search || query,
-                pathname: link.path,
-                hash: link.hash
-              }
-            };
-            if (link.activeQuery) {
-              linkProps.isActive = (match, location) => {
-                const activeSearchQuery = qs.parse(location.search)[
-                  link.activeQuery.key
-                ];
-                const linkSearchQuery = link.activeQuery.value;
-                return (
-                  activeSearchQuery === linkSearchQuery ||
-                  (index === 0 && !activeSearchQuery)
-                );
+          {links &&
+            links.map((link, index) => {
+              const linkProps = {
+                key: link.label,
+                className: theme.link,
+                activeClassName: theme.linkActive,
+                to: {
+                  search: link.search || query,
+                  pathname: link.path,
+                  hash: link.hash
+                }
               };
-            }
-            if (useRoutes) {
-              linkProps.exact = true;
+              if (link.activeQuery) {
+                linkProps.isActive = (match, location) => {
+                  const activeSearchQuery = qs.parse(location.search)[
+                    link.activeQuery.key
+                  ];
+                  const linkSearchQuery = link.activeQuery.value;
+                  return (
+                    activeSearchQuery === linkSearchQuery ||
+                    (index === 0 && !activeSearchQuery)
+                  );
+                };
+              }
+              if (useRoutes) {
+                linkProps.exact = true;
+                return (
+                  <NavLink {...linkProps} replace>
+                    {link.label}
+                  </NavLink>
+                );
+              }
+              linkProps.isActive = (match, location) =>
+                link.hash === activeSection ||
+                (link.defaultActiveHash &&
+                  (`#${link.hash}` === location.hash ||
+                    (!location.hash && index === 0)));
               return (
-                <NavLink {...linkProps} replace>
+                <NavHashLink
+                  {...linkProps}
+                  smooth
+                  scroll={el => {
+                    el.scrollIntoView(true);
+                    if (offset) window.scrollBy(0, offset[index]);
+                  }}
+                  replace
+                >
                   {link.label}
-                </NavLink>
+                </NavHashLink>
               );
-            }
-            linkProps.isActive = (match, location) =>
-              link.hash === activeSection ||
-              (link.defaultActiveHash &&
-                (`#${link.hash}` === location.hash ||
-                  (!location.hash && index === 0)));
-            return (
-              <NavHashLink
-                {...linkProps}
-                smooth
-                scroll={el => {
-                  el.scrollIntoView(true);
-                  if (offset) window.scrollBy(0, offset[index]);
-                }}
-                replace
-              >
-                {link.label}
-              </NavHashLink>
-            );
-          })}
+            })}
         </nav>
       </div>
     </div>

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -312,7 +312,10 @@ class CountryNdcOverview extends PureComponent {
           hasSectors &&
           !loading &&
           this.renderAlertText()}
-        <NdcContentOverviewProvider locations={[iso]} />
+        <NdcContentOverviewProvider
+          locations={[iso]}
+          document={selectedDocument && selectedDocument.document_type}
+        />
         {!hasSectors && !loading ? (
           <NoContent
             message="No overview content data"

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -267,18 +267,16 @@ class CountryNdcOverview extends PureComponent {
     );
   }
 
-  // We can only show the alert when we have the filtered by NDC content
-  renderAlertText = () =>
-    null && (
-      <div className={styles.alertContainer}>
-        <div className={styles.alert}>
-          <Icon icon={alertIcon} className={styles.alertIcon} />
-          <span className={styles.alertText}>
-            The information shown below only reflects the latest NDC submission.
-          </span>
-        </div>
+  renderAlertText = () => (
+    <div className={styles.alertContainer}>
+      <div className={styles.alert}>
+        <Icon icon={alertIcon} className={styles.alertIcon} />
+        <span className={styles.alertText}>
+          The information shown below only reflects the selected NDC submission.
+        </span>
       </div>
-    );
+    </div>
+  );
 
   render() {
     const {
@@ -288,9 +286,9 @@ class CountryNdcOverview extends PureComponent {
       actions,
       iso,
       isEmbed,
-      lastDocument
+      selectedDocument
     } = this.props;
-    const { date: documentDate } = lastDocument || {};
+    const { date: documentDate } = selectedDocument || {};
     const hasSectors = values && sectors;
     const description = hasSectors && (
       <p
@@ -304,10 +302,10 @@ class CountryNdcOverview extends PureComponent {
         }}
       />
     );
-    const summaryIntroText = !lastDocument
+    const summaryIntroText = !selectedDocument
       ? 'Summary'
-      : `Summary of ${lastDocument.document_type &&
-          lastDocument.document_type.toUpperCase()}`;
+      : `Summary of ${selectedDocument.document_type &&
+          selectedDocument.document_type.toUpperCase()}`;
     return (
       <div className={cx(styles.wrapper, { [styles.embededWrapper]: isEmbed })}>
         {FEATURE_LTS_EXPLORE &&
@@ -376,7 +374,7 @@ CountryNdcOverview.propTypes = {
   isNdcp: PropTypes.bool,
   isEmbed: PropTypes.bool,
   handleInfoClick: PropTypes.func.isRequired,
-  lastDocument: PropTypes.object,
+  selectedDocument: PropTypes.object,
   handleAnalyticsClick: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -47,7 +47,7 @@ export const getCountryDocuments = createSelector(
 );
 
 const documentValue = document =>
-  `${document.document_type}(${document.language})`;
+  `${document.document_type}-${document.language}`;
 
 export const getSelectedDocument = createSelector(
   [getCountryDocuments, getSearch],

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -1,25 +1,63 @@
 import { createSelector } from 'reselect';
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
+import qs from 'query-string';
 
-const getValues = state => (state && state.values) || null;
-const getIso = state => (state && state.iso) || null;
+const getIso = (state, { iso }) => iso || null;
 const getDocuments = state => (state && state.documents) || null;
+const getOverviewData = state =>
+  state.ndcContentOverview.data && state.ndcContentOverview.data.locations;
+const getCountryOverviewData = createSelector(
+  [getOverviewData, getIso],
+  (data, iso) => (data && data[iso] && data[iso]) || null
+);
 
-export const getValuesGrouped = createSelector(getValues, values => {
-  if (!values || !values.length) return null;
-  const groupedValues = groupBy(values, 'slug');
-  Object.keys(groupedValues).forEach(key => {
-    if (!groupedValues[key].length) groupedValues[key] = null;
-  });
-  return groupedValues;
-});
+const getSearch = (state, { location }) => {
+  const { search } = location;
+  if (!search) return null;
+  const parsedSearch = qs.parse(search);
+  return parsedSearch || null;
+};
 
-export const getLastDocument = createSelector(
+export const getSectors = createSelector(
+  [getCountryOverviewData],
+  data => (data && data.sectors) || null
+);
+
+export const getValuesGrouped = createSelector(
+  getCountryOverviewData,
+  overviewData => {
+    const { values } = overviewData || {};
+    if (!values || !values.length) return null;
+    const groupedValues = groupBy(values, 'slug');
+    Object.keys(groupedValues).forEach(key => {
+      if (!groupedValues[key].length) groupedValues[key] = null;
+    });
+    return groupedValues;
+  }
+);
+
+export const getCountryDocuments = createSelector(
   [getDocuments, getIso],
   (documents, iso) => {
     if (isEmpty(documents) || !iso || !documents[iso]) return null;
-    return documents[iso][documents[iso].length - 1];
+    return documents[iso];
+  }
+);
+
+const documentValue = document =>
+  `${document.document_type}(${document.language})`;
+
+export const getSelectedDocument = createSelector(
+  [getCountryDocuments, getSearch],
+  (documents, search) => {
+    if (isEmpty(documents)) return null;
+    const lastDocument = documents[documents.length - 1];
+    if (!search.document) return lastDocument;
+    return (
+      documents.find(document => documentValue(document) === search.document) ||
+      lastDocument
+    );
   }
 );
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -4,7 +4,8 @@ import isEmpty from 'lodash/isEmpty';
 import qs from 'query-string';
 
 const getIso = (state, { iso }) => iso || null;
-const getDocuments = state => (state && state.documents) || null;
+const getDataDocuments = state =>
+  (state && state.ndcsDocumentsMeta.data) || null;
 const getOverviewData = state =>
   state.ndcContentOverview.data && state.ndcContentOverview.data.locations;
 const getCountryOverviewData = createSelector(
@@ -38,7 +39,7 @@ export const getValuesGrouped = createSelector(
 );
 
 export const getCountryDocuments = createSelector(
-  [getDocuments, getIso],
+  [getDataDocuments, getIso],
   (documents, iso) => {
     if (isEmpty(documents) || !iso || !documents[iso]) return null;
     return documents[iso];
@@ -50,13 +51,14 @@ const documentValue = document =>
 
 export const getSelectedDocument = createSelector(
   [getCountryDocuments, getSearch],
-  (documents, search) => {
-    if (isEmpty(documents)) return null;
-    const lastDocument = documents[documents.length - 1];
-    if (!search.document) return lastDocument;
+  (countryDocuments, search) => {
+    if (isEmpty(countryDocuments)) return null;
+    const lastDocument = countryDocuments[countryDocuments.length - 1];
+    if (!search || !search.document) return lastDocument;
     return (
-      documents.find(document => documentValue(document) === search.document) ||
-      lastDocument
+      countryDocuments.find(
+        document => documentValue(document) === search.document
+      ) || lastDocument
     );
   }
 );

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -10,7 +10,7 @@ const getOverviewData = state =>
   state.ndcContentOverview.data && state.ndcContentOverview.data.locations;
 const getCountryOverviewData = createSelector(
   [getOverviewData, getIso],
-  (data, iso) => (data && data[iso] && data[iso]) || null
+  (data, iso) => (data && data[iso]) || null
 );
 
 const getSearch = (state, { location }) => {

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
@@ -12,17 +12,17 @@ import { actions as fetchActions } from 'components/ndcs/ndcs-country-accordion'
 import CountryNdcOverviewComponent from './country-ndc-overview-component';
 import {
   getValuesGrouped,
-  getLastDocument
+  getSelectedDocument,
+  getSectors,
+  getCountryDocuments
 } from './country-ndc-overview-selectors';
 
 const mapStateToProps = (state, { location, match }) => {
   const { iso } = match.params;
-  const overviewData =
-    state.ndcContentOverview.data && state.ndcContentOverview.data.locations;
-  const countryData = overviewData ? overviewData[iso] : null;
   const isNdcp = isPageNdcp(location);
   const isEmbed = isEmbededComponent(location);
   const documentsData = {
+    ...state,
     iso,
     documents: state.ndcsDocumentsMeta.data
   };
@@ -30,11 +30,11 @@ const mapStateToProps = (state, { location, match }) => {
     iso,
     isNdcp,
     isEmbed,
-    lastDocument: getLastDocument(documentsData),
-    values: getValuesGrouped(countryData),
+    selectedDocument: getSelectedDocument(documentsData, { location, iso }),
+    values: getValuesGrouped(state, { location, iso }),
     loading: state.ndcContentOverview.loading,
-    sectors: countryData ? countryData.sectors : null,
-    fetched: !isEmpty(countryData)
+    sectors: getSectors(state, { location, iso }),
+    fetched: !isEmpty(getCountryDocuments(state, { location, iso }))
   };
 };
 

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
@@ -21,16 +21,12 @@ const mapStateToProps = (state, { location, match }) => {
   const { iso } = match.params;
   const isNdcp = isPageNdcp(location);
   const isEmbed = isEmbededComponent(location);
-  const documentsData = {
-    ...state,
-    iso,
-    documents: state.ndcsDocumentsMeta.data
-  };
+
   return {
     iso,
     isNdcp,
     isEmbed,
-    selectedDocument: getSelectedDocument(documentsData, { location, iso }),
+    selectedDocument: getSelectedDocument(state, { location, iso }),
     values: getValuesGrouped(state, { location, iso }),
     loading: state.ndcContentOverview.loading,
     sectors: getSectors(state, { location, iso }),

--- a/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-component.jsx
+++ b/app/javascript/app/components/nav/nav-nested-menu/nav-nested-menu-component.jsx
@@ -84,7 +84,7 @@ NavNestedMenuComponent.propTypes = {
   theme: PropTypes.object
 };
 
-NavNestedMenuComponent.propTypes = {
+NavNestedMenuComponent.defaultProps = {
   theme: {}
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -14,7 +14,10 @@ const fetchNdcsCountryAccordionFailed = createAction(
 const fetchNdcsCountryAccordion = createThunkAction(
   'fetchNdcsCountryAccordion',
   params => dispatch => {
-    const { locations, category, compare, lts } = params;
+    const { locations, category, compare, lts, document } = params;
+    // Remove ndc filter when the data is ready
+    const documentParam =
+      document && document !== 'ndc' ? `?document=${document}` : '';
     if (locations) {
       dispatch(fetchNdcsCountryAccordionInit());
       fetch(
@@ -22,7 +25,7 @@ const fetchNdcsCountryAccordion = createThunkAction(
           lts
             ? '&source=LTS'
             : '&source[]=CAIT&source[]=WB&source[]=NDC Explore'
-        }${!compare ? '&filter=overview' : ''}`
+        }${documentParam}${!compare ? '&filter=overview' : ''}`
       )
         .then(response => {
           if (response.ok) return response.json();

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-component.jsx
@@ -4,6 +4,7 @@ import Accordion from 'components/accordion';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
 import DefinitionList from 'components/definition-list';
+import NdcsDocumentsProvider from 'providers/documents-provider';
 
 import layout from 'styles/layout.scss';
 import styles from './ndcs-country-accordion-styles.scss';
@@ -30,6 +31,7 @@ class NdcsCountryAccordion extends PureComponent {
     const showData = !loading && ndcsData && ndcsData.length > 0;
     return (
       <div className={styles.wrapper}>
+        <NdcsDocumentsProvider />
         {loading && <Loading light className={styles.loader} />}
         {showNoContent && (
           <NoContent message={message} className={styles.noContent} />
@@ -45,30 +47,29 @@ class NdcsCountryAccordion extends PureComponent {
               >
                 {ndcsData &&
                   ndcsData.length > 0 &&
-                  ndcsData.map(
-                    section =>
-                      (section.sectors && section.sectors.length > 0 ? (
-                        <Accordion
-                          key={section.slug}
-                          isChild
-                          className={styles.subAccordion}
-                          param="sector"
-                          data={section.sectors}
-                        >
-                          {section.sectors.map(desc => (
-                            <div
-                              key={desc.title}
-                              className={styles.definitionList}
-                            >
-                              <DefinitionList
-                                className={layout.content}
-                                definitions={desc.definitions}
-                                compare={compare}
-                              />
-                            </div>
-                          ))}
-                        </Accordion>
-                      ) : null)
+                  ndcsData.map(section =>
+                    (section.sectors && section.sectors.length > 0 ? (
+                      <Accordion
+                        key={section.slug}
+                        isChild
+                        className={styles.subAccordion}
+                        param="sector"
+                        data={section.sectors}
+                      >
+                        {section.sectors.map(desc => (
+                          <div
+                            key={desc.title}
+                            className={styles.definitionList}
+                          >
+                            <DefinitionList
+                              className={layout.content}
+                              definitions={desc.definitions}
+                              compare={compare}
+                            />
+                          </div>
+                        ))}
+                      </Accordion>
+                    ) : null)
                   )}
               </Accordion>
             ) : (

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -9,7 +9,24 @@ const getCountries = state => state.countries;
 const getAllIndicators = state => (state.data ? state.data.indicators : {});
 const getCategories = state => (state.data ? state.data.categories : {});
 const getSectors = state => (state.data ? state.data.sectors : {});
-const getSearch = state => deburrUpper(state.search);
+const getSearch = (state, { search }) =>
+  (search ? deburrUpper(search.search) : null);
+const getSearchDocument = (state, { search }) =>
+  (search && search.document) || null;
+const getDocuments = state => state.documents && state.documents.data;
+
+export const getDocumentSlug = createSelector(
+  [getDocuments, getSearchDocument],
+  (documents, searchDocument) => {
+    if (!searchDocument || !documents) {
+      return null;
+    }
+    const selectedDocument = documents.find(
+      d => d.slug === searchDocument.split('-')[0]
+    );
+    return (selectedDocument && selectedDocument.slug) || null;
+  }
+);
 
 export const parseIndicatorsDefs = createSelector(
   [getAllIndicators, getCategories, getCountries],

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { renderRoutes } from 'react-router-config';
 import Header from 'components/header';
@@ -22,44 +22,47 @@ import styles from './ndc-country-styles.scss';
 
 const FEATURE_LTS_EXPLORE = process.env.FEATURE_LTS_EXPLORE === 'true';
 
-class NDCCountry extends PureComponent {
-  renderFullTextButton() {
-    const {
-      documentsOptions,
-      documentSelected,
-      handleDropDownChange
-    } = this.props;
-    return (
-      documentsOptions && (
-        <Dropdown
-          className={cx(styles.countryDropdown)}
-          options={documentsOptions}
-          value={documentSelected}
-          onValueChange={handleDropDownChange}
-          white
-          hideResetButton
-        />
-      )
-    );
-  }
+function NDCCountry(props) {
+  const {
+    country,
+    onSearchChange,
+    search,
+    route,
+    anchorLinks,
+    notSummary,
+    location,
+    countriesOptions,
+    handleCountryLink,
+    documentsOptions,
+    documentSelected,
+    handleDropDownChange,
+    match
+  } = props;
 
-  renderFullTextDropdown() {
-    const { match, documentsOptions } = this.props;
-    return (
-      documentsOptions && (
-        <Button
-          variant="secondary"
-          link={`/ndcs/country/${match.params.iso}/full`}
-          className={styles.viewDocumentButton}
-        >
-          View Full Text
-        </Button>
-      )
+  const renderDocumentsDropdown = () =>
+    documentsOptions && (
+      <Dropdown
+        className={cx(styles.countryDropdown)}
+        options={documentsOptions}
+        value={documentSelected}
+        onValueChange={handleDropDownChange}
+        white
+        hideResetButton
+      />
     );
-  }
 
-  renderCompareButton() {
-    const { match } = this.props;
+  const renderFullTextButton = () =>
+    documentsOptions && (
+      <Button
+        variant="secondary"
+        link={`/ndcs/country/${match.params.iso}/full`}
+        className={styles.viewDocumentButton}
+      >
+        View Full Text
+      </Button>
+    );
+
+  const renderCompareButton = () => {
     if (!FEATURE_LTS_EXPLORE) {
       return (
         <Button
@@ -81,118 +84,107 @@ class NDCCountry extends PureComponent {
         </Button>
       </div>
     );
-  }
+  };
 
-  render() {
-    const {
-      country,
-      onSearchChange,
-      search,
-      route,
-      anchorLinks,
-      notSummary,
-      location,
-      countriesOptions,
-      handleCountryLink
-    } = this.props;
+  const countryName = country && `${country.wri_standard_name}`;
+  const hasSearch = notSummary;
 
-    const countryName = country && `${country.wri_standard_name}`;
-    const hasSearch = notSummary;
-
-    const renderIntroDropdown = () => (
-      <Intro
-        title={
-          <CWDropdown
-            value={
-              country && {
-                label: country.wri_standard_name,
-                value: country.iso_code3
-              }
+  const renderIntroDropdown = () => (
+    <Intro
+      title={
+        <CWDropdown
+          value={
+            country && {
+              label: country.wri_standard_name,
+              value: country.iso_code3
             }
-            options={countriesOptions}
-            onValueChange={handleCountryLink}
-            hideResetButton
-            theme={countryDropdownTheme}
-          />
-        }
-      />
-    );
+          }
+          options={countriesOptions}
+          onValueChange={handleCountryLink}
+          hideResetButton
+          theme={countryDropdownTheme}
+        />
+      }
+    />
+  );
 
-    return (
-      <div>
-        <MetaDescription
-          descriptionContext={NDC_COUNTRY({ countryName })}
-          subtitle={countryName}
-        />
-        <SocialMetadata
-          descriptionContext={NDC_COUNTRY({ countryName })}
-          href={location.href}
-        />
-        <NdcsDocumentsMetaProvider />
-        {country && (
-          <Header route={route}>
-            <div className={styles.header}>
-              <div
-                className={cx(styles.actionsContainer, {
-                  [styles.withSearch]: hasSearch,
-                  [styles.withoutBack]: !FEATURE_LTS_EXPLORE
-                })}
-              >
-                {!FEATURE_LTS_EXPLORE && renderIntroDropdown()}
-                {FEATURE_LTS_EXPLORE && (
-                  <BackButton
-                    backLabel="Explore NDCs"
-                    pathname="/ndcs-explore"
-                  />
-                )}
-                <TabletPortrait>
-                  {this.renderFullTextDropdown()}
-                  {this.renderFullTextButton()}
-                  {!FEATURE_LTS_EXPLORE && this.renderCompareButton()}
-                  {hasSearch && (
-                    <Search
-                      variant="transparent"
-                      placeholder="Search"
-                      value={search}
-                      onChange={onSearchChange}
-                    />
-                  )}
-                </TabletPortrait>
-              </div>
+  return (
+    <div>
+      <MetaDescription
+        descriptionContext={NDC_COUNTRY({ countryName })}
+        subtitle={countryName}
+      />
+      <SocialMetadata
+        descriptionContext={NDC_COUNTRY({ countryName })}
+        href={location.href}
+      />
+      <NdcsDocumentsMetaProvider />
+      {country && (
+        <Header route={route}>
+          <div className={styles.header}>
+            <div
+              className={cx(styles.actionsContainer, {
+                [styles.withSearch]: hasSearch,
+                [styles.withoutBack]: !FEATURE_LTS_EXPLORE
+              })}
+            >
+              {!FEATURE_LTS_EXPLORE && renderIntroDropdown()}
               {FEATURE_LTS_EXPLORE && (
-                <div className={styles.title}>{renderIntroDropdown()}</div>
+                <BackButton backLabel="Explore NDCs" pathname="/ndcs-explore" />
               )}
-              <MobileOnly>
-                <div className={styles.mobileActions}>
-                  {this.renderFullTextDropdown()}
-                  {hasSearch && (
-                    <Search
-                      variant="transparent"
-                      placeholder="Search"
-                      value={search}
-                      onChange={onSearchChange}
-                    />
-                  )}
-                </div>
-              </MobileOnly>
               <TabletPortrait>
-                {FEATURE_LTS_EXPLORE && this.renderCompareButton()}
+                {renderDocumentsDropdown()}
+                {renderFullTextButton()}
+                {!FEATURE_LTS_EXPLORE && renderCompareButton()}
               </TabletPortrait>
             </div>
-            <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
-              <AnchorNav
-                useRoutes
-                links={anchorLinks}
-                className={styles.anchorNav}
-                theme={anchorNavRegularTheme}
-              />
-            </Sticky>
-          </Header>
-        )}
-        <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
-      </div>
-    );
-  }
+            <TabletPortrait>
+              {hasSearch && (
+                <div className={styles.search}>
+                  <Search
+                    variant="transparent"
+                    placeholder="Search"
+                    value={search}
+                    onChange={onSearchChange}
+                  />
+                </div>
+              )}
+            </TabletPortrait>
+            {FEATURE_LTS_EXPLORE && (
+              <div className={styles.title}>{renderIntroDropdown()}</div>
+            )}
+            <MobileOnly>
+              <div className={styles.mobileActions}>
+                {renderDocumentsDropdown()}
+                {hasSearch && (
+                  <div className={styles.search}>
+                    <Search
+                      variant="transparent"
+                      placeholder="Search"
+                      value={search}
+                      onChange={onSearchChange}
+                    />
+                  </div>
+                )}
+              </div>
+            </MobileOnly>
+            <TabletPortrait>
+              {FEATURE_LTS_EXPLORE && renderCompareButton()}
+            </TabletPortrait>
+          </div>
+          <Sticky activeClass="sticky -ndcs" top="#navBarMobile">
+            <AnchorNav
+              useRoutes
+              links={anchorLinks}
+              className={styles.anchorNav}
+              theme={anchorNavRegularTheme}
+            />
+          </Sticky>
+        </Header>
+      )}
+      <div className={styles.wrapper}>{renderRoutes(route.routes)}</div>
+    </div>
+  );
 }
 
 NDCCountry.propTypes = {

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -39,28 +39,30 @@ function NDCCountry(props) {
     match
   } = props;
 
-  const renderDocumentsDropdown = () =>
-    documentsOptions && (
-      <Dropdown
-        className={cx(styles.countryDropdown)}
-        options={documentsOptions}
-        value={documentSelected}
-        onValueChange={handleDropDownChange}
-        white
-        hideResetButton
-      />
-    );
+  const renderDocumentsDropdown = () => (
+    <Dropdown
+      className={cx(styles.countryDropdown)}
+      options={documentsOptions}
+      value={documentSelected}
+      onValueChange={handleDropDownChange}
+      white
+      hideResetButton
+      disabled={!documentsOptions}
+    />
+  );
 
-  const renderFullTextButton = () =>
-    documentsOptions && (
-      <Button
-        variant="secondary"
-        link={`/ndcs/country/${match.params.iso}/full`}
-        className={styles.viewDocumentButton}
-      >
-        View Full Text
-      </Button>
-    );
+  const renderFullTextButton = () => (
+    <Button
+      variant="secondary"
+      link={`/ndcs/country/${
+        match.params.iso
+      }/full?document=${documentSelected && documentSelected.value}`}
+      className={styles.viewDocumentButton}
+      disabled={!documentsOptions}
+    >
+      View Full Text
+    </Button>
+  );
 
   const renderCompareButton = () => {
     if (!FEATURE_LTS_EXPLORE) {

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -17,38 +17,44 @@ import { MetaDescription, SocialMetadata } from 'components/seo';
 import { TabletPortrait, MobileOnly } from 'components/responsive';
 
 import anchorNavRegularTheme from 'styles/themes/anchor-nav/anchor-nav-regular.scss';
-import dropdownLinksTheme from 'styles/themes/dropdown/dropdown-links.scss';
 import countryDropdownTheme from 'styles/themes/dropdown/dropdown-country.scss';
 import styles from './ndc-country-styles.scss';
 
 const FEATURE_LTS_EXPLORE = process.env.FEATURE_LTS_EXPLORE === 'true';
 
 class NDCCountry extends PureComponent {
-  renderFullTextDropdown() {
-    const { match, documentsOptions, handleDropDownChange } = this.props;
+  renderFullTextButton() {
+    const {
+      documentsOptions,
+      documentSelected,
+      handleDropDownChange
+    } = this.props;
     return (
-      documentsOptions &&
-      (documentsOptions.length > 1 ? (
+      documentsOptions && (
         <Dropdown
-          className={cx(
-            dropdownLinksTheme.dropdownOptionWithArrow,
-            styles.countryDropdown
-          )}
-          placeholder="View full text"
+          className={cx(styles.countryDropdown)}
           options={documentsOptions}
+          value={documentSelected}
           onValueChange={handleDropDownChange}
           white
           hideResetButton
         />
-      ) : (
+      )
+    );
+  }
+
+  renderFullTextDropdown() {
+    const { match, documentsOptions } = this.props;
+    return (
+      documentsOptions && (
         <Button
           variant="secondary"
           link={`/ndcs/country/${match.params.iso}/full`}
           className={styles.viewDocumentButton}
         >
-          {`View ${documentsOptions[0].label} Document`}
+          View Full Text
         </Button>
-      ))
+      )
     );
   }
 
@@ -141,6 +147,7 @@ class NDCCountry extends PureComponent {
                 )}
                 <TabletPortrait>
                   {this.renderFullTextDropdown()}
+                  {this.renderFullTextButton()}
                   {!FEATURE_LTS_EXPLORE && this.renderCompareButton()}
                   {hasSearch && (
                     <Search
@@ -197,6 +204,7 @@ NDCCountry.propTypes = {
   search: PropTypes.string,
   anchorLinks: PropTypes.array,
   documentsOptions: PropTypes.array,
+  documentSelected: PropTypes.object,
   countriesOptions: PropTypes.array,
   handleDropDownChange: PropTypes.func,
   location: PropTypes.object,

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -11,19 +11,22 @@ const getCountries = state => sortBy(state.countries, 'wri_standard_name');
 const getCountryByIso = (countries, iso) =>
   countries.find(country => country.iso_code3 === iso);
 
+const getSearch = state => {
+  const { search } = state.location;
+  if (!search) return null;
+  const parsedSearch = qs.parse(state.location.search);
+  return parsedSearch || null;
+};
+
 export const getCountry = createSelector(
   [getCountries, getIso],
   getCountryByIso
 );
 
 export const getAnchorLinks = createSelector(
-  [
-    state => state.route.routes || [],
-    state => state.iso,
-    state => state.location.search
-  ],
+  [state => state.route.routes || [], state => state.iso, getSearch],
   (routes, iso, search) => {
-    const searchParams = { search: qs.parse(search).search };
+    const searchParams = { search: search.search };
     return routes
       .filter(route => route.anchor)
       .map(route => ({
@@ -34,15 +37,38 @@ export const getAnchorLinks = createSelector(
   }
 );
 
-export const getDocumentsOptions = createSelector(
+const getCountryDocuments = createSelector(
   [getDocuments, getIso],
   (documents, iso) => {
     if (isEmpty(documents) || !iso || !documents[iso]) return null;
-    return documents[iso].map(doc => ({
-      label: `${upperCase(doc.document_type)}(${doc.language})`,
-      value: `${doc.document_type}(${doc.language})`,
-      path: `/ndcs/country/${iso}/full?document=${doc.document_type}-${doc.language}`
-    }));
+    return documents[iso];
+  }
+);
+
+const documentValue = document =>
+  `${document.document_type}(${document.language})`;
+const documentOption = document => ({
+  label: `${upperCase(document.document_type)}(${document.language})`,
+  value: documentValue(document)
+});
+
+export const getDocumentsOptions = createSelector(
+  [getCountryDocuments],
+  documents => {
+    if (isEmpty(documents)) return null;
+    return documents.map(document => documentOption(document));
+  }
+);
+
+export const getDocumentSelected = createSelector(
+  [getCountryDocuments, getSearch],
+  (documents, search) => {
+    if (isEmpty(documents)) return null;
+    if (!search || !search.document) return documentOption(documents[0]);
+    const selectedDocument = documents.find(
+      d => documentValue(d) === search.document
+    );
+    return selectedDocument ? documentOption(selectedDocument) : null;
   }
 );
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -47,6 +47,7 @@ const getCountryDocuments = createSelector(
 
 const documentValue = document =>
   `${document.document_type}(${document.language})`;
+
 const documentOption = document => ({
   label: `${upperCase(document.document_type)}(${document.language})`,
   value: documentValue(document)

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
+import groupBy from 'lodash/groupBy';
 import upperCase from 'lodash/upperCase';
 import qs from 'query-string';
 
@@ -50,7 +51,7 @@ const documentValue = document =>
   `${document.document_type}-${document.language}`;
 
 const documentOption = document => ({
-  label: `${upperCase(document.document_type)}(${document.language})`,
+  label: upperCase(document.document_type),
   value: documentValue(document)
 });
 
@@ -58,7 +59,11 @@ export const getDocumentsOptions = createSelector(
   [getCountryDocuments],
   documents => {
     if (isEmpty(documents)) return null;
-    return documents.map(document => documentOption(document));
+    const groupedDocuments = groupBy(documents, 'document_type');
+    const englishDocuments = Object.values(groupedDocuments).map(
+      docs => docs.find(d => d.language === 'EN') || docs[0]
+    );
+    return englishDocuments.map(document => documentOption(document));
   }
 );
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -27,7 +27,7 @@ export const getAnchorLinks = createSelector(
   [state => state.route.routes || [], state => state.iso, getSearch],
   (routes, iso, search) => {
     if (!search) return null;
-    const searchParams = { search: search.search };
+    const searchParams = { search: search.search, document: search.document };
     return routes
       .filter(route => route.anchor)
       .map(route => ({
@@ -47,7 +47,7 @@ const getCountryDocuments = createSelector(
 );
 
 const documentValue = document =>
-  `${document.document_type}(${document.language})`;
+  `${document.document_type}-${document.language}`;
 
 const documentOption = document => ({
   label: `${upperCase(document.document_type)}(${document.language})`,

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -26,6 +26,7 @@ export const getCountry = createSelector(
 export const getAnchorLinks = createSelector(
   [state => state.route.routes || [], state => state.iso, getSearch],
   (routes, iso, search) => {
+    if (!search) return null;
     const searchParams = { search: search.search };
     return routes
       .filter(route => route.anchor)

--- a/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
+++ b/app/javascript/app/pages/ndc-country/ndc-country-styles.scss
@@ -36,31 +36,35 @@
   @media #{$tablet-portrait} {
     @include row(6);
     @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
-
-    &.withSearch {
-      @include row((6, 3, 3));
-    }
+    @include row((12, 6, 6));
 
     &.withoutBack {
-      @include row((12, 6, 6));
+      @include row((12, 6, 6, 6));
       @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
-
-      &.withSearch {
-        @include row(6);
-        @include xy-gutters($gutter-position: ('bottom'), $gutters: $gutter-padding);
-      }
     }
   }
 
   @media #{$tablet-landscape} {
-    @include row((9, 3));
+    @include row((6, 3, 3));
 
-    &.withSearch,
     &.withoutBack {
-      @include row((6, 3, 3));
+      @include row((12, 4, 4, 4));
     }
 
     z-index: $z-index-base;
+  }
+}
+
+.search {
+  @include row();
+
+  margin-top: 10px;
+
+  @media #{$tablet-portrait} {
+    @include row(6);
+
+    justify-content: flex-end;
+    margin-top: 10px;
   }
 }
 

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -1,4 +1,4 @@
-import { createElement, PureComponent } from 'react';
+import { createElement, useEffect } from 'react';
 import { connect } from 'react-redux';
 import Proptypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
@@ -51,22 +51,36 @@ const mapStateToProps = (state, { match, location, route }) => {
   };
 };
 
-class NDCCountryContainer extends PureComponent {
-  onSearchChange = query => {
-    this.updateUrlParam({ name: 'search', value: query });
-  };
+function NDCCountryContainer(props) {
+  const { history, location, country, documentsOptions } = props;
 
-  handleDropDownChange = documentSelected => {
-    this.updateUrlParam({ name: 'document', value: documentSelected.value });
-  };
-
-  updateUrlParam = (params, clear) => {
-    const { history, location } = this.props;
+  const updateUrlParam = (params, clear) => {
     history.replace(getLocationParamUpdated(location, params, clear));
   };
 
-  handleCountryLink = selected => {
-    const { history, country } = this.props;
+  useEffect(() => {
+    const search = location.search && qs.parse(location.search);
+    if (
+      (!search || !search.document) &&
+      documentsOptions &&
+      documentsOptions.length
+    ) {
+      updateUrlParam({
+        name: 'document',
+        value: documentsOptions[documentsOptions.length - 1].value
+      });
+    }
+  }, [documentsOptions]);
+
+  const onSearchChange = query => {
+    updateUrlParam({ name: 'search', value: query });
+  };
+
+  const handleDropDownChange = documentSelected => {
+    updateUrlParam({ name: 'document', value: documentSelected.value });
+  };
+
+  const handleCountryLink = selected => {
     const path = history.location.pathname.replace(
       country.iso_code3,
       selected.value
@@ -74,14 +88,12 @@ class NDCCountryContainer extends PureComponent {
     history.replace(path);
   };
 
-  render() {
-    return createElement(NDCCountryComponent, {
-      ...this.props,
-      onSearchChange: this.onSearchChange,
-      handleCountryLink: this.handleCountryLink,
-      handleDropDownChange: this.handleDropDownChange
-    });
-  }
+  return createElement(NDCCountryComponent, {
+    ...props,
+    onSearchChange,
+    handleCountryLink,
+    handleDropDownChange
+  });
 }
 
 NDCCountryContainer.propTypes = {

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -10,6 +10,7 @@ import {
   getCountry,
   getAnchorLinks,
   getDocumentsOptions,
+  getDocumentSelected,
   addUrlToCountries
 } from './ndc-country-selectors';
 
@@ -18,7 +19,8 @@ const mapStateToProps = (state, { match, location, route }) => {
   const search = qs.parse(location.search);
   const countryData = {
     countries: state.countries.data,
-    iso: match.params.iso
+    iso: match.params.iso,
+    location
   };
   const routeData = {
     iso,
@@ -27,7 +29,8 @@ const mapStateToProps = (state, { match, location, route }) => {
   };
   const documentsData = {
     iso,
-    data: state.ndcsDocumentsMeta.data
+    data: state.ndcsDocumentsMeta.data,
+    location
   };
   const pathname = location.pathname.split('/');
   const notSummary = [
@@ -43,6 +46,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     search: search.search,
     anchorLinks: getAnchorLinks(routeData),
     documentsOptions: getDocumentsOptions(documentsData),
+    documentSelected: getDocumentSelected(documentsData),
     notSummary
   };
 };
@@ -52,13 +56,13 @@ class NDCCountryContainer extends PureComponent {
     this.updateUrlParam({ name: 'search', value: query });
   };
 
+  handleDropDownChange = documentSelected => {
+    this.updateUrlParam({ name: 'document', value: documentSelected.value });
+  };
+
   updateUrlParam = (params, clear) => {
     const { history, location } = this.props;
     history.replace(getLocationParamUpdated(location, params, clear));
-  };
-
-  handleDropDownChange = selected => {
-    this.props.history.push(selected.path);
   };
 
   handleCountryLink = selected => {
@@ -74,8 +78,8 @@ class NDCCountryContainer extends PureComponent {
     return createElement(NDCCountryComponent, {
       ...this.props,
       onSearchChange: this.onSearchChange,
-      handleDropDownChange: this.handleDropDownChange,
-      handleCountryLink: this.handleCountryLink
+      handleCountryLink: this.handleCountryLink,
+      handleDropDownChange: this.handleDropDownChange
     });
   }
 }

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -81,11 +81,13 @@ function NDCCountryContainer(props) {
   };
 
   const handleCountryLink = selected => {
-    const path = history.location.pathname.replace(
-      country.iso_code3,
-      selected.value
-    );
-    history.replace(path);
+    if (selected) {
+      const path = history.location.pathname.replace(
+        country.iso_code3,
+        selected.value
+      );
+      history.replace(path);
+    }
   };
 
   return createElement(NDCCountryComponent, {

--- a/app/javascript/app/providers/documents-provider/documents-provider-actions.js
+++ b/app/javascript/app/providers/documents-provider/documents-provider-actions.js
@@ -1,0 +1,36 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import isEmpty from 'lodash/isEmpty';
+
+export const fetchNDCSDocumentsInit = createAction('fetchNDCSDocumentsInit');
+export const fetchNDCSDocumentsReady = createAction('fetchNDCSDocumentsReady');
+export const fetchNDCSDocumentsFail = createAction('fetchNDCSDocumentsFail');
+
+export const fetchNDCSDocuments = createThunkAction(
+  'fetchNDCSDocuments',
+  () => (dispatch, state) => {
+    const { documents } = state();
+    if (documents && isEmpty(documents.data) && !documents.loading) {
+      dispatch(fetchNDCSDocumentsInit());
+      fetch('/api/v1/data/ndc_content/documents')
+        .then(response => {
+          if (response.ok) return response.json();
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          dispatch(fetchNDCSDocumentsReady(data.data));
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchNDCSDocumentsFail());
+        });
+    }
+  }
+);
+
+export default {
+  fetchNDCSDocuments,
+  fetchNDCSDocumentsInit,
+  fetchNDCSDocumentsReady,
+  fetchNDCSDocumentsFail
+};

--- a/app/javascript/app/providers/documents-provider/documents-provider-reducers.js
+++ b/app/javascript/app/providers/documents-provider/documents-provider-reducers.js
@@ -1,0 +1,26 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  error: false,
+  data: null
+};
+
+const setLoading = (state, loading) => ({ ...state, loading });
+const setError = (state, error) => ({ ...state, error });
+const setLoaded = (state, loaded) => ({ ...state, loaded });
+
+export default {
+  fetchNDCSDocumentsInit: state => setLoading(state, true),
+  fetchNDCSDocumentsReady: (state, { payload }) =>
+    setLoaded(
+      setLoading(
+        {
+          ...state,
+          data: [...payload]
+        },
+        false
+      ),
+      true
+    ),
+  fetchNDCSDocumentsFail: state => setError(state, true)
+};

--- a/app/javascript/app/providers/documents-provider/documents-provider.js
+++ b/app/javascript/app/providers/documents-provider/documents-provider.js
@@ -1,0 +1,24 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import reducers, { initialState } from './documents-provider-reducers';
+import * as actions from './documents-provider-actions';
+
+class DocumentsProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchNDCSDocuments } = this.props;
+    fetchNDCSDocuments();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+DocumentsProvider.propTypes = {
+  fetchNDCSDocuments: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(null, actions)(DocumentsProvider);

--- a/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider-actions.js
+++ b/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider-actions.js
@@ -6,23 +6,25 @@ const getNdcContentOverviewFail = createAction('getNdcContentOverviewFail');
 const getNdcContentOverviewReady = createAction('getNdcContentOverviewReady');
 const getNdcContentOverview = createThunkAction(
   'getNdcContentOverview',
-  locations => (dispatch, getState) => {
+  ({ locations, document }) => dispatch => {
     dispatch(getNdcContentOverviewInit());
     const promises = [];
     const locationsWithPromise = [];
-    const { data } = getState().ndcContentOverview;
     locations.forEach(location => {
-      if (!data || !data.locations[location]) {
-        promises.push(
-          fetch(`/api/v1/ndcs/${location}/content_overview`).then(response => {
+      // Remove ndc filter when the data is ready
+      const documentParam =
+        document && document !== 'ndc' ? `?document=${document}` : '';
+      promises.push(
+        fetch(`/api/v1/ndcs/${location}/content_overview${documentParam}`).then(
+          response => {
             if (response.ok) {
               return response.json();
             }
             throw Error(response.statusText);
-          })
-        );
-        locationsWithPromise.push(location);
-      }
+          }
+        )
+      );
+      locationsWithPromise.push(location);
     });
     Promise.all(promises)
       .then(response => {

--- a/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider.js
+++ b/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider.js
@@ -8,19 +8,23 @@ import reducers, {
 
 class ndcContentOverviewProvider extends PureComponent {
   componentDidMount() {
-    const { locations, getNdcContentOverview } = this.props;
-    if (locations && locations.length) getNdcContentOverview(locations);
+    const { locations, document, getNdcContentOverview } = this.props;
+    if (locations && locations.length) {
+      getNdcContentOverview({ locations, document });
+    }
   }
 
   componentDidUpdate(prevProps) {
-    const { locations, getNdcContentOverview } = this.props;
+    const { locations, document, getNdcContentOverview } = this.props;
+
     if (
-      locations &&
-      locations.length &&
-      prevProps.locations &&
-      locations.sort().join() !== prevProps.locations.sort().join()
+      (document && document !== prevProps.document) ||
+      (locations &&
+        locations.length &&
+        prevProps.locations &&
+        locations.sort().join() !== prevProps.locations.sort().join())
     ) {
-      getNdcContentOverview(locations);
+      getNdcContentOverview({ locations, document });
     }
   }
 
@@ -31,6 +35,7 @@ class ndcContentOverviewProvider extends PureComponent {
 
 ndcContentOverviewProvider.propTypes = {
   locations: PropTypes.array,
+  document: PropTypes.string,
   getNdcContentOverview: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -6,6 +6,7 @@ import { handleActions } from 'app/utils/redux';
 import * as loginProvider from 'providers/login-provider';
 import * as countriesProvider from 'providers/countries-provider';
 import * as regionsProvider from 'providers/regions-provider';
+import * as documentsProvider from 'providers/documents-provider';
 import * as espLocationsProvider from 'providers/esp-locations-provider';
 import * as espTimeSeriesProvider from 'providers/esp-time-series-provider';
 import * as adaptationsProvider from 'providers/adaptations-provider';
@@ -42,6 +43,7 @@ const providersReducers = {
   login: handleActions(loginProvider),
   countries: handleActions(countriesProvider),
   regions: handleActions(regionsProvider),
+  documents: handleActions(documentsProvider),
   adaptations: handleActions(adaptationsProvider),
   emissions: handleActions(emissionsProvider),
   ndcsSdgsMeta: handleActions(ndcsSdgsMetaProvider),


### PR DESCRIPTION
This PR adds a dropdown that selects a document from the country NDC page

- The Full document link is now always a button that is linked to the document selection
- Both summary and accordion data is updated with the document selection
- When we start without a document the last document available is filled into the URL param. This is necessary for the filtering and the link
- The dropdown is only showing the English documents as we only have the information in English for this page. Once on the full page, you can select different languages. 

Try: Go to an NDC country page and change the document, country, tab, go to the full document, ...

![image](https://user-images.githubusercontent.com/9701591/77856301-752d0680-71f6-11ea-84b1-fa71e0640fe8.png)
