### PR TITLE
Change Ids to slugs in GHG emissions

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -95,7 +95,7 @@ export const getSourceSelected = createSelector(
       const defaultSource = sources.find(s => s.name === 'CAIT');
       return defaultSource || sources[0];
     }
-    return sources.find(category => category.value === selected);
+    return sources.find(category => category.name === selected);
   }
 );
 

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -133,7 +133,7 @@ class CountryGhgEmissionsContainer extends PureComponent {
     if (category) {
       this.updateUrlParam(
         [
-          { name: 'source', value: category.value },
+          { name: 'source', value: category.name },
           { name: 'sector', value: searchQuery.sector },
           { name: 'calculation', value: searchQuery.calculation }
         ],

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
-import { getGhgEmissionDefaults, toPlural } from 'utils/ghg-emissions';
+import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -222,7 +222,7 @@ const getDefaults = createSelector(
   (sourceSelected, meta) => {
     if (!sourceSelected || !meta) return null;
 
-    return getGhgEmissionDefaults(sourceSelected, meta);
+    return getGhgEmissionDefaultSlugs(sourceSelected, meta);
   }
 );
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -2,6 +2,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
 import isEmpty from 'lodash/isEmpty';
+import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaults, toPlural } from 'utils/ghg-emissions';
@@ -28,7 +29,7 @@ const getOptionSelectedFunction = filter => (options, selected) => {
     const defaultOption = options.find(b => b.value === DEFAULTS[filter]);
     return defaultOption || options[0];
   }
-  return options.find(o => o.value === selected);
+  return options.find(o => o.value === selected || o.name === selected);
 };
 
 // Sources selectors
@@ -125,7 +126,9 @@ const getRegionOptions = createSelector(
       if (
         sourceSelected.name.startsWith('UNFCCC') &&
         region.iso_code3 === 'WORLD'
-      ) { return; }
+      ) {
+        return;
+      }
       const regionMembers = region.members.map(m => m.iso_code3);
       regionOptions.push({
         label: region.wri_standard_name,
@@ -223,6 +226,19 @@ const getDefaults = createSelector(
   }
 );
 
+const isIncluded = (field, selectedValues, filter) => {
+  const kebabInclude = selectedValues.includes(kebabCase(filter.label));
+  const valueOrIsoInclude =
+    selectedValues.includes(String(filter.value)) ||
+    selectedValues.includes(filter.iso_code3);
+
+  return {
+    location: valueOrIsoInclude,
+    gas: kebabInclude,
+    sector: kebabInclude
+  }[field];
+};
+
 const getFiltersSelected = field =>
   createSelector(
     [getOptions, getSelection(field), getDefaults],
@@ -236,15 +252,12 @@ const getFiltersSelected = field =>
 
       // empty filter selected deliberately
       if (selected === '') return [];
-
       const selection = selected || defaultSelection;
       let selectedFilters = [];
       if (selection) {
         const selectedValues = selection.split(',');
-        selectedFilters = fieldOptions.filter(
-          filter =>
-            selectedValues.includes(String(filter.value)) ||
-            selectedValues.includes(filter.iso_code3)
+        selectedFilters = fieldOptions.filter(filter =>
+          isIncluded(field, selectedValues, filter)
         );
       }
 

--- a/app/javascript/app/utils/ghg-emissions.js
+++ b/app/javascript/app/utils/ghg-emissions.js
@@ -1,4 +1,8 @@
-import { DEFAULT_EMISSIONS_SELECTIONS, CALCULATION_OPTIONS } from 'data/constants';
+import {
+  DEFAULT_EMISSIONS_SELECTIONS,
+  CALCULATION_OPTIONS
+} from 'data/constants';
+import kebabCase from 'lodash/kebabCase';
 
 export const getGhgEmissionDefaults = (source, meta) => {
   const sourceName = source.name || source.label;
@@ -9,6 +13,19 @@ export const getGhgEmissionDefaults = (source, meta) => {
   return {
     gas: (meta.gas.find(g => g.label === defaults.gas) || {}).value,
     sector: (meta.sector.find(s => s.label === sectorDefaults) || {}).value,
+    location: defaults.location
+  };
+};
+
+export const getGhgEmissionDefaultSlugs = (source, meta) => {
+  const sourceName = source.name || source.label;
+  const defaults = DEFAULT_EMISSIONS_SELECTIONS[sourceName];
+  if (!defaults) return {};
+  const gas = meta.gas.find(g => g.label === defaults.gas);
+  const sector = meta.sector.find(s => s.label === defaults.sector);
+  return {
+    gas: gas && kebabCase(gas.label),
+    sector: sector && kebabCase(sector.label),
     location: defaults.location
   };
 };


### PR DESCRIPTION
Source, gas, and sector had ids on the URL instead of slugs. Now name is used for sources and kebabcased label for gases and sectors.

![image](https://user-images.githubusercontent.com/9701591/79866820-a2c43480-83dd-11ea-99dd-0ade237ff578.png)
This translates now to:
http://localhost:3000/ghg-emissions?breakBy=sector&chartType=line&gases=all-ghg&regions=TOP&sectors=agriculture&source=CAIT

Try changing the filters. Using the defaults and reloading the page. It should all work

Also, in Country pages:
![image](https://user-images.githubusercontent.com/9701591/79896188-53472e00-8408-11ea-8c8f-95974682ac48.png)
Should have this URL:
http://localhost:3000/countries/USA?source=UNFCCC_AI