### PR TITLE
Adds indicator_ids to sectors object on the ndcs endpoint

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -41,7 +41,7 @@ module Api
 
     class NdcsController < ApiController
       def index
-        sectors = ::Indc::Sector.all
+        sectors = ::Indc::Sector.includes(values: :indicator)
         indicators = filtered_indicators
         categories = filtered_categories(indicators)
 

--- a/app/models/indc/sector.rb
+++ b/app/models/indc/sector.rb
@@ -1,6 +1,8 @@
 module Indc
   class Sector < ApplicationRecord
     belongs_to :parent, class_name: 'Indc::Sector', optional: true
+    has_many :children, class_name: 'Indc::Sector', foreign_key: :parent_id
+
     has_many :values, class_name: 'Indc::Value'
 
     validates :name, presence: true

--- a/app/serializers/api/v1/indc/sector_serializer.rb
+++ b/app/serializers/api/v1/indc/sector_serializer.rb
@@ -5,6 +5,12 @@ module Api
         attribute :id
         attribute :parent_id, if: -> { object.parent_id }
         attribute :name
+        attribute :indicator_ids
+
+        def indicator_ids
+          object.values.select(:indicator_id).
+            order(:indicator_id).distinct.pluck(:indicator_id)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds indicator_ids to the sectors objects on the NDC api call. As per this [PR task](https://www.pivotaltracker.com/story/show/172764124).

Example URL: http://localhost:3000/api/v1/ndcs?location=CAN&category=summary&source=CAIT&filter=overview

I'm now thinking that maybe I should filter the sectors per the other filters passed.