### PR TITLE
Enable comparing indicators across different sources/types of documents

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -127,6 +127,12 @@ module Api
             where(locations: {iso_code3: locations_documents.map(&:first)},
                   indc_documents: {slug: locations_documents.map(&:second)})
         end
+
+        if params[:category]
+          parent = ::Indc::Category.includes(:category_type).
+            where(indc_category_types: {name: 'global'}, slug: params[:category])
+          indicators = indicators.joins(:categories).where(indc_categories: {parent_id: parent.map(&:id)})
+        end
         indicators.sort_by{|i| i.order}
       end
 

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -40,65 +40,15 @@ module Api
     end
 
     class NdcsController < ApiController
-      # rubocop:disable MethodLength, AbcSize
       def index
-        sectors = ::Indc::Sector.
-          all
-
-        categories = ::Indc::Category.
-          includes(:category_type).
-          order(:order)
-
-        # params[:filter] -> ['map', 'table']
-        if params[:filter]
-          categories = categories.where(
-            indc_category_types: {name: params[:filter]}
-          )
-        end
-
-        indicators = ::Indc::Indicator.
-          includes(:labels, :source, :categories,
-                   values: [:sector, :label, :location, :document]).
-          order(:order)
-
-        # params[:source] -> one of ["CAIT", "LTS", "WB", "NDC Explorer"]
-        if params[:source]
-          source = ::Indc::Source.where(name: params[:source])
-          indicators = indicators.where(source_id: source.map(&:id))
-        end
-
-        if params[:category]
-          parent = ::Indc::Category.
-            includes(:category_type).
-            where(
-              indc_category_types: {name: 'global'},
-              slug: params[:category]
-            )
-
-          categories = categories.
-            where(
-              parent_id: parent.map(&:id)
-            )
-        end
-
-        categories = categories.where(id: indicators.flat_map(&:category_ids).uniq)
-
-        if location_list
-          indicators = indicators.where(
-            values: {locations: {iso_code3: location_list}}
-          )
-        end
-
-        if params[:document]
-          indicators = indicators.
-            where(values: {indc_documents: {slug: [params[:document], nil]}})
-        end
+        sectors = ::Indc::Sector.all
+        indicators = filtered_indicators
+        categories = filtered_categories(indicators)
 
         render json: NdcIndicators.new(indicators, categories, sectors),
                serializer: Api::V1::Indc::NdcIndicatorsSerializer,
                locations_documents: locations_documents
       end
-      # rubocop:enable MethodLength, AbcSize
 
       def content_overview
         location = Location.find_by!(iso_code3: params[:code])
@@ -150,6 +100,52 @@ module Api
         params[:locations_documents].split(',').map do |loc_doc|
           loc_doc.split('-')
         end
+      end
+
+      def filtered_indicators
+        indicators = ::Indc::Indicator.includes(:labels, :source, :categories,
+                                                values: [:sector, :label, :location,
+                                                         :document])
+
+        if location_list
+          indicators = indicators.where(values: {locations: {iso_code3: location_list}})
+        end
+
+        if params[:document]
+          indicators = indicators.where(values: {indc_documents: {slug: [params[:document], nil]}})
+        end
+
+        # params[:source] -> one of ["CAIT", "LTS", "WB", "NDC Explorer"]
+        if params[:source]
+          source = ::Indc::Source.where(name: params[:source])
+          indicators = indicators.where(source_id: source.map(&:id))
+        end
+
+        if locations_documents
+          indicators = indicators.select('DISTINCT ON(COALESCE("normalized_slug", indc_indicators.slug)) indc_indicators.*')
+          indicators = indicators.joins(values: [:location, :document]).
+            where(locations: {iso_code3: locations_documents.map(&:first)},
+                  indc_documents: {slug: locations_documents.map(&:second)})
+        end
+        indicators.sort_by{|i| i.order}
+      end
+
+      def filtered_categories(indicators)
+        categories = ::Indc::Category.includes(:category_type).order(:order)
+
+        # params[:filter] -> ['map', 'table']
+        if params[:filter]
+          categories = categories.where(indc_category_types: {name: params[:filter]})
+        end
+
+        if params[:category]
+          parent = ::Indc::Category.includes(:category_type).
+            where(indc_category_types: {name: 'global'}, slug: params[:category])
+
+          categories = categories.where(parent_id: parent.map(&:id))
+        end
+
+        categories.where(id: indicators.flat_map(&:category_ids).uniq)
       end
     end
   end

--- a/app/models/indc/indicator.rb
+++ b/app/models/indc/indicator.rb
@@ -13,7 +13,13 @@ module Indc
     # format of the expected params is:
     # [[iso_code3, doc_slug], [iso_code3, doc_slug]]
     def values_for(locations_documents)
-      result = values.includes(:document, :location).joins(:document, :location)
+      result = if normalized_slug
+                 Indc::Value.joins(:indicator).
+                   where(indc_indicators: {normalized_slug: normalized_slug})
+               else
+                 values
+               end
+      result = result.includes(:document, :location).joins(:document, :location)
       where_clause = locations_documents.map do |loc, doc|
         "(locations.iso_code3 = '#{loc}' AND indc_documents.slug = '#{doc}')"
       end.join(' OR ')

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -11,11 +11,25 @@ module Api
         attribute :labels
         attribute :locations
 
+        def name
+          object.normalized_label.presence || object.name
+        end
+
+        def slug
+          object.normalized_slug.presence || object.slug
+        end
+
         def source
           object.source.name
         end
 
         def labels
+          labels = if object.normalized_slug
+                     ::Indc::Label.joins(:indicator).
+                       where(indc_indicators: {normalized_slug: object.normalized_slug})
+                   else
+                     object.labels
+                   end
           IndexedSerializer.serialize(
             object.labels,
             serializer: LabelSerializer,

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -52,6 +52,7 @@ platforms:
           - NDC_single_version
           - NDC_documents
           - pledges_data
+          - comparison_matrix
       - name: locations
         importer: ImportLocations
         datasets:

--- a/db/migrate/20200503165104_add_normalized_slug_and_normalized_label_to_indc_indicators.rb
+++ b/db/migrate/20200503165104_add_normalized_slug_and_normalized_label_to_indc_indicators.rb
@@ -1,0 +1,6 @@
+class AddNormalizedSlugAndNormalizedLabelToIndcIndicators < ActiveRecord::Migration[5.2]
+  def change
+    add_column :indc_indicators, :normalized_slug, :string
+    add_column :indc_indicators, :normalized_label, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -959,7 +959,9 @@ CREATE TABLE public.indc_indicators (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     "order" integer,
-    multiple_versions boolean
+    multiple_versions boolean,
+    normalized_slug character varying,
+    normalized_label character varying
 );
 
 
@@ -4240,6 +4242,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200317204602'),
 ('20200317210227'),
 ('20200317210928'),
-('20200423085052');
+('20200423085052'),
+('20200503165104');
 
 

--- a/spec/controllers/api/v1/ndcs_controller_spec.rb
+++ b/spec/controllers/api/v1/ndcs_controller_spec.rb
@@ -37,5 +37,35 @@ describe Api::V1::NdcsController, type: :controller do
         expect(response).to be_not_found
       end
     end
+
+    describe 'GET index filtered by PRT-indc' do
+      it 'returns a successful 200 response' do
+        code = some_indc_values.first.values.first.location.iso_code3
+        slug = some_indc_values.first.values.first.document.slug
+        get :index, params: {locations_documents: "#{code}-#{slug}"}
+        expect(response).to be_successful
+      end
+
+      it 'lists all relevant indc indicators' do
+        source = some_indc_values.first.source.name
+        code = some_indc_values.first.values.first.location.iso_code3
+        slug = some_indc_values.first.values.first.document.slug
+        get :index, params: {source: source, locations_documents: "#{code}-#{slug}"}
+        expect(parsed_body['indicators'].length).to eq(1)
+      end
+
+      it 'lists all relevant normalized indc indicators' do
+        ind = some_indc_values.first
+        ind.normalized_slug = 'derpish'
+        ind.save
+        ind.reload
+        source = ind.source.name
+        code = ind.values.first.location.iso_code3
+        slug = ind.values.first.document.slug
+        get :index, params: {source: source, locations_documents: "#{code}-#{slug}"}
+        expect(parsed_body['indicators'].length).to eq(1)
+        expect(parsed_body['indicators'].first['slug']).to eq('derpish')
+      end
+    end
   end
 end

--- a/spec/factories/indc_documents.rb
+++ b/spec/factories/indc_documents.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :indc_document, class: 'Indc::Document' do
-    ordering { "" }
-    slug { "MyString" }
+    sequence(:ordering) { |n| n }
+    sequence(:slug) { |n| "#{n}_document" }
     long_name { "MyString" }
     description { "MyText" }
   end

--- a/spec/factories/indc_values.rb
+++ b/spec/factories/indc_values.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     association :indicator, factory: :indc_indicator
     association :label, factory: :indc_label
     association :sector, factory: :indc_sector
+    association :document, factory: :indc_document
     value { 'myvalue' }
   end
 end


### PR DESCRIPTION
This PR implements the comparison of indicators across Pledges, INDC and LTS. It does this by adding a `normalized_slug` and `normalized_label` to the Indc::Indicators, and when fetching the data finding only one of the normalized indicators and grouping the data across the documents under that one.

This doesn't require any change on the front end, as the endpoint doesn't change. 

To test it you should run:

```
bundle exec rails db:migrate
bundle exec rails db:admin_boilerplate:create
```

And then reimport the indc data from staging:

`bundle exec rails indc:import`

You should now be able to compare data from Pledges and First NDC for instance, or in the endpoint: http://localhost:3000/api/v1/ndcs?locations_documents=AUS-pledges,ALB-first_ndc&category=overview&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer , you should get this indicator: `nrm_summary`, which merges data from `indc_summary` and `pledges_summary`.

I have added some specs to test this out, and refactored the controller a little to tidy it up, and to only return indicators with data, so less data to be handled by the frontend.
