### PR TITLE
Fix/remove source from custom compare provider

### DIFF
--- a/app/javascript/app/providers/custom-compare-accordion-provider/custom-compare-accordion-provider-actions.js
+++ b/app/javascript/app/providers/custom-compare-accordion-provider/custom-compare-accordion-provider-actions.js
@@ -17,7 +17,7 @@ const fetchCustomCompareAccordion = createThunkAction(
     if (locationsDocuments) {
       dispatch(fetchCustomCompareAccordionInit());
       fetch(
-        `/api/v1/ndcs?locations_documents=${locationsDocuments}&category=${category}&filter=overview&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer`
+        `/api/v1/ndcs?locations_documents=${locationsDocuments}&category=${category}&filter=overview`
       )
         .then(response => {
           if (response.ok) return response.json();

--- a/app/javascript/app/styles/themes/table/compare-table-theme.scss
+++ b/app/javascript/app/styles/themes/table/compare-table-theme.scss
@@ -5,6 +5,11 @@
   display: flex;
   align-items: center;
   margin-right: 0 !important; // Due to the :global in styles
+
+  a {
+    border-bottom: none !important;
+    text-decoration: underline !important;
+  }
 }
 
 .headerRow {


### PR DESCRIPTION
This PR removes the source params from the custom compare provider URL, which was filtering out the pledges & lts data. It also fixes the link underline on the compare-all-targets table:
[SLACK - remove source params](https://vizzuality.slack.com/archives/C6DFY8GVC/p1588614167010300) | [PIVOTAL - underline issue](https://www.pivotaltracker.com/story/show/172646780)
![image](https://user-images.githubusercontent.com/15097138/81057765-5b55a200-8ecd-11ea-8ac9-0970d9887fb5.png)
