### PR TITLE
We had the wrong source name it should be NDC Explorer

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -22,7 +22,7 @@ const fetchNdcsCountryAccordion = createThunkAction(
         `/api/v1/ndcs?location=${locations}&category=${category}${
           lts
             ? '&source=LTS'
-            : '&source[]=CAIT&source[]=WB&source[]=NDC Explore'
+            : '&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
         }${documentParam}${!compare ? '&filter=overview' : ''}`
       )
         .then(response => {

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -23,7 +23,7 @@ const fetchNDCS = createThunkAction(
         `/api/v1/ndcs${
           overrideFilter
             ? ''
-            : '?filter=map&source[]=CAIT&source[]=WB&source[]=NDC'
+            : '?filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
         }`
       )
         .then(response => {

--- a/app/javascript/app/providers/ndc-country-accordion-provider/ndc-country-accordion-provider-actions.js
+++ b/app/javascript/app/providers/ndc-country-accordion-provider/ndc-country-accordion-provider-actions.js
@@ -21,7 +21,7 @@ const fetchNdcsCountryAccordion = createThunkAction(
         `/api/v1/ndcs?location=${locations}&category=${category}${
           lts
             ? '&source=LTS'
-            : '&source[]=CAIT&source[]=WB&source[]=NDC Explore'
+            : '&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
         }${!compare ? '&filter=overview' : ''}`
       )
         .then(response => {


### PR DESCRIPTION
Fix for the NDC content page. Missing indicators

I've just realised that this bug: https://basecamp.com/1756858/projects/13795275/todos/410321905 is related with the wrong name of the NDC Explorer source that we are using on the app. I am fixing this directly in production, so that we can fast track this fix.
