### PR TITLE
Updates indc importer to consume Pledges data

### DIFF
--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -51,6 +51,7 @@ platforms:
           - NDC_metadata
           - NDC_single_version
           - NDC_documents
+          - pledges_data
       - name: locations
         importer: ImportLocations
         datasets:


### PR DESCRIPTION
This PR enables importing Pledges data that will be used on the Compare All page.

You will need to run a couple of tasks to test this:

```
bundle exec rails db:admin_boilerplate:create 
bundle exec rails indc:import
```

Make sure you are pointing to the staging folder on the CW_FILES_PREFIX env var.

I decided to merge the Pledges' legend and metadata information with the NDC_legend and NDC_metadata file, as it makes it more standard. And so we only have one extra file which is the pledges_data file.
I also added a new document into the NDC_Documents to represent the pledges.

You can see that it works if there's data for pledges on this endpoint: http://localhost:3000/api/v1/ndcs/countries_documents?location=AUS