### PR TITLE
Filter out "Cumulative" calculation option when UNFCCC Non-Annex is selected

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -115,10 +115,29 @@ const getBreakByOptions = () =>
       }
     ]);
 
+// Filtered calculation selectors
+const getFilteredCalculationOptions = createSelector(
+  [getCalculationOptions, getSourceSelected],
+  (calculationOptions, sourceSelected) => {
+    if (!calculationOptions || !sourceSelected) return null;
+    if (sourceSelected.name === 'UNFCCC_NAI') {
+      return calculationOptions.filter(({ value }) => value !== 'CUMULATIVE');
+    }
+    return calculationOptions;
+  }
+);
+
 export const getCalculationSelected = createSelector(
-  [getCalculationOptions, getSelection('calculation'), getSelection('breakBy')],
+  [
+    getFilteredCalculationOptions,
+    getSelection('calculation'),
+    getSelection('breakBy')
+  ],
   (options, selected, breakBySelected) => {
     if (!options) return null;
+    const defaultOption = options.find(
+      ({ value }) => value === DEFAULTS.calculation
+    );
     if (!selected) {
       const breakByArray = breakBySelected && breakBySelected.split('-');
       if (breakByArray && breakByArray[1]) {
@@ -126,12 +145,10 @@ export const getCalculationSelected = createSelector(
           o => o.value === breakByArray[1] // to support legacy URLs
         );
       }
-
-      const defaultOption = options.find(b => b.value === DEFAULTS.calculation);
       return defaultOption || options[0];
     }
-
-    return options.find(o => o.value === selected);
+    const selectedCalculation = options.find(o => o.value === selected);
+    return selectedCalculation || defaultOption;
   }
 );
 
@@ -286,7 +303,7 @@ export const getOptions = createStructuredSelector({
   sources: getSourceOptions,
   chartType: getChartTypeOptions,
   breakBy: getBreakByOptions,
-  calculation: getCalculationOptions,
+  calculation: getFilteredCalculationOptions,
   regions: getRegionOptions,
   sectors: getSectorOptions,
   gases: getGasOptions
@@ -334,7 +351,6 @@ const getFiltersSelected = field =>
           isIncluded(field, selectedValues, filter)
         );
       }
-
       return selectedFilters;
     }
   );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -121,7 +121,9 @@ const getFilteredCalculationOptions = createSelector(
   (calculationOptions, sourceSelected) => {
     if (!calculationOptions || !sourceSelected) return null;
     if (sourceSelected.name === 'UNFCCC_NAI') {
-      return calculationOptions.filter(({ value }) => value !== 'CUMULATIVE');
+      return calculationOptions.filter(
+        ({ value }) => value !== CALCULATION_OPTIONS.CUMULATIVE.value
+      );
     }
     return calculationOptions;
   }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -122,7 +122,7 @@ const getFilteredCalculationOptions = createSelector(
     if (!calculationOptions || !sourceSelected) return null;
     if (sourceSelected.name === 'UNFCCC_NAI') {
       return calculationOptions.filter(
-        ({ value }) => value !== CALCULATION_OPTIONS.CUMULATIVE.value
+        ({ value }) => value !== GHG_CALCULATION_OPTIONS.CUMULATIVE.value
       );
     }
     return calculationOptions;


### PR DESCRIPTION
This small PR filters out the "Cumulative..."  calculation option when `UNFCCC Non-Annex I` source is selected. This change is required by the client, check the pivotal tracker ticket:
[PIVOTAL](https://www.pivotaltracker.com/story/show/172815461)
![image](https://user-images.githubusercontent.com/15097138/81918335-9f842900-95d6-11ea-8fb1-019d1a895057.png)
