### PR TITLE
Trigger donut chart index from legend and map

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -64,9 +64,10 @@ const renderLegend = legendData => (
   <div className={styles.legendCardContainer}>
     <div className={styles.legendContainer}>
       {legendData &&
-        legendData.map(l => (
+        legendData.map((l, index) => (
           <LegendItem
             key={l.name}
+            index={index}
             name={l.name}
             number={l.countriesNumber}
             value={l.value}
@@ -78,29 +79,6 @@ const renderLegend = legendData => (
 );
 
 function LTSExploreMap(props) {
-  const tooltipParentRef = useRef(null);
-  const pieChartRef = useRef(null);
-  const [stickyStatus, setStickyStatus] = useState(Sticky.STATUS_ORIGINAL);
-  const renderDonutChart = emissionsCardData => (
-    <div className={styles.donutContainer} ref={pieChartRef}>
-      <PieChart
-        data={emissionsCardData.data}
-        width={200}
-        config={emissionsCardData.config}
-        customTooltip={
-          <CustomTooltip
-            reference={tooltipParentRef.current}
-            chartReference={pieChartRef.current}
-            data={emissionsCardData.data}
-            itemName={'Parties'}
-          />
-        }
-        customInnerHoverLabel={CustomInnerHoverLabel}
-        theme={{ pieChart: styles.pieChart }}
-      />
-    </div>
-  );
-
   const {
     loading,
     paths,
@@ -120,8 +98,34 @@ function LTSExploreMap(props) {
     handleIndicatorChange,
     handleOnChangeChecked,
     checked,
-    tooltipValues
+    tooltipValues,
+    donutActiveIndex,
+    selectActiveDonutIndex
   } = props;
+  const tooltipParentRef = useRef(null);
+  const pieChartRef = useRef(null);
+  const [stickyStatus, setStickyStatus] = useState(Sticky.STATUS_ORIGINAL);
+  const renderDonutChart = () => (
+    <div className={styles.donutContainer} ref={pieChartRef}>
+      <PieChart
+        customActiveIndex={donutActiveIndex}
+        onHover={(_, index) => selectActiveDonutIndex(index)}
+        data={emissionsCardData.data}
+        width={200}
+        config={emissionsCardData.config}
+        customTooltip={
+          <CustomTooltip
+            reference={tooltipParentRef.current}
+            chartReference={pieChartRef.current}
+            data={emissionsCardData.data}
+            itemName={'Parties'}
+          />
+        }
+        customInnerHoverLabel={CustomInnerHoverLabel}
+        theme={{ pieChart: styles.pieChart }}
+      />
+    </div>
+  );
 
   const TOOLTIP_ID = 'lts-map-tooltip';
 
@@ -258,7 +262,9 @@ LTSExploreMap.propTypes = {
   tooltipValues: PropTypes.object,
   handleOnChangeChecked: PropTypes.func,
   checked: PropTypes.bool,
-  handleIndicatorChange: PropTypes.func
+  handleIndicatorChange: PropTypes.func,
+  selectActiveDonutIndex: PropTypes.func.isRequired,
+  donutActiveIndex: PropTypes.number
 };
 
 export default LTSExploreMap;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -19,6 +19,8 @@ const getCountries = state => state.countries || null;
 const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
 const getZoom = state => state.map.zoom || null;
+export const getDonutActiveIndex = state =>
+  state.exploreMap.activeIndex || null;
 
 export const getIsShowEUCountriesChecked = createSelector(
   getSearch,
@@ -234,11 +236,14 @@ export const getTooltipCountryValues = createSelector(
 
     const tooltipCountryValues = {};
     Object.keys(updatedSelectedIndicator.locations).forEach(iso => {
-      tooltipCountryValues[iso] = {
-        value:
-          updatedSelectedIndicator.locations[iso] &&
-          updatedSelectedIndicator.locations[iso].value
-      };
+      const location = updatedSelectedIndicator.locations[iso];
+      const originalIndicatorLocation = selectedIndicator.locations[iso];
+      if (location) {
+        tooltipCountryValues[iso] = {
+          labelId: originalIndicatorLocation.label_id,
+          value: location.value
+        };
+      }
     });
     return tooltipCountryValues;
   }

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -120,7 +120,7 @@ class LTSExploreMapContainer extends PureComponent {
           l => parseInt(l.id, 10) === tooltipValue.labelId
         );
         if (hoveredlegendData) {
-          selectActiveDonutIndex(hoveredlegendData.index - 1);
+          selectActiveDonutIndex(legendData.indexOf(hoveredlegendData));
         }
       } else {
         // This is the last legend item aggregating all the no data geographies

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -9,6 +9,7 @@ import { getLocationParamUpdated } from 'utils/navigation';
 
 import { actions as fetchActions } from 'pages/lts-explore';
 import { actions as modalActions } from 'components/modal-metadata';
+import exploreMapActions from 'components/ndcs/shared/explore-map/explore-map-actions';
 
 import Component from './lts-explore-map-component';
 import {
@@ -23,10 +24,11 @@ import {
   getCategoryIndicators,
   getSelectedCategory,
   getTooltipCountryValues,
+  getDonutActiveIndex,
   getIsShowEUCountriesChecked
 } from './lts-explore-map-selectors';
 
-const actions = { ...fetchActions, ...modalActions };
+const actions = { ...fetchActions, ...modalActions, ...exploreMapActions };
 
 const mapStateToProps = (state, { location }) => {
   const { data, loading } = state.LTS;
@@ -59,7 +61,8 @@ const mapStateToProps = (state, { location }) => {
     categories: getCategories(LTSWithSelection),
     indicators: getCategoryIndicators(LTSWithSelection),
     selectedCategory: getSelectedCategory(LTSWithSelection),
-    checked: getIsShowEUCountriesChecked(LTSWithSelection)
+    checked: getIsShowEUCountriesChecked(LTSWithSelection),
+    donutActiveIndex: getDonutActiveIndex(LTSWithSelection)
   };
 };
 
@@ -100,18 +103,32 @@ class LTSExploreMapContainer extends PureComponent {
   };
 
   handleCountryEnter = geography => {
-    const { tooltipCountryValues } = this.props;
+    const {
+      tooltipCountryValues,
+      legendData,
+      selectActiveDonutIndex
+    } = this.props;
     const iso = geography.properties && geography.properties.id;
 
     if (iso === 'TWN') {
       // We won't show Taiwan as an independent country
       this.setState({ tooltipValues: null, country: null });
     } else {
+      const tooltipValue = tooltipCountryValues && tooltipCountryValues[iso];
+      if (tooltipValue && tooltipValue.labelId) {
+        const hoveredlegendData = legendData.find(
+          l => parseInt(l.id, 10) === tooltipValue.labelId
+        );
+        if (hoveredlegendData) {
+          selectActiveDonutIndex(hoveredlegendData.index - 1);
+        }
+      } else {
+        // This is the last legend item aggregating all the no data geographies
+        selectActiveDonutIndex(legendData.length - 1);
+      }
+
       const tooltipValues = {
-        value:
-          tooltipCountryValues && tooltipCountryValues[iso]
-            ? tooltipCountryValues[iso].value
-            : 'No Document Submitted',
+        value: (tooltipValue && tooltipValue.value) || 'No Document Submitted',
         countryName: geography.properties && geography.properties.name
       };
 
@@ -187,6 +204,8 @@ LTSExploreMapContainer.propTypes = {
   summaryData: PropTypes.array,
   indicator: PropTypes.object,
   tooltipCountryValues: PropTypes.object,
+  selectActiveDonutIndex: PropTypes.func.isRequired,
+  legendData: PropTypes.array,
   checked: PropTypes.bool
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -70,9 +70,10 @@ const renderLegend = legendData => (
   <div className={styles.legendCardContainer}>
     <div className={styles.legendContainer}>
       {legendData &&
-        legendData.map(l => (
+        legendData.map((l, index) => (
           <LegendItem
             key={l.name}
+            index={index}
             name={l.name}
             number={l.partiesNumber}
             value={l.value}
@@ -84,28 +85,6 @@ const renderLegend = legendData => (
 );
 
 function NDCSExploreMap(props) {
-  const tooltipParentRef = useRef(null);
-  const pieChartRef = useRef(null);
-  const [stickyStatus, setStickyStatus] = useState(Sticky.STATUS_ORIGINAL);
-  const renderDonutChart = emissionsCardData => (
-    <div className={styles.donutContainer} ref={pieChartRef}>
-      <PieChart
-        data={emissionsCardData.data}
-        width={200}
-        config={emissionsCardData.config}
-        customTooltip={
-          <CustomTooltip
-            reference={tooltipParentRef.current}
-            chartReference={pieChartRef.current}
-            data={emissionsCardData.data}
-          />
-        }
-        customInnerHoverLabel={CustomInnerHoverLabel}
-        theme={{ pieChart: styles.pieChart }}
-      />
-    </div>
-  );
-
   const {
     loading,
     paths,
@@ -123,8 +102,34 @@ function NDCSExploreMap(props) {
     handleCategoryChange,
     selectedCategory,
     handleIndicatorChange,
-    tooltipValues
+    tooltipValues,
+    selectActiveDonutIndex,
+    donutActiveIndex
   } = props;
+
+  const tooltipParentRef = useRef(null);
+  const pieChartRef = useRef(null);
+  const [stickyStatus, setStickyStatus] = useState(Sticky.STATUS_ORIGINAL);
+  const renderDonutChart = () => (
+    <div className={styles.donutContainer} ref={pieChartRef}>
+      <PieChart
+        customActiveIndex={donutActiveIndex}
+        onHover={(_, index) => selectActiveDonutIndex(index)}
+        data={emissionsCardData.data}
+        width={200}
+        config={emissionsCardData.config}
+        customTooltip={
+          <CustomTooltip
+            reference={tooltipParentRef.current}
+            chartReference={pieChartRef.current}
+            data={emissionsCardData.data}
+          />
+        }
+        customInnerHoverLabel={CustomInnerHoverLabel}
+        theme={{ pieChart: styles.pieChart }}
+      />
+    </div>
+  );
 
   const TOOLTIP_ID = 'ndcs-map-tooltip';
 
@@ -257,7 +262,9 @@ NDCSExploreMap.propTypes = {
   handleCategoryChange: PropTypes.func,
   selectedCategory: PropTypes.object,
   tooltipValues: PropTypes.object,
-  handleIndicatorChange: PropTypes.func
+  handleIndicatorChange: PropTypes.func,
+  selectActiveDonutIndex: PropTypes.func.isRequired,
+  donutActiveIndex: PropTypes.number
 };
 
 export default NDCSExploreMap;

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -26,6 +26,8 @@ const getIndicatorsData = state => state.indicators || null;
 const getCountriesDocumentsData = state =>
   state.countriesDocuments.data || null;
 const getZoom = state => state.map.zoom || null;
+export const getDonutActiveIndex = state =>
+  state.exploreMap.activeIndex || null;
 
 export const getCategories = createSelector(getCategoriesData, categories =>
   (!categories
@@ -220,11 +222,13 @@ export const getTooltipCountryValues = createSelector(
     }
     const tooltipCountryValues = {};
     Object.keys(selectedIndicator.locations).forEach(iso => {
-      tooltipCountryValues[iso] = {
-        value:
-          selectedIndicator.locations[iso] &&
-          selectedIndicator.locations[iso].value
-      };
+      const location = selectedIndicator.locations[iso];
+      if (location) {
+        tooltipCountryValues[iso] = {
+          labelId: location.label_id,
+          value: location.value
+        };
+      }
     });
     return tooltipCountryValues;
   }

--- a/app/javascript/app/components/ndcs/shared/explore-map/explore-map-actions.js
+++ b/app/javascript/app/components/ndcs/shared/explore-map/explore-map-actions.js
@@ -1,0 +1,7 @@
+import { createAction } from 'redux-actions';
+
+export const selectActiveDonutIndex = createAction('selectActiveDonutIndex');
+
+export default {
+  selectActiveDonutIndex
+};

--- a/app/javascript/app/components/ndcs/shared/explore-map/explore-map-reducers.js
+++ b/app/javascript/app/components/ndcs/shared/explore-map/explore-map-reducers.js
@@ -1,0 +1,10 @@
+export const initialState = {
+  activeIndex: null
+};
+
+export default {
+  selectActiveDonutIndex: (state, { payload }) => ({
+    ...state,
+    activeIndex: payload
+  })
+};

--- a/app/javascript/app/components/ndcs/shared/explore-map/explore-map.js
+++ b/app/javascript/app/components/ndcs/shared/explore-map/explore-map.js
@@ -1,0 +1,4 @@
+import actions from './explore-map-actions';
+import reducers, { initialState } from './explore-map-reducers';
+
+export { actions, reducers, initialState };

--- a/app/javascript/app/components/ndcs/shared/legend-item/legend-item-component.jsx
+++ b/app/javascript/app/components/ndcs/shared/legend-item/legend-item-component.jsx
@@ -3,8 +3,19 @@ import Progress from 'components/progress';
 import PropTypes from 'prop-types';
 import styles from './legend-item-styles.scss';
 
-const LegendItem = ({ name, number, value, color, itemsName }) => (
-  <div className={styles.legendItem}>
+const LegendItem = ({
+  name,
+  number,
+  value,
+  color,
+  itemsName,
+  index,
+  selectActiveDonutIndex
+}) => (
+  <div
+    className={styles.legendItem}
+    onMouseEnter={() => selectActiveDonutIndex(index)}
+  >
     <div className={styles.legendName}>
       <span className={styles.legendDot} style={{ backgroundColor: color }} />
       <span>{name}</span>
@@ -23,7 +34,9 @@ LegendItem.propTypes = {
   number: PropTypes.number,
   itemsName: PropTypes.array,
   value: PropTypes.number,
-  color: PropTypes.string
+  index: PropTypes.number.isRequired,
+  color: PropTypes.string,
+  selectActiveDonutIndex: PropTypes.func.isRequired
 };
 
 LegendItem.defaultProps = {

--- a/app/javascript/app/components/ndcs/shared/legend-item/legend-item-styles.scss
+++ b/app/javascript/app/components/ndcs/shared/legend-item/legend-item-styles.scss
@@ -3,6 +3,8 @@
 $progress-bar-width: 180px;
 
 .legendItem {
+  cursor: default;
+
   &:not(:last-child) {
     margin-bottom: 10px;
   }

--- a/app/javascript/app/components/ndcs/shared/legend-item/legend-item.js
+++ b/app/javascript/app/components/ndcs/shared/legend-item/legend-item.js
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux';
+import actions from 'components/ndcs/shared/explore-map/explore-map-actions';
+import LegendItem from './legend-item-component';
+
+export default connect(null, actions)(LegendItem);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -124,6 +124,7 @@ import * as ndcSdgLinkagesComponent from 'components/ndc-sdg/ndc-sdg-linkages-co
 import * as HamburgerComponent from 'components/hamburger';
 import * as GHGComponent from 'components/ghg-emissions/ghg-emissions';
 import * as AnchorNavComponent from 'components/anchor-nav';
+import * as ExploreMapShared from 'components/ndcs/shared/explore-map';
 
 const componentsReducers = {
   map: handleActions(mapComponent),
@@ -146,7 +147,8 @@ const componentsReducers = {
   ndcSdg: handleActions(ndcSdgLinkagesComponent),
   hamburger: handleActions(HamburgerComponent),
   dataZoom: handleActions(GHGComponent),
-  anchorNav: handleActions(AnchorNavComponent)
+  anchorNav: handleActions(AnchorNavComponent),
+  exploreMap: handleActions(ExploreMapShared)
 };
 
 export default combineReducers({

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "copy-to-clipboard": "3.0.8",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.61.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.62.0",
     "d3-format": "1.2.0",
     "d3-scale": "1.0.6",
     "d3-time-format": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,9 +2763,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.61.0":
-  version "1.61.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/b3a572dd1796a132f4ab739745e2400e968866e4"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.62.0":
+  version "1.62.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/901812efad201337ceb59a5e6e8074aaea935e15"
   dependencies:
     "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"


### PR DESCRIPTION
This PR makes it possible to hover the map or the legend on LTS and NDC pages and see the donut chart selection changing accordingly.

Please test both NDC explore and LTS explore pages:
Try: Hover over map and legend, the donut chart should change

![donut](https://user-images.githubusercontent.com/9701591/81275598-32124e80-9052-11ea-8edc-a2397af55ab3.gif)
