### PR TITLE
Add countries guard

### DIFF
--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -19,7 +19,7 @@ const getCountries = state => {
 };
 
 const getCountryByIso = (countries, iso) =>
-  countries.find(country => country.iso_code3 === iso);
+  (countries ? countries.find(country => country.iso_code3 === iso) : null);
 
 const getSearch = state => {
   const { search } = state.location;


### PR DESCRIPTION
This fix is already included here:
https://github.com/Vizzuality/climate-watch/pull/1070

Adds a guard for the countries if we still havent retrieved them on the country pages.
Try: http://localhost:3000/countries/DZA