### PR TITLE
Fix data zoom filter changes

### DIFF
--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
@@ -6,14 +6,12 @@ import DataZoomComponent from './data-zoom-component';
 const PADDING = 20;
 
 function DataZoomContainer(props) {
-  const { data, onYearChange } = props;
+  const { data, onYearChange, position, setPosition } = props;
 
   const steps = data && data.length - 1;
 
   const dataZoomRef = useRef();
   const [width, setWidth] = useState(0);
-  const [position, setPosition] = useState({ min: 0, max: width - PADDING });
-
   useEffect(() => {
     if (dataZoomRef.current) {
       const debouncedSetWidth = debounce(
@@ -65,7 +63,9 @@ function DataZoomContainer(props) {
 
 DataZoomContainer.propTypes = {
   data: PropTypes.array,
-  onYearChange: PropTypes.func.isRequired
+  onYearChange: PropTypes.func.isRequired,
+  position: PropTypes.object.isRequired,
+  setPosition: PropTypes.func.isRequired
 };
 
 export default DataZoomContainer;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -86,7 +86,9 @@ function GhgEmissions(props) {
     handleDownloadDataClick,
     handleInfoClick,
     setColumnWidth,
-    downloadLink
+    downloadLink,
+    dataZoomPosition,
+    setDataZoomPosition
   } = props;
 
   const renderDropdown = (label, field, dropdownIcons, extraProps) => {
@@ -165,6 +167,8 @@ function GhgEmissions(props) {
             !loading && (
               <DataZoom
                 data={dataZoomData}
+                position={dataZoomPosition}
+                setPosition={setDataZoomPosition}
                 onYearChange={(min, max) => setYears({ min, max })}
               />
             )
@@ -302,7 +306,9 @@ GhgEmissions.propTypes = {
   providerFilters: PropTypes.object,
   loading: PropTypes.bool,
   downloadLink: PropTypes.string,
-  hideRemoveOptions: PropTypes.bool
+  hideRemoveOptions: PropTypes.bool,
+  dataZoomPosition: PropTypes.object,
+  setDataZoomPosition: PropTypes.func.isRequired
 };
 
 export default GhgEmissions;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -33,6 +33,33 @@ function GhgEmissionsContainer(props) {
     tableData,
     data
   } = props;
+
+  // Data Zoom Logic
+  const DATA_ZOOM_START_POSITION = {
+    min: 0,
+    max: 0
+  };
+  const [dataZoomPosition, setDataZoomPosition] = useState(
+    DATA_ZOOM_START_POSITION
+  );
+  const [years, setYears] = useState(null);
+  const [updatedData, setUpdatedData] = useState(data);
+
+  const resetDataZoom = () => {
+    setDataZoomPosition(DATA_ZOOM_START_POSITION);
+    setYears(null);
+  };
+
+  useEffect(() => {
+    if (data) {
+      if (years) {
+        setUpdatedData(data.filter(d => d.x >= years.min && d.x <= years.max));
+      } else {
+        setUpdatedData(data);
+      }
+    }
+  }, [years, data]);
+
   useEffect(() => {
     const { sourceSelected } = selected;
     if (!(search && search.source) && sourceSelected) {
@@ -52,6 +79,7 @@ function GhgEmissionsContainer(props) {
       { name: 'sectors', value: null },
       { name: 'gases', value: null }
     ]);
+    resetDataZoom();
     handleAnalytics('Historical Emissions', 'Source selected', category.label);
   };
 
@@ -143,19 +171,6 @@ function GhgEmissionsContainer(props) {
     return 200;
   };
 
-  // Data Zoom Logic
-  const [years, setYears] = useState(null);
-  const [updatedData, setUpdatedData] = useState(data);
-  useEffect(() => {
-    if (data) {
-      if (years) {
-        setUpdatedData(data.filter(d => d.x >= years.min && d.x <= years.max));
-      } else {
-        setUpdatedData(data);
-      }
-    }
-  }, [years, data]);
-
   return (
     <GhgEmissionsComponent
       {...props}
@@ -166,6 +181,8 @@ function GhgEmissionsContainer(props) {
       handleDownloadDataClick={handleDownloadDataClick}
       setColumnWidth={setColumnWidth}
       setYears={setYears}
+      dataZoomPosition={dataZoomPosition}
+      setDataZoomPosition={setDataZoomPosition}
     />
   );
 }


### PR DESCRIPTION
This PR fixes the data zoom problems when we changed the dropdowns on the GHG emissions.

- When we change the source: The Data zoom is reset and the user will have to change it again (This is needed as the years might not be the same)
- When we change other filters: The Data zoom handles are kept

![image](https://user-images.githubusercontent.com/9701591/80240516-3dcd4080-8662-11ea-96c1-30f5726877a8.png)
