### PR TITLE
Remove the FEATURE_NEW_GHG from the id to slug changes

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -25,8 +25,6 @@ import {
   DATA_SCALE
 } from 'data/constants';
 
-const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
-
 // constants needed for data parsing
 const BASE_COLORS = ['#25597C', '#DFE9ED'];
 
@@ -98,10 +96,7 @@ export const getSourceSelected = createSelector(
       return defaultSource || sources[0];
     }
 
-    if (FEATURE_NEW_GHG) {
-      return sources.find(category => category.name === selected);
-    }
-    return sources.find(category => category.value === selected);
+    return sources.find(category => category.name === selected);
   }
 );
 

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -33,8 +33,6 @@ import {
 
 const actions = { ...ownActions, ...modalActions };
 
-const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
-
 const mapStateToProps = (state, { location, match }) => {
   const { data, quantifications } = state.countryGhgEmissions;
   const calculationData = state.wbCountryData.data;
@@ -137,7 +135,7 @@ class CountryGhgEmissionsContainer extends PureComponent {
         [
           {
             name: 'source',
-            value: FEATURE_NEW_GHG ? category.name : category.value
+            value: category.name
           },
           { name: 'sector', value: searchQuery.sector },
           { name: 'calculation', value: searchQuery.calculation }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -5,11 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
-import {
-  getGhgEmissionDefaultSlugs,
-  getGhgEmissionDefaults,
-  toPlural
-} from 'utils/ghg-emissions';
+import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -301,10 +297,7 @@ const getDefaults = createSelector(
   [getSourceSelected, getMeta],
   (sourceSelected, meta) => {
     if (!sourceSelected || !meta) return null;
-    if (FEATURE_NEW_GHG) {
-      return getGhgEmissionDefaultSlugs(sourceSelected, meta);
-    }
-    return getGhgEmissionDefaults(sourceSelected, meta);
+    return getGhgEmissionDefaultSlugs(sourceSelected, meta);
   }
 );
 
@@ -339,10 +332,7 @@ const getFiltersSelected = field =>
       if (selection) {
         const selectedValues = selection.split(',');
         selectedFilters = fieldOptions.filter(filter =>
-          (FEATURE_NEW_GHG
-            ? isIncluded(field, selectedValues, filter)
-            : selectedValues.includes(String(filter.value)) ||
-              selectedValues.includes(filter.iso_code3))
+          isIncluded(field, selectedValues, filter)
         );
       }
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -15,8 +15,6 @@ import { GHG_TABLE_HEADER } from 'data/constants';
 import GhgEmissionsComponent from './ghg-emissions-component';
 import { getGHGEmissions } from './ghg-emissions-selectors/ghg-emissions-selectors';
 
-const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
-
 const mapStateToProps = (state, props) => {
   const { location } = props;
   const search = location && location.search && qs.parse(location.search);
@@ -66,7 +64,7 @@ function GhgEmissionsContainer(props) {
     if (!(search && search.source) && sourceSelected) {
       updateUrlParam({
         name: 'source',
-        value: FEATURE_NEW_GHG ? sourceSelected.name : sourceSelected.value
+        value: sourceSelected.name
       });
     }
   }, []);
@@ -75,7 +73,7 @@ function GhgEmissionsContainer(props) {
     updateUrlParam([
       {
         name: 'source',
-        value: FEATURE_NEW_GHG ? category.name : category.value
+        value: category.name
       },
       { name: 'sectors', value: null },
       { name: 'gases', value: null }
@@ -129,7 +127,7 @@ function GhgEmissionsContainer(props) {
     updateUrlParam({
       name: [field],
       value: castArray(filters)
-        .map(v => (FEATURE_NEW_GHG ? kebabCase(v.label) : v.value))
+        .map(v => kebabCase(v.label))
         .join(',')
     });
     sendToAnalitics(field, filters);


### PR DESCRIPTION
This PR Removes the FEATURE_NEW_GHG from the id to slug changes

Try: Go to the GHG emissions page with the flag on false. And try that the slugs are used instead of the ids on the URL when you change the source, gas and sector filters. Also on the country pages (GHG chart source)