### PR TITLE
Enabling inclusion of LTS information on the country_documents endpoint

### DIFF
--- a/app/controllers/api/v1/data/ndc_content/documents_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/documents_controller.rb
@@ -4,8 +4,7 @@ module Api
       module NdcContent
         class DocumentsController < Api::V1::Data::ApiController
           def index
-            documents = ::Indc::Document.order(:ordering)
-              .where(is_ndc: true)
+            documents = ::Indc::Document.order(:ordering).where(is_ndc: true)
             render json: documents,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::DocumentSerializer,

--- a/app/controllers/api/v1/data/ndc_content/documents_controller.rb
+++ b/app/controllers/api/v1/data/ndc_content/documents_controller.rb
@@ -5,6 +5,7 @@ module Api
         class DocumentsController < Api::V1::Data::ApiController
           def index
             documents = ::Indc::Document.order(:ordering)
+              .where(is_ndc: true)
             render json: documents,
                    adapter: :json,
                    each_serializer: Api::V1::Data::NdcContent::DocumentSerializer,

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -113,8 +113,10 @@ class ImportIndc
     }
   end
 
-  def value_ndc_attributes(row, location, indicator)
-    doc_slug = row[:document]&.parameterize&.gsub('-', '_')
+  # for datasets that don't have multiple files we can pass the doc_slug
+  # as a param, for example for LTS
+  def value_ndc_attributes(row, location, indicator, doc_slug=nil)
+    doc_slug = doc_slug || row[:document]&.parameterize&.gsub('-', '_')
     {
       location: location,
       indicator: indicator,
@@ -144,7 +146,8 @@ class ImportIndc
       ordering: doc[:order_number],
       slug: doc_slug,
       long_name: doc[:long_name],
-      description: doc[:description]
+      description: doc[:description],
+      is_ndc: doc[:is_ndc]
     }
   end
 
@@ -336,7 +339,7 @@ class ImportIndc
         next unless r[:"#{indicator.slug}"].present?
 
         Indc::Value.create!(
-          value_ndc_attributes(r, location, indicator)
+          value_ndc_attributes(r, location, indicator, 'lts')
         )
       end
     end

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -115,8 +115,8 @@ class ImportIndc
 
   # for datasets that don't have multiple files we can pass the doc_slug
   # as a param, for example for LTS
-  def value_ndc_attributes(row, location, indicator, doc_slug=nil)
-    doc_slug = doc_slug || row[:document]&.parameterize&.gsub('-', '_')
+  def value_ndc_attributes(row, location, indicator, doc_slug = nil)
+    doc_slug ||= row[:document]&.parameterize&.gsub('-', '_')
     {
       location: location,
       indicator: indicator,

--- a/db/migrate/20200423085052_add_is_ndc_to_indc_documents.rb
+++ b/db/migrate/20200423085052_add_is_ndc_to_indc_documents.rb
@@ -1,0 +1,5 @@
+class AddIsNdcToIndcDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :indc_documents, :is_ndc, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -922,7 +922,8 @@ CREATE TABLE public.indc_documents (
     long_name character varying,
     description text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    is_ndc boolean
 );
 
 
@@ -4238,6 +4239,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190725143552'),
 ('20200317204602'),
 ('20200317210227'),
-('20200317210928');
+('20200317210928'),
+('20200423085052');
 
 


### PR DESCRIPTION
My first approach was to inject the LTS information on the endpoint, but then decided to keep it less hard-coded, so I have extended the NDC_Documents file to have a flag to state if it's an NDC file or another extra file.

This meant changing the importer, so for you to test this you'll need to run the indc importer:

`bundle exec rails indc:import`

Then you will see that in this endpoint, it will include the LTS document and  if the country has data for LTS:

* No LTS data: http://localhost:3000/api/v1/ndcs/countries_documents?location=BRA
* With LTS data: http://localhost:3000/api/v1/ndcs/countries_documents?location=USA
* All the countries at once: http://localhost:3000/api/v1/ndcs/countries_documents

The endpoint that we use on the NDC Explore page, will just return the documents that are related to NDC, as it is an NDC Content related endpoint: http://localhost:3000/api/v1/data/ndc_content/documents

This is related with Compare All work, and will give you the info to power the matrix/table.
