### PR TITLE
Change updatedData setting condition

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -47,14 +47,12 @@ function GhgEmissionsContainer(props) {
     DATA_ZOOM_START_POSITION
   );
   useEffect(() => {
-    if (data) {
-      if (dataZoomYears) {
-        setUpdatedData(
-          data.filter(d => d.x >= dataZoomYears.min && d.x <= dataZoomYears.max)
-        );
-      } else {
-        setUpdatedData(data);
-      }
+    if (dataZoomYears) {
+      setUpdatedData(
+        data.filter(d => d.x >= dataZoomYears.min && d.x <= dataZoomYears.max)
+      );
+    } else {
+      setUpdatedData(data);
     }
   }, [dataZoomYears, data]);
   const resetDataZoom = () => {


### PR DESCRIPTION
This PR avoids a weird behaviour that was happening on some selections when no data was returned from the server request (after some data had been displayed on the chart). Since we were not providing an `else` option in case there is no `data` (inside a `useEffect` hook with `data` as a dependency) the previous already persisted `updatedData` state was being delivered to the chart. 
Now the empty data array is delivered instead.

Join [this URL](http://localhost:3000/ghg-emissions?breakBy=sector&chartType=line&gases=f-gas&regions=TOP&sectors=agriculture&source=CAIT) to test it.
And read the [Pivotal ticket](https://www.pivotaltracker.com/story/show/172432422) for full context.