### PR TITLE
Resize all borders on zoom

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -146,27 +146,26 @@ export const getPathsWithStyles = createSelector(
 
         const iso = path.properties && path.properties.id;
         const countryData = locations[iso];
-
-        let style = COUNTRY_STYLES;
+        const strokeWidth = zoom > 2 ? (1 / zoom) * 2 : 0.5;
+        const style = {
+          ...COUNTRY_STYLES,
+          default: {
+            ...COUNTRY_STYLES.default,
+            'stroke-width': strokeWidth,
+            fillOpacity: 1
+          },
+          hover: {
+            ...COUNTRY_STYLES.hover,
+            cursor: 'pointer',
+            'stroke-width': strokeWidth,
+            fillOpacity: 1
+          }
+        };
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex);
-          style = {
-            ...COUNTRY_STYLES,
-            default: {
-              ...COUNTRY_STYLES.default,
-              fill: color,
-              fillOpacity: 1,
-              'stroke-width': zoom > 2 ? 0.1 : 0.5
-            },
-            hover: {
-              ...COUNTRY_STYLES.hover,
-              cursor: 'pointer',
-              fill: color,
-              fillOpacity: 1,
-              'stroke-width': zoom > 2 ? 0.1 : 0.5
-            }
-          };
+          style.default.fill = color;
+          style.hover.fill = color;
         }
 
         paths.push({

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -140,26 +140,26 @@ export const getPathsWithStyles = createSelector(
 
         const iso = path.properties && path.properties.id;
         const countryData = locations[iso];
-        let style = COUNTRY_STYLES;
+        const strokeWidth = zoom > 2 ? (1 / zoom) * 2 : 0.5;
+        const style = {
+          ...COUNTRY_STYLES,
+          default: {
+            ...COUNTRY_STYLES.default,
+            'stroke-width': strokeWidth,
+            fillOpacity: 1
+          },
+          hover: {
+            ...COUNTRY_STYLES.hover,
+            cursor: 'pointer',
+            'stroke-width': strokeWidth,
+            fillOpacity: 1
+          }
+        };
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex);
-          style = {
-            ...COUNTRY_STYLES,
-            default: {
-              ...COUNTRY_STYLES.default,
-              fill: color,
-              fillOpacity: 1,
-              'stroke-width': zoom > 2 ? 0.1 : 0.5
-            },
-            hover: {
-              ...COUNTRY_STYLES.hover,
-              cursor: 'pointer',
-              fill: color,
-              fillOpacity: 1,
-              'stroke-width': zoom > 2 ? 0.1 : 0.5
-            }
-          };
+          style.default.fill = color;
+          style.hover.fill = color;
         }
 
         paths.push({


### PR DESCRIPTION
We weren't resizing the border of the geographies without data. Also now it's inversely proportional to the level of zoom

Before: 
![image](https://user-images.githubusercontent.com/9701591/81092637-32e79b00-8f01-11ea-8306-cc6c03c9494f.png)
After:
![image](https://user-images.githubusercontent.com/9701591/81092645-367b2200-8f01-11ea-85c9-74a8aea881da.png)
