### PR TITLE
Enable download button on the countries emission chart

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -52,7 +52,8 @@ class CountryGhgEmissions extends PureComponent {
       handleInfoClick,
       handleAnalyticsClick,
       isEmbed,
-      isNdcp
+      isNdcp,
+      downloadLink
     } = this.props;
 
     const buttonGroupConfig = isEmbed
@@ -70,7 +71,8 @@ class CountryGhgEmissions extends PureComponent {
         },
         {
           type: 'download',
-          section: 'ghg-emissions'
+          section: 'ghg-emissions',
+          link: downloadLink
         },
         {
           type: 'addToUser'
@@ -222,7 +224,8 @@ CountryGhgEmissions.propTypes = {
   handleAnalyticsClick: PropTypes.func.isRequired,
   handleYearHover: PropTypes.func,
   handleSourceChange: PropTypes.func.isRequired,
-  handleCalculationChange: PropTypes.func.isRequired
+  handleCalculationChange: PropTypes.func.isRequired,
+  downloadLink: PropTypes.string
 };
 
 CountryGhgEmissions.defaultProps = {

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-selectors.js
@@ -8,6 +8,7 @@ import orderBy from 'lodash/orderBy';
 import flatten from 'lodash/flatten';
 import sumBy from 'lodash/sumBy';
 import { getGhgEmissionDefaults, calculatedRatio } from 'utils/ghg-emissions';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 
 import {
   getYColumnValue,
@@ -151,6 +152,24 @@ export const getSelectorDefaults = createSelector(
   (sourceSelected, meta) => {
     if (!sourceSelected || !meta || isEmpty(meta)) return null;
     return getGhgEmissionDefaults(sourceSelected, meta);
+  }
+);
+
+export const getDownloadLink = createSelector(
+  [getSourceSelected, getIso, getFilterSelection, getSelectorDefaults],
+  (sourceSelected, iso, filtersSelected, selectorDefaults) => {
+    if (!sourceSelected || !iso || !selectorDefaults) return null;
+    const searchParams = {
+      source: sourceSelected.value,
+      regions: iso,
+      sectors: filtersSelected || '',
+      gases: selectorDefaults.gas
+    };
+    const link = generateLinkToDataExplorer(
+      searchParams,
+      'historical-emissions'
+    );
+    return link;
   }
 );
 
@@ -349,5 +368,6 @@ export default {
   getSourceSelected,
   getFilterOptions,
   getFiltersSelected,
-  getCalculationData
+  getCalculationData,
+  getDownloadLink
 };

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -28,7 +28,8 @@ import {
   getQuantificationsData,
   getQuantificationsTagsConfig,
   getFilterOptions,
-  getFiltersSelected
+  getFiltersSelected,
+  getDownloadLink
 } from './country-ghg-emissions-selectors';
 
 const actions = { ...ownActions, ...modalActions };
@@ -67,7 +68,8 @@ const mapStateToProps = (state, { location, match }) => {
     filtersOptions: getFilterOptions(countryGhg),
     filtersSelected: getFiltersSelected(countryGhg),
     config: getChartConfig(countryGhg),
-    selectorDefaults: getSelectorDefaults(countryGhg)
+    selectorDefaults: getSelectorDefaults(countryGhg),
+    downloadLink: getDownloadLink(countryGhg)
   };
 };
 


### PR DESCRIPTION
This PR fixes the download link button on the countries emission chart
[PIVOTAL](https://www.pivotaltracker.com/story/show/172720434)
![image](https://user-images.githubusercontent.com/15097138/81819485-a99f1c80-952f-11ea-9ddf-9f98c24b9b01.png)

After click it opens the data explorer with filters:
- country iso code,
- selected sectors,
- selected source,
- `All GHG` gas,

**Test:** Go to the [countries](http://localhost:3000/countries/ALB) page, change filters, and click on the download button - check if filters on data explorer page are the same as on the country page.
