### PR TITLE
Include total submitters on the countries_documents endpoint

### DIFF
--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,5 +1,6 @@
 class Indc::Document < ApplicationRecord
   has_many :values, class_name: 'Indc::Value'
+  has_many :locations, through: :values
 
   def as_json(_={})
     super(except: [:created_at, :updated_at])

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -16,6 +16,14 @@ module Api
 
         def documents
           ::Indc::Document.order(:ordering).map do |d|
+            locs = Location.where(id: ::Indc::Value.select(:location_id).where(document_id: d.id).distinct.pluck(:location_id))
+            total_countries = if locs.where(iso_code3: 'EUU').any?
+                                # sum the 26 countries plus EUU entry to sum 27 countries in the EU
+                                # to avoid double counting
+                                locs.where(is_in_eu: [nil, false]).count + 26
+                              else
+                                locs.count
+                              end
             {
               id: d.id,
               ordering: d.ordering,
@@ -23,7 +31,7 @@ module Api
               long_name: d.long_name,
               description: d.description,
               is_ndc: d.is_ndc,
-              total_countries: d.locations.distinct.count
+              total_countries: total_countries
             }
           end
         end

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -15,7 +15,17 @@ module Api
         end
 
         def documents
-          ::Indc::Document.order(:ordering)
+          ::Indc::Document.order(:ordering).map do |d|
+            {
+              id: d.id,
+              ordering: d.ordering,
+              slug: d.slug,
+              long_name: d.long_name,
+              description: d.description,
+              is_ndc: d.is_ndc,
+              total_countries: d.locations.distinct.count
+            }
+          end
         end
 
         def laws


### PR DESCRIPTION
Adds a new attribute to the documents array with the total submitters, which can be used on the places where we need this value!

E.g.: http://localhost:3000/api/v1/ndcs/countries_documents?location=BRA