### PR TITLE
Adds option for aggregated results

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -34,6 +34,7 @@ import {
   getModelSelected,
   getMetricSelected,
   getOptionsSelected,
+  getIsRegionAggregated,
   getOptions
 } from './ghg-emissions-selectors-filters';
 
@@ -41,12 +42,18 @@ const LEGEND_LIMIT = 10;
 
 const getShouldExpand = filter =>
   createSelector(
-    [getModelSelected, getOptionsSelected],
-    (modelSelected, selectedOptions) => {
+    [getModelSelected, getOptionsSelected, getIsRegionAggregated],
+    (modelSelected, selectedOptions, isRegionAggregated) => {
       const model = modelSelected && toPlural(modelSelected);
       const dataSelected = selectedOptions[`${filter}Selected`];
 
-      if (!selectedOptions || !model || model !== filter || !dataSelected) {
+      if (
+        isRegionAggregated ||
+        !selectedOptions ||
+        !model ||
+        model !== filter ||
+        !dataSelected
+      ) {
         return false;
       }
 
@@ -515,7 +522,15 @@ export const getTableData = createSelector(
 export const getTitleLinks = createSelector(
   [getTableData, getModelSelected, getRegions, getCountries],
   (data, model, regions, countries) => {
-    if (!data || isEmpty(data) || !regions || !countries || model !== 'regions') { return null; }
+    if (
+      !data ||
+      isEmpty(data) ||
+      !regions ||
+      !countries ||
+      model !== 'regions'
+    ) {
+      return null;
+    }
     const allRegions = regions
       .filter(r => r.iso_code3 === europeSlug)
       .concat(countries);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -51,8 +51,12 @@ const getSourceSelected = createSelector(
 // BreakBy selectors
 const BREAK_BY_OPTIONS = [
   {
-    label: 'Regions-Totals',
+    label: 'Regions',
     value: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
+  },
+  {
+    label: 'Regions-Total Aggregated',
+    value: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}-aggregated`
   },
   {
     label: 'Regions-Per Capita',
@@ -84,7 +88,11 @@ const getBreakBySelected = createSelector(
   breakBySelected => {
     if (!breakBySelected) return null;
     const breakByArray = breakBySelected.value.split('-');
-    return { modelSelected: breakByArray[0], metricSelected: breakByArray[1] };
+    return {
+      modelSelected: breakByArray[0],
+      metricSelected: breakByArray[1],
+      isAggregated: breakByArray[2] === 'aggregated'
+    };
   }
 );
 
@@ -95,6 +103,10 @@ export const getModelSelected = createSelector(
 export const getMetricSelected = createSelector(
   getBreakBySelected,
   breakBySelected => (breakBySelected && breakBySelected.metricSelected) || null
+);
+export const getIsRegionAggregated = createSelector(
+  getBreakBySelected,
+  breakBySelected => (breakBySelected && breakBySelected.isAggregated) || null
 );
 
 const filterOptionsBySource = field =>


### PR DESCRIPTION
This small PR adds an option to the show by dropdown: Regions - Total aggregated
This option works the same as the Regions total option but only displays aggregated regions without expanding them like on the other Regions option.

![image](https://user-images.githubusercontent.com/9701591/79999345-150b4680-84bc-11ea-90e5-553ad676b19f.png)
