### PR TITLE
Add share buttons to the sitcky bar on lts-explore page

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -23,8 +23,12 @@ import newMapTheme from 'styles/themes/map/map-new-zoom-controls.scss';
 import blueCheckboxTheme from 'styles/themes/checkbox/blue-checkbox.scss';
 import styles from './lts-explore-map-styles.scss';
 
-const renderButtonGroup = (clickHandler, downloadLink) => (
-  <div className={styles.buttonGroupContainer}>
+const renderButtonGroup = (clickHandler, downloadLink, stickyStatus) => (
+  <div
+    className={cx(styles.buttonGroupContainer, {
+      [styles.padded]: stickyStatus !== Sticky.STATUS_ORIGINAL
+    })}
+  >
     <ButtonGroup
       className={styles.buttonGroup}
       buttonsConfig={[
@@ -169,8 +173,11 @@ function LTSExploreMap(props) {
                       />
                     </div>
                     {isTablet &&
-                      stickyStatus === Sticky.STATUS_ORIGINAL &&
-                      renderButtonGroup(handleInfoClick, downloadLink)}
+                      renderButtonGroup(
+                        handleInfoClick,
+                        downloadLink,
+                        stickyStatus
+                      )}
                   </div>
                 </div>
               </div>

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
@@ -217,6 +217,10 @@
   @media #{$tablet-landscape} {
     width: 150px;
   }
+
+  &.padded {
+    padding-top: 10px;
+  }
 }
 
 .buttonGroup {


### PR DESCRIPTION
This PR fixes the issue when the share button disappears from the sticky bar on the LTS-explorer page:
[PIVOTAL](https://www.pivotaltracker.com/story/show/172716747)
_bug:_
![image](https://user-images.githubusercontent.com/15097138/81302772-140d1400-907b-11ea-97ef-f700033a997a.png)

Now it works the same way as in NDC-explorer page:
![image](https://user-images.githubusercontent.com/15097138/81302827-24bd8a00-907b-11ea-91e2-17bfc1658611.png)
