### PR TITLE
Tweak country-ghg chart values rounding

### DIFF
--- a/app/javascript/app/components/charts/line/line-component.jsx
+++ b/app/javascript/app/components/charts/line/line-component.jsx
@@ -93,7 +93,7 @@ class ChartLine extends PureComponent {
       height,
       margin,
       domain,
-      forceFixedFormatDecimals,
+      customD3Format,
       espGraph,
       dot
     } = this.props;
@@ -165,7 +165,7 @@ class ChartLine extends PureComponent {
               <TooltipChart
                 content={content}
                 config={config}
-                forceFixedFormatDecimals={forceFixedFormatDecimals}
+                customD3Format={customD3Format}
               />
             )}
           />
@@ -213,7 +213,7 @@ ChartLine.propTypes = {
   data: PropTypes.array.isRequired,
   height: PropTypes.any.isRequired,
   onMouseMove: PropTypes.func.isRequired,
-  forceFixedFormatDecimals: PropTypes.number,
+  customD3Format: PropTypes.string,
   margin: PropTypes.object,
   domain: PropTypes.object,
   espGraph: PropTypes.bool.isRequired,

--- a/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
+++ b/app/javascript/app/components/charts/stacked-area/stacked-area-component.jsx
@@ -23,10 +23,13 @@ import {
   ResponsiveContainer
 } from 'recharts';
 import TooltipChart from 'components/charts/tooltip-chart';
-import { format } from 'd3-format';
+import { formatSIwithDecimals } from 'utils/d3-custom-format';
 
 import { QUANTIFICATION_COLORS } from 'data/constants';
 import DividerLine from './divider-line';
+
+const NUMBER_PRECISION = '2';
+const formatLabel = value => formatSIwithDecimals(value, NUMBER_PRECISION, 't');
 
 class ChartStackedArea extends PureComponent {
   constructor() {
@@ -73,8 +76,7 @@ class ChartStackedArea extends PureComponent {
       points.length > 0 &&
       points.map(point => {
         const isActivePoint =
-          activePoint &&
-          (point.x === activePoint.x && point.y === activePoint.y);
+          activePoint && point.x === activePoint.x && point.y === activePoint.y;
         let colorPoint = point.label.includes('BAU')
           ? QUANTIFICATION_COLORS.BAU
           : QUANTIFICATION_COLORS.QUANTIFIED;
@@ -122,8 +124,8 @@ class ChartStackedArea extends PureComponent {
 
         // value label
         const valueLabelValue = point.isRange
-          ? `${format('.3s')(point.y[0])}t - ${format('.3s')(point.y[1])}t`
-          : `${format('.3s')(point.y)}t`;
+          ? `${formatLabel(point.y[0])} - ${formatLabel(point.y[1])}`
+          : `${formatLabel(point.y)}`;
         const valueLabel = (
           <Label
             value={valueLabelValue}
@@ -139,9 +141,9 @@ class ChartStackedArea extends PureComponent {
         // RANGES AND POINTS
         const isNotQuantifiable = point.y === null;
         if (point.isRange || isNotQuantifiable) {
-          const key = `${point.label}-${point.y
-            ? point.x + point.y[0] + point.y[1]
-            : point.x}`;
+          const key = `${point.label}-${
+            point.y ? point.x + point.y[0] + point.y[1] : point.x
+          }`;
           return (
             <ReferenceArea
               key={key}
@@ -211,7 +213,7 @@ class ChartStackedArea extends PureComponent {
           style={{ paintOrder: 'stroke' }}
         />
         <Label
-          value={`${format('.3s')(lastData.y)}t`}
+          value={`${formatLabel(lastData.y)}`}
           position="top"
           fill="#113750"
           fontSize="18px"
@@ -285,7 +287,12 @@ class ChartStackedArea extends PureComponent {
               isAnimationActive={false}
               cursor={{ stroke: '#113750', strokeWidth: 2 }}
               content={content => (
-                <TooltipChart content={content} config={config} showTotal />
+                <TooltipChart
+                  content={content}
+                  config={config}
+                  showTotal
+                  customFormatFunction={value => formatLabel(value)}
+                />
               )}
               filterNull={false}
             />

--- a/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
+++ b/app/javascript/app/components/charts/tooltip-chart/tooltip-chart-component.jsx
@@ -1,17 +1,25 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import Proptypes from 'prop-types';
 import { format } from 'd3-format';
 import cx from 'classnames';
 
 import styles from 'styles/themes/chart-tooltip/chart-tooltip.scss';
 
-class TooltipChart extends PureComponent {
-  getFormat() {
-    const { forceFixedFormatDecimals } = this.props;
-    return forceFixedFormatDecimals ? `.${forceFixedFormatDecimals}f` : '.2s';
-  }
+const TooltipChartComponent = ({
+  config,
+  content,
+  showTotal,
+  customD3Format = '.2',
+  customFormatFunction
+}) => {
+  const htmlUnit =
+    config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
+  const valueUnit = htmlUnit === 'CO<sub>2</sub>e' ? 't' : '';
+  const formatValue =
+    customFormatFunction ||
+    (value => `${format(customD3Format)(value)}${valueUnit}`);
 
-  getTotal = (keys, data, unitIsCo2) => {
+  const getTotal = (keys, data) => {
     if (!keys || !data) return '';
     let total = 0;
     let hasData = false;
@@ -21,12 +29,10 @@ class TooltipChart extends PureComponent {
         total += data.payload[key.value];
       }
     });
-    return hasData
-      ? `${format(this.getFormat())(total)}${unitIsCo2 ? 't' : ''}`
-      : 'n/a';
+    return hasData ? `${formatValue(total)}` : 'n/a';
   };
 
-  sortByValue = payload => {
+  const sortByValue = payload => {
     const yValues = payload[0].payload;
     const compare = (a, b) => {
       if (yValues[b.dataKey] === undefined) return -1;
@@ -36,80 +42,64 @@ class TooltipChart extends PureComponent {
     return payload.sort(compare);
   };
 
-  render() {
-    const { config, content, showTotal } = this.props;
-    const unit =
-      config && config.axes && config.axes.yLeft && config.axes.yLeft.unit;
-    const unitIsCo2 = unit === 'CO<sub>2</sub>e';
-    return (
-      <div className={styles.tooltip}>
-        <div className={styles.tooltipHeader}>
-          <span className={cx(styles.labelName, styles.labelNameBold)}>
-            {content.label}
-          </span>
-          <span
-            className={styles.unit}
-            dangerouslySetInnerHTML={{ __html: unit }} // eslint-disable-line
-          />
-        </div>
-        {showTotal && (
-          <div className={cx(styles.label, styles.labelTotal)}>
-            <p>TOTAL</p>
-            <p>
-              {this.getTotal(config.columns.y, content.payload[0], unitIsCo2)}
-            </p>
-          </div>
-        )}
-        {content &&
-          content.payload &&
-          content.payload.length > 0 &&
-          this.sortByValue(content.payload, config).map(
-            y =>
-              (y.payload && y.dataKey !== 'total' ? (
-                <div key={`${y.dataKey}`} className={styles.label}>
-                  <div className={styles.legend}>
-                    <span
-                      className={styles.labelDot}
-                      style={{
-                        backgroundColor:
-                          config.theme[y.dataKey] &&
-                          config.theme[y.dataKey].stroke
-                      }}
-                    />
-                    <p
-                      className={cx(styles.labelName, {
-                        [styles.notAvailable]: !(
-                          y.payload && y.payload[y.dataKey]
-                        )
-                      })}
-                    >
-                      {config.theme[y.dataKey] &&
-                        config.tooltip[y.dataKey].label}
-                    </p>
-                  </div>
-                  <p className={styles.labelValue}>
-                    {y.payload && y.payload[y.dataKey] !== undefined ? (
-                      `${format(this.getFormat())(
-                        y.payload[y.dataKey]
-                      )}${unitIsCo2 ? 't' : ''}`
-                    ) : (
-                      'n/a'
-                    )}
-                  </p>
-                </div>
-              ) : null)
-          )}
-        {content && !content.payload && <div>No data fool</div>}
+  return (
+    <div className={styles.tooltip}>
+      <div className={styles.tooltipHeader}>
+        <span className={cx(styles.labelName, styles.labelNameBold)}>
+          {content.label}
+        </span>
+        <span
+          className={styles.unit}
+          dangerouslySetInnerHTML={{ __html: htmlUnit }} // eslint-disable-line
+        />
       </div>
-    );
-  }
-}
+      {showTotal && (
+        <div className={cx(styles.label, styles.labelTotal)}>
+          <p>TOTAL</p>
+          <p>{getTotal(config.columns.y, content.payload[0])}</p>
+        </div>
+      )}
+      {content &&
+        content.payload &&
+        content.payload.length > 0 &&
+        sortByValue(content.payload, config).map(y =>
+          (y.payload && y.dataKey !== 'total' ? (
+            <div key={`${y.dataKey}`} className={styles.label}>
+              <div className={styles.legend}>
+                <span
+                  className={styles.labelDot}
+                  style={{
+                    backgroundColor:
+                      config.theme[y.dataKey] && config.theme[y.dataKey].stroke
+                  }}
+                />
+                <p
+                  className={cx(styles.labelName, {
+                    [styles.notAvailable]: !(y.payload && y.payload[y.dataKey])
+                  })}
+                >
+                  {config.theme[y.dataKey] && config.tooltip[y.dataKey].label}
+                </p>
+              </div>
+              <p className={styles.labelValue}>
+                {y.payload && y.payload[y.dataKey] !== undefined
+                  ? `${formatValue(y.payload[y.dataKey])}`
+                  : 'n/a'}
+              </p>
+            </div>
+          ) : null)
+        )}
+      {content && !content.payload && <div>No data fool</div>}
+    </div>
+  );
+};
 
-TooltipChart.propTypes = {
+TooltipChartComponent.propTypes = {
   content: Proptypes.object,
   config: Proptypes.object,
   showTotal: Proptypes.bool,
-  forceFixedFormatDecimals: Proptypes.number
+  customD3Format: Proptypes.string,
+  customFormatFunction: Proptypes.func
 };
 
-export default TooltipChart;
+export default TooltipChartComponent;

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -117,10 +117,10 @@ class CountryGhgEmissions extends PureComponent {
     const useLineChart =
       calculationSelected.value === CALCULATION_OPTIONS.PER_CAPITA.value ||
       calculationSelected.value === CALCULATION_OPTIONS.PER_GDP.value;
-    const forceFixedFormatDecimals =
+    const customD3Format =
       calculationSelected.value === CALCULATION_OPTIONS.PER_CAPITA.value
-        ? 2
-        : 0;
+        ? '.2f'
+        : '.0f';
 
     return (
       <Chart
@@ -135,7 +135,7 @@ class CountryGhgEmissions extends PureComponent {
         dataSelected={filtersSelected}
         loading={loading}
         height={360}
-        forceFixedFormatDecimals={forceFixedFormatDecimals}
+        customD3Format={customD3Format}
         stepped={sourceSelected.label === 'UNFCCC'}
       />
     );

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -112,7 +112,8 @@ class EmissionPathwayGraph extends PureComponent {
                 label="Country/Region"
                 options={filtersOptions.locations}
                 onValueChange={option =>
-                  handleSelectorChange(option, 'currentLocation')}
+                  handleSelectorChange(option, 'currentLocation')
+                }
                 value={filtersSelected.location}
                 hideResetButton
               />
@@ -131,7 +132,8 @@ class EmissionPathwayGraph extends PureComponent {
                 hideResetButton
                 disabled={filtersDisabled}
                 onValueChange={option =>
-                  handleSelectorChange(option, 'category')}
+                  handleSelectorChange(option, 'category')
+                }
                 value={filtersSelected.category}
               />
               <Dropdown
@@ -141,7 +143,8 @@ class EmissionPathwayGraph extends PureComponent {
                 hideResetButton
                 disabled={filtersDisabled}
                 onValueChange={option =>
-                  handleSelectorChange(option, 'subcategory')}
+                  handleSelectorChange(option, 'subcategory')
+                }
                 value={filtersSelected.subcategory}
               />
               <Dropdown
@@ -151,7 +154,8 @@ class EmissionPathwayGraph extends PureComponent {
                 hideResetButton
                 disabled={filtersDisabled}
                 onValueChange={option =>
-                  handleSelectorChange(option, 'indicator')}
+                  handleSelectorChange(option, 'indicator')
+                }
                 value={filtersSelected.indicator}
               />
             </div>
@@ -169,7 +173,7 @@ class EmissionPathwayGraph extends PureComponent {
             loading={loading}
             error={error}
             targetParam="scenario"
-            forceFixedFormatDecimals={3}
+            customD3Format={'.3f'}
             margin={{ top: 50 }}
             espGraph
             model={model || null}

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -163,7 +163,7 @@ class EmissionPathwayGraph extends PureComponent {
           loading={loading}
           error={error}
           targetParam="scenario"
-          forceFixedFormatDecimals={3}
+          customD3Format={'.3f'}
           margin={{ top: 50 }}
           espGraph
           model={model || null}

--- a/app/javascript/app/utils/d3-custom-format.js
+++ b/app/javascript/app/utils/d3-custom-format.js
@@ -1,0 +1,11 @@
+import { formatPrefix } from 'd3-format';
+
+export const formatSIwithDecimals = (value, precision = 2, unit = '') =>
+  /*
+    Formats label with an SI prefix and fixed number of decimal digits, e.g.:
+      11592122500 -> 11.59G
+      5372.28744 -> 5.37k
+      4.731 -> 4.73
+  */
+  `${formatPrefix(`.${precision}`, value)(value)}${unit}`
+;


### PR DESCRIPTION
This PR changes the rounding of the  `country-ghg` chart values  - now they always have two decimal digits for stacked-chart metrics (`Cumulative across...`, `Percentage change...` and `Total`).
[PIVOTAL](https://www.pivotaltracker.com/story/show/172721275)

I added new format features to the `TooltipChart` component:
- `customD3Format` -  custom d3 format, before it was the number of significant digits
- `customFormatFunction` - custom format function,

Also, I added a new utils file `utils/d3-custom-format.js` with `formatSIwithDecimals`  function. It returns a value with an  SI prefix and with a fixed number of decimal digits, which was not possible using a regular format.

![image](https://user-images.githubusercontent.com/15097138/81677962-9b7ace80-9451-11ea-876d-251c29a13bce.png)
