### PR TITLE
Fix/table height

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -47,7 +47,8 @@ export const getIsEUUSubmitted = createSelector(
 
 export const getMaximumCountries = createSelector(
   [getCountries, getIsEUUSubmitted],
-  (countries, isEUUsubmitted) => (isEUUsubmitted ? countries.length + 1 : countries.length)
+  (countries, isEUUsubmitted) =>
+    (isEUUsubmitted ? countries.length + 1 : countries.length)
 );
 
 export const getISOCountries = createSelector([getCountries], countries =>
@@ -298,7 +299,7 @@ export const getSummaryCardData = createSelector(
       l => l.value
     ).length;
     if (isEUUsubmitted) {
-      const partiesNumber = countriesNumber + 1;
+      const partiesNumber = countriesNumber;
       const europeanCountriesWithSubmission = europeanCountries.filter(
         iso => LTSIndicator.locations[iso]
       );

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-component.jsx
@@ -54,6 +54,7 @@ const LTSExploreTable = ({
                   ? exploreTableTwoHighlightedColumnsTheme
                   : exploreTableTheme
               }
+              tableHeight={650}
             />
           </div>
         )}

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-component.jsx
@@ -48,6 +48,7 @@ const NDCSExploreTable = ({
               defaultColumns={columns}
               theme={exploreTableTheme}
               titleLinks={titleLinks}
+              tableHeight={650}
             />
           </div>
         )}

--- a/app/javascript/app/pages/lts-country/lts-country-component.jsx
+++ b/app/javascript/app/pages/lts-country/lts-country-component.jsx
@@ -53,6 +53,13 @@ class LTSCountry extends PureComponent {
     );
   }
 
+  renderCountryOption = option => (
+    <div
+      className={cx('simple-option', { [styles.boldOption]: !!option.hasData })}
+    >
+      {option.label}
+    </div>
+  );
   render() {
     const {
       country,
@@ -82,6 +89,7 @@ class LTSCountry extends PureComponent {
             onValueChange={handleCountryLink}
             hideResetButton
             theme={countryDropdownTheme}
+            renderOption={this.renderCountryOption}
           />
         }
       />

--- a/app/javascript/app/pages/lts-country/lts-country-selectors.js
+++ b/app/javascript/app/pages/lts-country/lts-country-selectors.js
@@ -45,15 +45,20 @@ export const getDocumentLink = createSelector(
   }
 );
 
-export const addUrlToCountries = createSelector(
-  [getCountries, getCountry],
-  (countries, country) => {
-    if (!countries) return null;
+export const addUrlAndHasDataToCountries = createSelector(
+  [getCountries, getCountry, getIndicators],
+  (countries, country, indicators) => {
+    if (!countries || !indicators) return null;
+    const submissionIndicator = indicators.find(
+      i => i.slug === 'lts_submission'
+    );
     return countries
       .filter(c => c.iso_code3 !== country.iso_code3)
       .map(c => ({
         value: c.iso_code3,
-        label: c.wri_standard_name
+        label: c.wri_standard_name,
+        hasData:
+          submissionIndicator && submissionIndicator.locations[c.iso_code3]
       }));
   }
 );

--- a/app/javascript/app/pages/lts-country/lts-country-styles.scss
+++ b/app/javascript/app/pages/lts-country/lts-country-styles.scss
@@ -70,3 +70,8 @@
   width: 13px;
   height: 13px;
 }
+
+.boldOption {
+  font-weight: $font-weight-very-bold !important;
+  color: $theme-color-bright !important;
+}

--- a/app/javascript/app/pages/lts-country/lts-country.js
+++ b/app/javascript/app/pages/lts-country/lts-country.js
@@ -11,7 +11,7 @@ import {
   getCountry,
   getAnchorLinks,
   getDocumentLink,
-  addUrlToCountries
+  addUrlAndHasDataToCountries
 } from './lts-country-selectors';
 
 const mapStateToProps = (state, { match, location, route }) => {
@@ -37,7 +37,7 @@ const mapStateToProps = (state, { match, location, route }) => {
     country: getCountry(stateData),
     search: search.search,
     anchorLinks: getAnchorLinks(stateData),
-    countriesOptions: addUrlToCountries(stateData),
+    countriesOptions: addUrlAndHasDataToCountries(stateData),
     documentLink: getDocumentLink(stateData),
     notSummary
   };

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -17,6 +17,7 @@ $font-weight-light: 300;
 $font-weight: 400;
 $font-weight-semi-bold: 500;
 $font-weight-bold: 600;
+$font-weight-very-bold: 900;
 
 // line height
 $line-height-xs: 0.85;


### PR DESCRIPTION
- Increase table height in LTS and NDC explore pages

![image](https://user-images.githubusercontent.com/9701591/77857812-297f5a80-7200-11ea-83d5-53b1b07cff6b.png)

- Fix parties count on LTS summary card: On staging it says 16 and it will be 15 instead when EU data is included.

- Add bold style to options that have data in LTS Country - country drowpdown. Also the color is changed as the bold was not enough

![image](https://user-images.githubusercontent.com/9701591/77857788-00f76080-7200-11ea-87af-32effd78b6ce.png)
