### PR TITLE
Fix Donut tooltip positioning

### DIFF
--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -18,7 +18,11 @@ const DonutTooltip = props => {
   const chartTop = chartReference && chartReference.getBoundingClientRect().top;
   const referenceTop = reference.getBoundingClientRect().top;
 
-  const top = chartTop - referenceTop + coordinate.y;
+  const DEFAULT_OFFSET = 210; // If the parent reference is not loaded
+  const top = chartTop
+    ? chartTop - referenceTop + coordinate.y
+    : DEFAULT_OFFSET + coordinate.y;
+
   // Avoid covering the label on the center
   const left = coordinate.x > 40 ? coordinate.x + 80 : coordinate.x;
   return ReactDOM.createPortal(


### PR DESCRIPTION
Add a default offset because the parent reference was not always loaded when we show the tooltip

![image](https://user-images.githubusercontent.com/9701591/79978191-c6e84a00-849f-11ea-9b14-5803037326a2.png)
