### PR TITLE
Revert lts-tracker embed route

### DIFF
--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -15,11 +15,17 @@ import AgricultureEmissionPieChart from 'components/sectors-agriculture/drivers-
 import LTSExploreMap from 'components/ndcs/lts-explore-map';
 import NDCSExploreMap from 'components/ndcs/ndcs-explore-map';
 import NDCOverviewSection from 'components/ndcs/ndcs-overview-section';
+import NDCSLTSViz from 'components/ndcs/ndcs-lts-viz';
 
 export default [
   {
     path: '/embed/ndcs',
     component: NDCMap,
+    exact: true
+  },
+  {
+    path: '/embed/lts-tracker',
+    component: NDCSLTSViz,
     exact: true
   },
   {


### PR DESCRIPTION
This tiny PR reverts the embed route for the LTS-tracker page. It seems to be working, I can't fully check it because I think I don't have data to display anything on the widgets there:
![image](https://user-images.githubusercontent.com/15097138/81085822-011e0680-8ef8-11ea-9eca-b676496e52aa.png)
