### PR TITLE
Feature/ghg new calculations

### DIFF
--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-actions.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-actions.js
@@ -1,0 +1,7 @@
+import { createAction } from 'redux-actions';
+
+export const setYears = createAction('setYears');
+
+export default {
+  setYears
+};

--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-reducers.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-reducers.js
@@ -1,0 +1,7 @@
+export const initialState = {
+  years: null
+};
+
+const setYears = (state, { payload }) => ({ ...state, years: payload });
+
+export default { setYears };

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -4,10 +4,9 @@ import startCase from 'lodash/startCase';
 import isArray from 'lodash/isArray';
 import { isPageContained } from 'utils/navigation';
 import cx from 'classnames';
-import { GHG_TABLE_HEADER } from 'data/constants';
-import { Multiselect, MultiLevelDropdown, Dropdown } from 'cw-components';
+import { GHG_TABLE_HEADER, CALCULATION_OPTIONS } from 'data/constants';
+import { Chart, Multiselect, MultiLevelDropdown, Dropdown } from 'cw-components';
 import LegendChart from 'components/charts/legend-chart';
-import Chart from 'components/charts/chart';
 import EmissionsMetaProvider from 'providers/ghg-emissions-meta-provider';
 import EmissionsProvider from 'providers/emissions-provider';
 import RegionsProvider from 'providers/regions-provider';
@@ -21,6 +20,7 @@ import ModalMetadata from 'components/modal-metadata';
 import ModalShare from 'components/modal-share';
 import { TabletPortraitOnly, TabletLandscape } from 'components/responsive';
 import { toPlural } from 'utils/ghg-emissions';
+import { format } from 'd3-format';
 
 import lineIcon from 'assets/icons/line_chart.svg';
 import areaIcon from 'assets/icons/area_chart.svg';
@@ -223,7 +223,11 @@ function GhgEmissions(props) {
     }
 
     const tableDataReady = !loading && tableData && tableData.length;
-
+    const isPercentageChangeCalculation =
+      selectedOptions.calculationSelected.value ===
+      CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
+    const percentageChangeCustomLabelFormat = value =>
+      (value ? `${format('.2r')(value)}` : 0);
     return (
       <React.Fragment>
         <Chart
@@ -241,6 +245,11 @@ function GhgEmissions(props) {
           showUnit
           onLegendChange={v => handleChange(toPlural(fieldToBreakBy), v)}
           hideRemoveOptions={hideRemoveOptions}
+          getCustomYLabelFormat={
+            isPercentageChangeCalculation
+              ? percentageChangeCustomLabelFormat
+              : undefined
+          }
           dataZoomComponent={
             FEATURE_NEW_GHG &&
             !loading && (

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -226,8 +226,14 @@ function GhgEmissions(props) {
     const isPercentageChangeCalculation =
       selectedOptions.calculationSelected.value ===
       CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
-    const percentageChangeCustomLabelFormat = value =>
-      (value ? `${format('.2r')(value)}` : 0);
+
+    const percentageChangeCustomLabelFormat = value => {
+      if (value === undefined) {
+        return 'n/a';
+      }
+      return value ? `${format('.2r')(value)}%` : '0%';
+    };
+
     return (
       <React.Fragment>
         <Chart

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -29,7 +29,8 @@ import {
   getWBData,
   getData,
   getRegions,
-  getCountries
+  getCountries,
+  getDataZoomYears
 } from './ghg-emissions-selectors-get';
 import {
   getModelSelected,
@@ -311,7 +312,8 @@ export const getChartData = createSelector(
     getYColumnOptions,
     getMetricSelected,
     getCalculationData,
-    getCalculationSelected
+    getCalculationSelected,
+    getDataZoomYears
   ],
   (
     data,
@@ -320,7 +322,8 @@ export const getChartData = createSelector(
     yColumnOptions,
     metric,
     calculationData,
-    calculationSelected
+    calculationSelected,
+    dataZoomYears
   ) => {
     if (
       !data ||
@@ -395,13 +398,15 @@ export const getChartData = createSelector(
     const accumulatedValues = {};
     const previousYearValues = {};
 
-    const getItemValue = (totalValue, key, totalMetric) => {
+    const getItemValue = (totalValue, key, totalMetric, year) => {
       let scaledValue = totalValue ? totalValue * DATA_SCALE : null;
 
       if (calculationSelected.value === CALCULATION_OPTIONS.CUMULATIVE.value) {
         if (scaledValue) {
           if (accumulatedValues[key]) {
-            accumulatedValues[key] += scaledValue;
+            if (!dataZoomYears || year > dataZoomYears.min) {
+              accumulatedValues[key] += scaledValue;
+            }
           } else {
             accumulatedValues[key] = scaledValue;
           }
@@ -452,7 +457,7 @@ export const getChartData = createSelector(
           }
         });
 
-        yItems[key] = getItemValue(totalValue, key, totalMetric);
+        yItems[key] = getItemValue(totalValue, key, totalMetric, year);
       });
 
       dataParsed.push({

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -419,7 +419,7 @@ export const getChartData = createSelector(
           scaledValue = previousValue
             ? ((scaledValue - previousYearValues[key]) * 100) /
               previousYearValues[key]
-            : 0;
+            : 'n/a';
         }
         previousYearValues[key] = currentYearValue;
       }
@@ -534,7 +534,7 @@ export const getChartConfig = createSelector(
         yLeft: {
           ...DEFAULT_AXES_CONFIG.yLeft,
           unit,
-          suffix: isPercentageChangeCalculation ? '%' : 't'
+          suffix: isPercentageChangeCalculation ? '' : 't'
         }
       },
       theme: colorThemeCache,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -61,20 +61,15 @@ const getSourceSelected = createSelector(
 );
 
 // Calculation selectors
-const getCalculationOptions = () => [
-  {
-    label: 'Total',
-    value: CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
-  },
-  {
-    label: 'Per Capita',
-    value: CALCULATION_OPTIONS.PER_CAPITA.value
-  },
-  {
-    label: 'Per GDP',
-    value: CALCULATION_OPTIONS.PER_GDP.value
-  }
-];
+const getCalculationOptions = () =>
+  Object.keys(CALCULATION_OPTIONS).reduce(
+    (acc, key) =>
+      acc.concat({
+        label: CALCULATION_OPTIONS[key].label,
+        value: CALCULATION_OPTIONS[key].value
+      }),
+    []
+  );
 
 // BreakBy selectors
 const getBreakByOptions = () =>

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -115,7 +115,7 @@ const getBreakByOptions = () =>
       }
     ]);
 
-const getCalculationSelected = createSelector(
+export const getCalculationSelected = createSelector(
   [getCalculationOptions, getSelection('calculation'), getSelection('breakBy')],
   (options, selected, breakBySelected) => {
     if (!options) return null;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -400,7 +400,7 @@ const getChartConflicts = (metricSelected, chartSelected) => {
   const conflicts = [];
 
   if (
-    ['PER_CAPITA', 'PER_GDP'].includes(metricSelected) &&
+    ['PER_CAPITA', 'PER_GDP', 'PERCENTAGE_CHANGE'].includes(metricSelected) &&
     chartSelected.value !== 'line'
   ) {
     const metricOption = CALCULATION_OPTIONS[metricSelected];

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -7,6 +7,8 @@ export const getData = ({ emissions }) => (emissions && emissions.data) || [];
 export const getMeta = ({ ghgEmissionsMeta }) =>
   (ghgEmissionsMeta && ghgEmissionsMeta.meta) || null;
 export const getRegions = ({ regions }) => (regions && regions.data) || null;
+export const getDataZoomYears = ({ dataZoom }) =>
+  (dataZoom && dataZoom.years) || null;
 export const getCountries = ({ countries }) =>
   (countries && countries.data) || null;
 export const getSources = createSelector(

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -1,7 +1,8 @@
 import { createStructuredSelector } from 'reselect';
 import {
   getSearch,
-  getLinkToDataExplorer
+  getLinkToDataExplorer,
+  getDataZoomYears
 } from './ghg-emissions-selectors-get';
 import {
   getOptions,
@@ -37,6 +38,7 @@ export const getGHGEmissions = createStructuredSelector({
   domain: getChartDomain,
   config: getChartConfig,
   dataZoomData: getDataZoomData,
+  dataZoomYears: getDataZoomYears,
   loading: getLoading,
   fieldToBreakBy: getModelSelected,
   hideRemoveOptions: getHideRemoveOptions,

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -18,7 +18,7 @@ export const SOCIAL_APP_NAMES = ['twitter', 'facebook', 'google'];
 
 export const CALCULATION_OPTIONS = {
   ABSOLUTE_VALUE: {
-    label: 'Absolute value',
+    label: 'Total',
     value: 'ABSOLUTE_VALUE'
   },
   PER_CAPITA: {
@@ -28,6 +28,14 @@ export const CALCULATION_OPTIONS = {
   PER_GDP: {
     label: 'per GDP',
     value: 'PER_GDP'
+  },
+  CUMULATIVE: {
+    label: 'Cumulative across available years',
+    value: 'CUMULATIVE'
+  },
+  PERCENTAGE_CHANGE: {
+    label: 'Percentage change from prior year',
+    value: 'PERCENTAGE_CHANGE'
   }
 };
 

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -122,6 +122,7 @@ import * as myVisualisationsCreator from 'components/my-climate-watch/viz-creato
 import * as myVisualisationsGraphComponent from 'components/my-climate-watch/my-visualisations/my-cw-vis-graph';
 import * as ndcSdgLinkagesComponent from 'components/ndc-sdg/ndc-sdg-linkages-content';
 import * as HamburgerComponent from 'components/hamburger';
+import * as GHGComponent from 'components/ghg-emissions/ghg-emissions';
 import * as AnchorNavComponent from 'components/anchor-nav';
 
 const componentsReducers = {
@@ -144,6 +145,7 @@ const componentsReducers = {
   espGraph: handleActions(espGraphComponent),
   ndcSdg: handleActions(ndcSdgLinkagesComponent),
   hamburger: handleActions(HamburgerComponent),
+  dataZoom: handleActions(GHGComponent),
   anchorNav: handleActions(AnchorNavComponent)
 };
 

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -11,7 +11,7 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
+SET default_with_oids = false;
 
 --
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,7 +30,7 @@ CREATE FUNCTION public.emissions_filter_by_year_range(emissions jsonb, start_yea
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
+SET default_with_oids = false;
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -


### PR DESCRIPTION
This PR adds two new calculation options to the GHG chart:

- Cumulative over years: This calculation sums the value of the prior years to show the accumulated value. This is data zoom selection dependant, so if we move the start year for the data zoom this is recalculated

![image](https://user-images.githubusercontent.com/9701591/80995402-7fb66d80-8e3e-11ea-96c5-43601a7ed1c4.png)

- Percentage Change: Each year presents the percentage of change compared to the previous year. The first year of data shows as blank in the chart and  'n/a' in the tooltip as it hasn't anything to compare too

![image](https://user-images.githubusercontent.com/9701591/80995670-e9367c00-8e3e-11ea-90cb-c7795e226a17.png)

