### PR TITLE
Enables comparison betweeen locations-documents

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -145,9 +145,9 @@ module Api
       end
 
       def locations_documents
-        return nil unless params[:locations_docs].present?
+        return nil unless params[:locations_documents].present?
 
-        params[:locations_docs].split(',').map do |loc_doc|
+        params[:locations_documents].split(',').map do |loc_doc|
           loc_doc.split('-')
         end
       end

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -95,7 +95,8 @@ module Api
         end
 
         render json: NdcIndicators.new(indicators, categories, sectors),
-               serializer: Api::V1::Indc::NdcIndicatorsSerializer
+               serializer: Api::V1::Indc::NdcIndicatorsSerializer,
+               locations_documents: locations_documents
       end
       # rubocop:enable MethodLength, AbcSize
 
@@ -140,6 +141,14 @@ module Api
           nil
         else
           params[:location].split(',')
+        end
+      end
+
+      def locations_documents
+        return nil unless params[:locations_docs].present?
+
+        params[:locations_docs].split(',').map do |loc_doc|
+          loc_doc.split('-')
         end
       end
     end

--- a/app/models/indc/indicator.rb
+++ b/app/models/indc/indicator.rb
@@ -9,5 +9,16 @@ module Indc
     validates :slug, presence: true
     validates :name, presence: true
     validates :slug, uniqueness: true
+
+    # format of the expected params is:
+    # [[iso_code3, doc_slug], [iso_code3, doc_slug]]
+    def values_for(locations_documents)
+      result = values.includes(:document, :location).joins(:document, :location)
+      where_clause = locations_documents.map do |loc, doc|
+        "(locations.iso_code3 = '#{loc}' AND indc_documents.slug = '#{doc}')"
+      end.join(' OR ')
+
+      result.where(where_clause)
+    end
   end
 end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -24,8 +24,13 @@ module Api
         end
 
         def locations
+          values = if instance_options[:locations_documents]
+                     object.values_for instance_options[:locations_documents]
+                   else
+                     object.values
+                   end
           IndexedSerializer.serialize_collection(
-            object.values,
+            values,
             serializer: ValueSerializer
           ) do |v|
             v.location.iso_code3


### PR DESCRIPTION
This PR implements the changes to enable comparing NDC indicators between countries and different documents, it builds on the existing endpoint to enable a new parameter:

e.g.:
`locations_documents=ALB-first_ndc,DZA-indc`

This will be used instead of the current `location` parameter.

The route is then:

`/api/v1/ndcs?locations_documents=DZA-indc,ALB-first_ndc&category=overview&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer`


It expects a comma separated list of {iso-code3}-{document_slugs} pairs.

This endpoint doesn't yet include all of the data, as some bits are still work in progress, but they won't change the format of neither the request nor the response.

In regards to the laws and policies that is still missing overall, but we'll try to use the same endpoint for those as well. More on that later.