### PR TITLE
Split dropdowns and add legacy URL support

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -239,7 +239,7 @@ function GhgEmissions(props) {
       <RegionsProvider />
       <EmissionsMetaProvider />
       {providerFilters && <EmissionsProvider filters={providerFilters} />}
-      <div className={styles.col4}>
+      <div className={cx(styles.col4, { [styles.newGHG]: FEATURE_NEW_GHG })}>
         {renderDropdown('Data Source', 'sources')}
         <Multiselect
           label={'Countries/Regions'}
@@ -266,7 +266,7 @@ function GhgEmissions(props) {
           onValueChange={selected => handleChange('gases', selected)}
           theme={dropdownTheme}
         />
-        {renderDropdown('Calculations', 'calculation')}
+        {FEATURE_NEW_GHG && renderDropdown('Calculations', 'calculation')}
         {renderDropdown('Show data by', 'breakBy')}
         {renderDropdown(null, 'chartType', icons, {
           variant: 'icons-labels',

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -266,6 +266,7 @@ function GhgEmissions(props) {
           onValueChange={selected => handleChange('gases', selected)}
           theme={dropdownTheme}
         />
+        {renderDropdown('Calculations', 'calculation')}
         {renderDropdown('Show data by', 'breakBy')}
         {renderDropdown(null, 'chartType', icons, {
           variant: 'icons-labels',

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -19,8 +19,12 @@ import {
   getSelection
 } from './ghg-emissions-selectors-get';
 
+const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
+
 const DEFAULTS = {
-  breakBy: 'regions',
+  breakBy: FEATURE_NEW_GHG
+    ? 'regions'
+    : `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`,
   calculation: CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
 };
 
@@ -31,7 +35,7 @@ const getOptionSelectedFunction = filter => (options, selected) => {
     return defaultOption || options[0];
   }
 
-  if (filter === 'breakBy') {
+  if (FEATURE_NEW_GHG && filter === 'breakBy') {
     return options.find(
       o => o.value === selected || selected.startsWith(o.value) // to support legacy URL
     );
@@ -73,24 +77,48 @@ const getCalculationOptions = () => [
 ];
 
 // BreakBy selectors
-const getBreakByOptions = () => [
-  {
-    label: 'Regions',
-    value: 'regions'
-  },
-  {
-    label: 'Regions-Total Aggregated',
-    value: 'aggregated'
-  },
-  {
-    label: 'Sectors',
-    value: 'sector'
-  },
-  {
-    label: 'Gases',
-    value: 'gas'
-  }
-];
+const getBreakByOptions = () =>
+  (FEATURE_NEW_GHG
+    ? [
+      {
+        label: 'Regions',
+        value: 'regions'
+      },
+      {
+        label: 'Regions-Total Aggregated',
+        value: 'aggregated'
+      },
+      {
+        label: 'Sectors',
+        value: 'sector'
+      },
+      {
+        label: 'Gases',
+        value: 'gas'
+      }
+    ]
+    : [
+      {
+        label: 'Regions',
+        value: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
+      },
+      {
+        label: 'Regions-Per Capita',
+        value: `regions-${CALCULATION_OPTIONS.PER_CAPITA.value}`
+      },
+      {
+        label: 'Regions-Per GDP',
+        value: `regions-${CALCULATION_OPTIONS.PER_GDP.value}`
+      },
+      {
+        label: 'Sectors',
+        value: 'sector'
+      },
+      {
+        label: 'Gases',
+        value: 'gas'
+      }
+    ]);
 
 const getCalculationSelected = createSelector(
   [getCalculationOptions, getSelection('calculation')],

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -50,7 +50,11 @@ $min-height: 500px;
   }
 
   @media #{$tablet-landscape} {
-    @include columns((1.8, 1.8, 1.8, 1.8, 1.8, 1.8, 1.2));
+    @include columns((2.1, 2.1, 2.1, 2.1, 2.1, 1.4));
+
+    &.newGHG {
+      @include columns((1.8, 1.8, 1.8, 1.8, 1.8, 1.8, 1.2));
+    }
 
     align-items: flex-end;
   }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-styles.scss
@@ -50,7 +50,7 @@ $min-height: 500px;
   }
 
   @media #{$tablet-landscape} {
-    @include columns((2.1, 2.1, 2.1, 2.1, 2.1, 1.4));
+    @include columns((1.8, 1.8, 1.8, 1.8, 1.8, 1.8, 1.2));
 
     align-items: flex-end;
   }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -52,9 +52,18 @@ function GhgEmissionsContainer(props) {
     handleAnalytics('Historical Emissions', 'Break by selected', breakBy.label);
   };
 
+  const handleCalculationChange = calculation => {
+    updateUrlParam({ name: 'calculation', value: calculation.value });
+    handleAnalytics(
+      'Historical Emissions',
+      'Calculation selected',
+      calculation.label
+    );
+  };
+
   const handleChartTypeChange = type => {
     updateUrlParam({ name: 'chartType', value: type.value });
-    handleAnalytics('Chart Type', 'chart type selected', type.label);
+    handleAnalytics('Chart Type', 'Chart type selected', type.label);
   };
 
   const handleRegionsChange = filters => {
@@ -97,6 +106,7 @@ function GhgEmissionsContainer(props) {
       regions: handleRegionsChange,
       sources: handleSourcesChange,
       breakBy: handleBreakByChange,
+      calculation: handleCalculationChange,
       chartType: handleChartTypeChange
     };
     return changeFunctions[field](optionSelected);


### PR DESCRIPTION
This PR splits the breakBy dropdown into breakBy and calculation. The legacy URLs as in https://www.climatewatchdata.org/ghg-emissions?breakBy=regions-PER_GDP are also parsed correctly

![image](https://user-images.githubusercontent.com/9701591/80088377-b6e27000-855c-11ea-95c3-04cac411304b.png)

Try: Go to GHG emissions. defaults and change dropdowns should work. Also, try some legacy URLs
