### PR TITLE
Fix/first ndc count

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -17,6 +17,7 @@ import ShareButton from 'components/button/share-button';
 import ModalShare from 'components/modal-share';
 import Sticky from 'react-stickynode';
 import cx from 'classnames';
+import CountriesDocumentsProvider from 'providers/countries-documents-provider';
 
 import newMapTheme from 'styles/themes/map/map-new-zoom-controls.scss';
 import layout from 'styles/layout.scss';
@@ -129,6 +130,7 @@ function NDCSExploreMap(props) {
 
   return (
     <div>
+      <CountriesDocumentsProvider />
       <TabletLandscape>
         {isTablet => (
           <div className={styles.wrapper}>

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -6,7 +6,6 @@ import {
 } from 'utils/map';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
-import groupBy from 'lodash/groupBy';
 import intersection from 'lodash/intersection';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
@@ -24,6 +23,8 @@ const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
 const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
+const getCountriesDocumentsData = state =>
+  state.countriesDocuments.data || null;
 const getZoom = state => state.map.zoom || null;
 
 export const getCategories = createSelector(getCategoriesData, categories =>
@@ -264,38 +265,33 @@ export const getEmissionsCardData = createSelector(
 const getCountriesAndParties = submissions => {
   const partiesNumber = submissions.length;
   let countriesNumber = submissions.length;
-  const submissionIsos = submissions.map(s => s.iso_code3);
-  if (!submissionIsos.includes(europeSlug)) {
+
+  if (!submissions.includes(europeSlug)) {
     return { partiesNumber, countriesNumber };
   }
   const europeanCountriesWithSubmission = intersection(
     europeanCountries,
-    submissions.map(s => s.iso_code3)
+    submissions
   );
+
   countriesNumber +=
     europeanCountries.length - europeanCountriesWithSubmission.length - 1;
   return { partiesNumber, countriesNumber };
 };
 
 export const getSummaryCardData = createSelector(
-  [getIndicatorsData],
-  indicators => {
-    if (!indicators) return null;
-    const latestSubmissionIndicator = indicators.find(
-      i => i.slug === 'submission'
-    );
-    const locationSubmissions = Object.keys(
-      latestSubmissionIndicator.locations
-    ).map(key => ({
-      iso_code3: key,
-      value: latestSubmissionIndicator.locations[key].value
-    }));
-    const groupedSubmissions = groupBy(locationSubmissions, 'value');
+  [getIndicatorsData, getCountriesDocumentsData],
+  (indicators, countriesDocuments) => {
+    if (!indicators || !countriesDocuments) return null;
+    const getSubmissionIsos = slug =>
+      Object.keys(countriesDocuments).filter(iso =>
+        countriesDocuments[iso].some(doc => doc.slug === slug)
+      );
     const firstNDCCountriesAndParties = getCountriesAndParties(
-      groupedSubmissions['First NDC Submitted']
+      getSubmissionIsos('first_ndc')
     );
     const secondNDCCountriesAndParties = getCountriesAndParties(
-      groupedSubmissions['Second NDC Submitted']
+      getSubmissionIsos('second_ndc')
     );
     return [
       {

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
@@ -149,6 +149,14 @@
     .summaryCardDescription {
       font-size: $font-size-sm;
       flex: 3;
+
+      @media #{$desktop} {
+        font-size: $font-size-sm;
+      }
+
+      @media #{$tablet-landscape} {
+        font-size: $font-size-s;
+      }
     }
   }
 }

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { isEmbededComponent } from 'utils/navigation';
+import CountriesDocumentsProvider from 'providers/countries-documents-provider';
 import layout from 'styles/layout.scss';
 import ShareButton from 'components/button/share-button';
 import ModalShare from 'components/modal-share';
@@ -17,6 +18,7 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
         [styles.commitmentContainer]: !isEmbed
       })}
     >
+      {section === 1 && <CountriesDocumentsProvider />}
       <div className={layout.content}>
         <div className={cx(styles.section, { [styles.padded]: !isEmbed })}>
           <div className={styles.commitmentWrapper}>
@@ -52,6 +54,7 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
                 color={color}
                 questionText={question.questionText}
                 answerLabel={question.answerLabel}
+                source={question.source}
                 handleInfoClick={handleInfoClick}
                 hasExternalLink={question.hasExternalLink}
               />

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -19,9 +19,9 @@ export const commitmentsData = [
         questionText:
           'How many Parties submitted first Nationally Determined Contributions?',
         link: '/ndcs-explore?indicator=submission',
-        slug: 'submission',
         metadataSlug: 'ndc_cw',
-        answerLabel: 'First NDC Submitted'
+        source: 'countriesDocuments',
+        answerLabel: 'first_ndc'
       },
       {
         questionText: 'How many Parties have submitted Long-Term Strategies?',

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
@@ -5,13 +5,26 @@ const getIndicators = state =>
   (state.ndcs && state.ndcs.data.indicators) || null;
 const getSlug = (state, { slug }) => slug || null;
 const getAnswerLabel = (state, { answerLabel }) => answerLabel || null;
+const getSource = (state, { source }) => source || null;
+const getCountriesDocuments = state => state.countriesDocuments.data || null;
 
 export const getTotalCountriesNumber = state =>
   (state.countries && state.countries.data.length) || null;
 
+const getFirstNDCSubmittedIsos = createSelector(
+  [getSource, getCountriesDocuments, getAnswerLabel],
+  (source, countriesDocuments, answerLabel) => {
+    if (!source || !countriesDocuments) return null;
+    return Object.keys(countriesDocuments).filter(iso =>
+      countriesDocuments[iso].some(doc => doc.slug === answerLabel)
+    );
+  }
+);
+
 const getPositiveAnswerIsos = createSelector(
-  [getIndicators, getSlug, getAnswerLabel],
-  (indicators, slug, answerLabel) => {
+  [getIndicators, getSlug, getAnswerLabel, getFirstNDCSubmittedIsos],
+  (indicators, slug, answerLabel, firstNDCSubmittedIsos) => {
+    if (firstNDCSubmittedIsos) return firstNDCSubmittedIsos;
     if (!indicators || !slug || !answerLabel) return null;
     const indicator = indicators.find(i => i.slug === slug);
     if (!indicator) return null;


### PR DESCRIPTION
The first NDC count on the overview and NDC explore pages was depending on the last submitted indicator but this was incorrect as countries could submit a second NDC but after submitting the first NDC. 

In this PR I use the countries documents endpoint to get the isos of the countries with the first NDC submitted and calculate the different emissions and numbers in Overview and NDC emissions page on the summary card.

Overview page (first section - second question):

![image](https://user-images.githubusercontent.com/9701591/81178981-4f3f1280-8fa9-11ea-8a10-f559a0beec64.png)

NDC explore page (Summary card):

![image](https://user-images.githubusercontent.com/9701591/81178882-29197280-8fa9-11ea-8d5f-2d6bbe3b1de3.png)
