### PR TITLE
Fix/different documents data for the same country sectoral information

### DIFF
--- a/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
+++ b/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
@@ -27,14 +27,6 @@ export const getSelectedTargets = createSelector([getSearch], search => {
   });
 });
 
-export const getSelectedCountries = createSelector(
-  [getSelectedTargets],
-  selectedTargets => {
-    if (!selectedTargets) return null;
-    return selectedTargets.map(({ country }) => country);
-  }
-);
-
 export const parseIndicatorsDefs = createSelector(
   [getIndicators, getCategories, getSelectedTargets],
   (indicators, categories, selectedTargets) => {
@@ -122,9 +114,9 @@ export const getCategoriesWithSectors = createSelector(
 
 // data for section 'SectoralInformation'
 export const getSectoralInformationData = createSelector(
-  [getCategoriesWithSectors, getSectors, getSelectedCountries],
-  (categoriesWithSectors, sectors, selectedCountries) => {
-    if (!categoriesWithSectors || !sectors || !selectedCountries) return null;
+  [getCategoriesWithSectors, getSectors, getSelectedTargets],
+  (categoriesWithSectors, sectors, selectedTargets) => {
+    if (!categoriesWithSectors || !sectors || !selectedTargets) return null;
     const sectoralInformationData = categoriesWithSectors.map(cat => {
       const sectorsParsed = sortBy(
         cat.sectors &&
@@ -132,18 +124,22 @@ export const getSectoralInformationData = createSelector(
           cat.sectors.map(sec => {
             const definitions = [];
             cat.indicators.forEach(ind => {
-              const descriptions = selectedCountries.map(loc => {
-                const valueObject = ind.locations[loc]
-                  ? ind.locations[loc].find(v => v.sector_id === sec)
-                  : null;
-                const value =
-                  (valueObject && valueObject.value) ||
-                  (isNaN(parseInt(loc, 10)) ? '-' : null);
-                return {
-                  iso: loc,
-                  value
-                };
-              });
+              const descriptions = selectedTargets.map(
+                ({ country, document }) => {
+                  const valueObject = ind.locations[country]
+                    ? ind.locations[country].find(
+                      v => v.sector_id === sec && v.document_slug === document
+                    )
+                    : null;
+                  const value =
+                    (valueObject && valueObject.value) ||
+                    (isNaN(parseInt(country, 10)) ? '-' : null);
+                  return {
+                    iso: country,
+                    value
+                  };
+                }
+              );
               definitions.push({
                 title: ind.name,
                 slug: ind.slug,

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -16,7 +16,7 @@ import {
   getIndicatorEmissionsData,
   getLabels
 } from 'components/ndcs/shared/utils';
-import { europeanSlug, europeanCountries } from 'app/data/european-countries';
+import { europeSlug, europeanCountries } from 'app/data/european-countries';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -265,7 +265,7 @@ const getCountriesAndParties = submissions => {
   const partiesNumber = submissions.length;
   let countriesNumber = submissions.length;
   const submissionIsos = submissions.map(s => s.iso_code3);
-  if (!submissionIsos.includes(europeanSlug)) {
+  if (!submissionIsos.includes(europeSlug)) {
     return { partiesNumber, countriesNumber };
   }
   const europeanCountriesWithSubmission = intersection(

--- a/app/javascript/app/providers/custom-compare-accordion-provider/custom-compare-accordion-provider.js
+++ b/app/javascript/app/providers/custom-compare-accordion-provider/custom-compare-accordion-provider.js
@@ -21,7 +21,7 @@ const CustomCompareAccordionProvider = ({
 };
 
 CustomCompareAccordionProvider.propTypes = {
-  locationsDocuments: PropTypes.array,
+  locationsDocuments: PropTypes.string,
   category: PropTypes.string,
   fetchCustomCompareAccordion: PropTypes.func.isRequired
 };


### PR DESCRIPTION
This PR fixes the issue in the `Sectoral information` section when the same values are displayed for different documents from the same country.
_bug:_
![image](https://user-images.githubusercontent.com/15097138/80999543-243bae00-8e45-11ea-94c7-f84aef2d8535.png)
_fix:_
![Screenshot_5](https://user-images.githubusercontent.com/15097138/80999590-361d5100-8e45-11ea-866d-4a3587d98ba8.png)

It also fixes the wrong `europeSlug` import in `ndcs-map.js`