### PR TITLE
Fix country compare page crash on wri country labels

### DIFF
--- a/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability-selectors.js
+++ b/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability-selectors.js
@@ -135,7 +135,9 @@ export const getSectionData = createSelector(
   (iso, adaptations, search, countries) => {
     const queryIsos = getQueryIsos(search);
     const sections = adaptations.data;
-    if ((!iso || isEmpty(sections)) && (!search || isEmpty(sections))) {
+    const noCountriesSelected = !iso && !search;
+
+    if (noCountriesSelected || isEmpty(countries) || isEmpty(sections)) {
       return null;
     } // eslint-disable-line no-mixed-operators
 


### PR DESCRIPTION
This tiny PR fixes the crash on the country-compare page - it was happening when `countries` data wasn't ready but `sections` data had been already loaded.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172721233)

To test it, open a few tabs  on the compare page e.g. from [here](http://localhost:3000/countries/compare?locations=ALB%2CDZA%2CAND&source=17), and try to refresh it a few times and check if the page doesn't crash