### PR TITLE
Dont default to first country

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/location-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/location-selectors.js
@@ -7,5 +7,5 @@ const getIsoCodeFromSearch = (state, props) =>
 export default createSelector([getIsoCodeFromSearch], search => {
   if (!search) return 'WORLD';
   const { emissionsCountry } = search && qs.parse(search);
-  return (emissionsCountry && emissionsCountry) || 'WORLD';
+  return emissionsCountry || 'WORLD';
 });

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors/location-selectors.js
@@ -4,7 +4,8 @@ import qs from 'query-string';
 
 const getCountries = state => state.countries || null;
 const getRegions = state => state.regions || null;
-const getSourceSelection = state => (state.location && state.location.search) || null;
+const getSourceSelection = state =>
+  (state.location && state.location.search) || null;
 const getLocationsWithData = state =>
   get(state, 'agricultureEmissions.meta.emission_locations_with_data', null);
 
@@ -50,12 +51,16 @@ export const getEmissionCountrySelected = createSelector(
   [getSourceSelection, getLocationsOptionsUnfiltered],
   (selectedEmissionOption, countriesOptions) => {
     if (!countriesOptions) return null;
-    const defaultCountry = countriesOptions.find(({ value }) => value === 'WORLD');
+    const defaultCountry = countriesOptions.find(
+      ({ value }) => value === 'WORLD'
+    );
     if (!selectedEmissionOption) {
-      return defaultCountry || countriesOptions[0];
+      return defaultCountry || null;
     }
     const { emissionsCountry } = qs.parse(selectedEmissionOption);
-    const selectedCountry = countriesOptions.find(({ value }) => value === emissionsCountry);
+    const selectedCountry = countriesOptions.find(
+      ({ value }) => value === emissionsCountry
+    );
     return selectedCountry || defaultCountry;
   }
 );


### PR DESCRIPTION
I can't import the regions data for some reason, but we were defaulting to the first country if we didn't found the default region = World. So for a brief moment it was loading the AFG data and we had an unexpected chart render. I think this will fix staging and production where we have the regions data.

![image](https://user-images.githubusercontent.com/9701591/79783445-f2085780-8340-11ea-82ae-812a65dde3c6.png)
