### PR TITLE
Fix z-index of the ghg-emissions filter dropdowns

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -31,6 +31,7 @@ import lineIcon from 'assets/icons/line_chart.svg';
 import areaIcon from 'assets/icons/area_chart.svg';
 import percentageIcon from 'assets/icons/icon-percentage-chart.svg';
 import dropdownTheme from 'styles/themes/dropdown/react-selectize.scss';
+import multiSelectTheme from 'styles/themes/dropdown/multiselect-dropdown.scss';
 import multiLevelDropdownTheme from 'styles/themes/dropdown/multi-level-dropdown.scss';
 import legendChartTheme from 'styles/themes/chart/legend-chart.scss';
 import DataZoom from './data-zoom';
@@ -343,7 +344,7 @@ function GhgEmissions(props) {
           options={options.regions || []}
           values={getValues(selectedOptions.regionsSelected)}
           onValueChange={selected => handleChange('regions', selected)}
-          theme={dropdownTheme}
+          theme={multiSelectTheme}
         />
         <MultiLevelDropdown
           label="Sectors/Subsectors"
@@ -360,7 +361,7 @@ function GhgEmissions(props) {
           options={options.gases}
           values={getValues(selectedOptions.gasesSelected)}
           onValueChange={selected => handleChange('gases', selected)}
-          theme={dropdownTheme}
+          theme={multiSelectTheme}
         />
         {FEATURE_NEW_GHG && renderDropdown('Calculations', 'calculation')}
         {renderDropdown('Show data by', 'breakBy')}

--- a/app/javascript/app/components/modal/modal-component.jsx
+++ b/app/javascript/app/components/modal/modal-component.jsx
@@ -27,7 +27,7 @@ class CustomModal extends PureComponent {
     } = this.props;
     const defaultStyles = {
       overlay: {
-        zIndex: 20,
+        zIndex: 23,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/app/javascript/app/styles/themes/dropdown/multi-level-dropdown.scss
+++ b/app/javascript/app/styles/themes/dropdown/multi-level-dropdown.scss
@@ -15,6 +15,7 @@
     border: $dropdown-border !important;
     border-radius: 0 0 4px 4px;
     margin-top: -3px;
+    z-index: 10;
   }
 
   //dropdown toggle arrow wrapper styles

--- a/app/javascript/app/styles/themes/dropdown/multiselect-dropdown.scss
+++ b/app/javascript/app/styles/themes/dropdown/multiselect-dropdown.scss
@@ -1,9 +1,9 @@
 @import './react-selectize.scss';
 
 .wrapper {
-  z-index: unset;
+  z-index: auto;
 }
 
 .values {
-  z-index: unset;
+  z-index: auto;
 }

--- a/app/javascript/app/styles/themes/dropdown/multiselect-dropdown.scss
+++ b/app/javascript/app/styles/themes/dropdown/multiselect-dropdown.scss
@@ -1,0 +1,9 @@
+@import './react-selectize.scss';
+
+.wrapper {
+  z-index: unset;
+}
+
+.values {
+  z-index: unset;
+}


### PR DESCRIPTION
This small PR fixes the issue with the position of the dropdown menu on the ghg-emissions page - check it on the mobile and tablet resolutions
[PIVOTAL](https://www.pivotaltracker.com/story/show/172589517)

_bug:_
![Pasted Image at 2020_04_29_20_04 pm (1)](https://user-images.githubusercontent.com/15097138/81281116-b6b49b00-9059-11ea-8f2e-48f63679d6df.png)

**UPDATE:**
It also fixes the problem with filters covering the modal on the `ndc-` and `lts- explore` pages:
[PIVOTAL](https://www.pivotaltracker.com/story/show/172129936)
_bug:_
![Pasted Image at 2020_04_02_06_21 pm](https://user-images.githubusercontent.com/15097138/81286616-a4d6f600-9061-11ea-90ff-141aec080bc2.png)
