### PR TITLE
Fix document options on ndc and full ndc documents

### DIFF
--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -1,12 +1,14 @@
 import { createSelector } from 'reselect';
 import uniqBy from 'lodash/uniqBy';
 
+const DEFAULT_LANGUAGE = 'EN';
+
 const getCountries = state => state.countries.data;
 const getSelected = state => state.document || null;
 const getContent = state => state.content || null;
 
 export const getCountry = createSelector(
-  [getCountries, (countries, iso) => iso],
+  [getCountries, (_, iso) => iso],
   (countries, iso) => countries.find(country => country.iso_code3 === iso)
 );
 
@@ -19,7 +21,7 @@ export const getSelectedContent = createSelector(
     return content.find(
       item =>
         item.document_type === splitSelected[0] &&
-        item.language === splitSelected[1],
+        (item.language === splitSelected[1] || DEFAULT_LANGUAGE),
       10
     );
   }
@@ -42,7 +44,14 @@ export const getContentOptionSelected = createSelector(
   [getSelected, getContentOptions],
   (selected, options) => {
     if (!selected) return options[0];
-    return options.find(option => option.value === selected);
+    // Allow finding document only by document name and default to English
+    return (
+      options.find(option => option.value === selected) ||
+      options.find(
+        option => option.value === `${selected}-${DEFAULT_LANGUAGE}`
+      ) ||
+      options.find(option => option.value.startsWith(selected))
+    );
   }
 );
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
+++ b/app/javascript/app/pages/ndc-country/ndc-country-component.jsx
@@ -9,7 +9,7 @@ import Search from 'components/search';
 import cx from 'classnames';
 import Sticky from 'react-stickynode';
 import AnchorNav from 'components/anchor-nav';
-import NdcsDocumentsMetaProvider from 'providers/ndcs-documents-meta-provider';
+import CountriesDocumentsProvider from 'providers/countries-documents-provider';
 import Dropdown from 'components/dropdown';
 import { Dropdown as CWDropdown } from 'cw-components';
 import { NDC_COUNTRY } from 'data/SEO';
@@ -39,6 +39,8 @@ function NDCCountry(props) {
     match
   } = props;
 
+  const { iso } = match.params;
+
   const renderDocumentsDropdown = () => (
     <Dropdown
       className={cx(styles.countryDropdown)}
@@ -54,9 +56,8 @@ function NDCCountry(props) {
   const renderFullTextButton = () => (
     <Button
       variant="secondary"
-      link={`/ndcs/country/${
-        match.params.iso
-      }/full?document=${documentSelected && documentSelected.value}`}
+      link={`/ndcs/country/${iso}/full?document=${documentSelected &&
+        documentSelected.value}`}
       className={styles.viewDocumentButton}
       disabled={!documentsOptions}
     >
@@ -69,7 +70,7 @@ function NDCCountry(props) {
       return (
         <Button
           variant="primary"
-          link={`/ndcs/compare/mitigation?locations=${match.params.iso}`}
+          link={`/ndcs/compare/mitigation?locations=${iso}`}
         >
           Compare
         </Button>
@@ -79,7 +80,7 @@ function NDCCountry(props) {
       <div className={styles.compareButtonContainer}>
         <Button
           variant="primary"
-          link={`/ndcs/compare/mitigation?locations=${match.params.iso}`}
+          link={`/ndcs/compare/mitigation?locations=${iso}`}
           className={styles.compareButton}
         >
           Compare Countries and Submissions
@@ -120,7 +121,7 @@ function NDCCountry(props) {
         descriptionContext={NDC_COUNTRY({ countryName })}
         href={location.href}
       />
-      <NdcsDocumentsMetaProvider />
+      <CountriesDocumentsProvider location={iso} />
       {country && (
         <Header route={route}>
           <div className={styles.header}>

--- a/app/javascript/app/pages/ndc-country/ndc-country.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country.js
@@ -17,20 +17,11 @@ import {
 const mapStateToProps = (state, { match, location, route }) => {
   const { iso } = match.params;
   const search = qs.parse(location.search);
-  const countryData = {
-    countries: state.countries.data,
-    iso: match.params.iso,
-    location
-  };
-  const routeData = {
+  const stateData = {
     iso,
+    route,
     location,
-    route
-  };
-  const documentsData = {
-    iso,
-    data: state.ndcsDocumentsMeta.data,
-    location
+    ...state
   };
   const pathname = location.pathname.split('/');
   const notSummary = [
@@ -41,12 +32,12 @@ const mapStateToProps = (state, { match, location, route }) => {
   ].includes(pathname[pathname.length - 1]);
 
   return {
-    countriesOptions: addUrlToCountries(countryData),
-    country: getCountry(countryData),
+    countriesOptions: addUrlToCountries(stateData),
+    country: getCountry(stateData),
     search: search.search,
-    anchorLinks: getAnchorLinks(routeData),
-    documentsOptions: getDocumentsOptions(documentsData),
-    documentSelected: getDocumentSelected(documentsData),
+    anchorLinks: getAnchorLinks(stateData),
+    documentsOptions: getDocumentsOptions(stateData),
+    documentSelected: getDocumentSelected(stateData),
     notSummary
   };
 };

--- a/app/javascript/app/providers/countries-documents-provider/countries-documents-provider-actions.js
+++ b/app/javascript/app/providers/countries-documents-provider/countries-documents-provider-actions.js
@@ -14,15 +14,18 @@ export const fetchCountriesDocumentsFail = createAction(
 
 export const fetchCountriesDocuments = createThunkAction(
   'fetchCountriesDocuments',
-  () => (dispatch, state) => {
+  location => (dispatch, state) => {
     const { countriesDocuments } = state();
     if (
-      countriesDocuments &&
-      isEmpty(countriesDocuments.data) &&
-      !countriesDocuments.loading
+      !countriesDocuments.loading &&
+      (isEmpty(countriesDocuments.data) ||
+        (!!location && isEmpty(countriesDocuments.data[location])))
     ) {
+      const url = `/api/v1/ndcs/countries_documents${
+        location ? `?location=${location}` : ''
+      }`;
       dispatch(fetchCountriesDocumentsInit());
-      fetch('/api/v1/ndcs/countries_documents')
+      fetch(url)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/javascript/app/providers/countries-documents-provider/countries-documents-provider.js
+++ b/app/javascript/app/providers/countries-documents-provider/countries-documents-provider.js
@@ -8,17 +8,24 @@ import * as actions from './countries-documents-provider-actions';
 
 class CountriesDocumentsProvider extends PureComponent {
   componentDidMount() {
-    const { fetchCountriesDocuments } = this.props;
-    fetchCountriesDocuments();
+    const { fetchCountriesDocuments, location } = this.props;
+    fetchCountriesDocuments(location);
   }
 
+  componentDidUpdate(prevProps) {
+    const { fetchCountriesDocuments, location } = this.props;
+    const { location: prevLocation } = prevProps;
+
+    if (prevLocation !== location) fetchCountriesDocuments(location);
+  }
   render() {
     return null;
   }
 }
 
 CountriesDocumentsProvider.propTypes = {
-  fetchCountriesDocuments: PropTypes.func.isRequired
+  fetchCountriesDocuments: PropTypes.func.isRequired,
+  location: PropTypes.string
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider-actions.js
+++ b/app/javascript/app/providers/ndcs-sdgs-data-provider/ndcs-sdgs-data-provider-actions.js
@@ -10,12 +10,14 @@ const getNdcsSdgsData = createThunkAction(
     const { ndcsSdgsData } = state();
     if (ndcsSdgsData) {
       dispatch(getNdcsSdgsDataInit());
-      const documentFilter = document
-        ? `?document_type=${document.split('-')[0]}&language=${document.split(
-          '-'
-        )[1]}`
-        : '';
-      fetch(`/api/v1/ndcs/${iso}/sdgs${documentFilter}`)
+      const getDocumentFilter = () => {
+        if (!document) return '';
+        const [documentType, documentLanguage] = document.split('-');
+        return `?document_type=${documentType}&language=${documentLanguage ||
+          'EN'}`;
+      };
+
+      fetch(`/api/v1/ndcs/${iso}/sdgs${getDocumentFilter()}`)
         .then(response => {
           if (response.ok) return response.json();
           throw Error(response.statusText);

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -12,11 +12,11 @@ module Api
         attribute :locations
 
         def name
-          object.normalized_label.presence || object.name
+          (instance_options[:locations_documents] && object.normalized_label.presence) || object.name
         end
 
         def slug
-          object.normalized_slug.presence || object.slug
+          (instance_options[:locations_documents] && object.normalized_slug.presence) || object.slug
         end
 
         def source
@@ -24,7 +24,7 @@ module Api
         end
 
         def labels
-          labels = if object.normalized_slug
+          labels = if instance_options[:locations_documents] && object.normalized_slug
                      ::Indc::Label.joins(:indicator).
                        where(indc_indicators: {normalized_slug: object.normalized_slug})
                    else


### PR DESCRIPTION
This PR fixes the NDC country page document options. Before we had NDC and First NDC together and now we are getting these documents from the country documents endpoint.

Also allows the full document page to receive documents without language as the documents country documents don't have a language. Before we were defaulting to English and that is what we continue doing. The user can select other documents on the full-text page with the dropdown.

![image](https://user-images.githubusercontent.com/9701591/81068520-cb215800-8ee0-11ea-80bf-bfffdfeb7d26.png)
