### PR TITLE
Split GHG calculations from rest of calculation options on the page. Fix compare chart calculations

### DIFF
--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
@@ -224,25 +224,23 @@ export const getChartData = createSelector(
     selectedLocations,
     calculationSelected
   ) => {
-    const oneOfAbsoluteValueCalculationsIsSelected = [
-      CALCULATION_OPTIONS.ABSOLUTE_VALUE.value,
-      CALCULATION_OPTIONS.CUMULATIVE.value,
-      CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value
-    ].includes(calculationSelected && calculationSelected.value);
+    const AbsoluteValueCalculationIsSelected =
+      calculationSelected &&
+      calculationSelected.value === CALCULATION_OPTIONS.ABSOLUTE_VALUE.value;
     if (
       !data ||
       !data.length ||
       !filters ||
       !calculationSelected ||
       !selectedLocations ||
-      (!oneOfAbsoluteValueCalculationsIsSelected && !locationCalculationData)
+      (!AbsoluteValueCalculationIsSelected && !locationCalculationData)
     ) {
       return [];
     }
 
     const yearsForLocation = getYearsForLocation(
       data,
-      oneOfAbsoluteValueCalculationsIsSelected,
+      AbsoluteValueCalculationIsSelected,
       locationCalculationData
     );
     const yearData = [];
@@ -255,7 +253,7 @@ export const getChartData = createSelector(
       yearsWithData.forEach(year => {
         const yData = d.emissions.find(e => e.year === year);
         if (yData) {
-          const calculationRatio = oneOfAbsoluteValueCalculationsIsSelected
+          const calculationRatio = AbsoluteValueCalculationIsSelected
             ? 1
             : calculatedRatio(
               calculationSelected.value,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -4,7 +4,7 @@ import startCase from 'lodash/startCase';
 import isArray from 'lodash/isArray';
 import { isPageContained } from 'utils/navigation';
 import cx from 'classnames';
-import { GHG_TABLE_HEADER, CALCULATION_OPTIONS } from 'data/constants';
+import { GHG_TABLE_HEADER, GHG_CALCULATION_OPTIONS } from 'data/constants';
 import {
   Chart,
   Multiselect,
@@ -232,7 +232,7 @@ function GhgEmissions(props) {
     const tableDataReady = !loading && tableData && tableData.length;
     const isPercentageChangeCalculation =
       selectedOptions.calculationSelected.value ===
-      CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
+      GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
 
     const percentageChangeCustomLabelFormat = value => {
       if (value === undefined) {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -22,7 +22,7 @@ import {
   CHART_COLORS_EXTENDED,
   CHART_COLORS_EXTRA,
   OTHER_COLOR,
-  CALCULATION_OPTIONS
+  GHG_CALCULATION_OPTIONS
 } from 'data/constants';
 import { europeSlug } from 'app/data/european-countries';
 import {
@@ -337,8 +337,8 @@ export const getChartData = createSelector(
     }
     const yearValues = data[0].emissions.map(d => d.year);
     const metricField = {
-      [CALCULATION_OPTIONS.PER_CAPITA.value]: 'population',
-      [CALCULATION_OPTIONS.PER_GDP.value]: 'gdp'
+      [GHG_CALCULATION_OPTIONS.PER_CAPITA.value]: 'population',
+      [GHG_CALCULATION_OPTIONS.PER_GDP.value]: 'gdp'
     }[metric];
     const shouldHaveMetricData = !!metricField;
 
@@ -401,7 +401,9 @@ export const getChartData = createSelector(
     const getItemValue = (totalValue, key, totalMetric, year) => {
       let scaledValue = totalValue ? totalValue * DATA_SCALE : null;
 
-      if (calculationSelected.value === CALCULATION_OPTIONS.CUMULATIVE.value) {
+      if (
+        calculationSelected.value === GHG_CALCULATION_OPTIONS.CUMULATIVE.value
+      ) {
         if (scaledValue) {
           if (accumulatedValues[key]) {
             if (!dataZoomYears || year > dataZoomYears.min) {
@@ -416,7 +418,7 @@ export const getChartData = createSelector(
 
       if (
         calculationSelected.value ===
-        CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value
+        GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value
       ) {
         const currentYearValue = scaledValue || 0;
         if (scaledValue) {
@@ -529,7 +531,8 @@ export const getChartConfig = createSelector(
     if (!model || !yColumns) return null;
     const colorPalette = getColorPalette(yColumns);
     const isPercentageChangeCalculation =
-      calculationSelected.value === CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
+      calculationSelected.value ===
+      GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
     colorThemeCache = getThemeConfig(yColumns, colorPalette, colorThemeCache);
     const tooltip = getTooltipConfig(yColumns.filter(c => c && !c.hideLegend));
     const unit = getUnit(metric);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -10,7 +10,7 @@ import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
   TOP_EMITTERS_OPTION,
-  CALCULATION_OPTIONS
+  GHG_CALCULATION_OPTIONS
 } from 'data/constants';
 import {
   getMeta,
@@ -24,8 +24,8 @@ const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
 const DEFAULTS = {
   breakBy: FEATURE_NEW_GHG
     ? 'regions'
-    : `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`,
-  calculation: CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
+    : `regions-${GHG_CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`,
+  calculation: GHG_CALCULATION_OPTIONS.ABSOLUTE_VALUE.value
 };
 
 const getOptionSelectedFunction = filter => (options, selected) => {
@@ -62,11 +62,11 @@ const getSourceSelected = createSelector(
 
 // Calculation selectors
 const getCalculationOptions = () =>
-  Object.keys(CALCULATION_OPTIONS).reduce(
+  Object.keys(GHG_CALCULATION_OPTIONS).reduce(
     (acc, key) =>
       acc.concat({
-        label: CALCULATION_OPTIONS[key].label,
-        value: CALCULATION_OPTIONS[key].value
+        label: GHG_CALCULATION_OPTIONS[key].label,
+        value: GHG_CALCULATION_OPTIONS[key].value
       }),
     []
   );
@@ -95,15 +95,15 @@ const getBreakByOptions = () =>
     : [
       {
         label: 'Regions',
-        value: `regions-${CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
+        value: `regions-${GHG_CALCULATION_OPTIONS.ABSOLUTE_VALUE.value}`
       },
       {
         label: 'Regions-Per Capita',
-        value: `regions-${CALCULATION_OPTIONS.PER_CAPITA.value}`
+        value: `regions-${GHG_CALCULATION_OPTIONS.PER_CAPITA.value}`
       },
       {
         label: 'Regions-Per GDP',
-        value: `regions-${CALCULATION_OPTIONS.PER_GDP.value}`
+        value: `regions-${GHG_CALCULATION_OPTIONS.PER_GDP.value}`
       },
       {
         label: 'Sectors',
@@ -407,7 +407,7 @@ const getChartConflicts = (metricSelected, chartSelected) => {
     ['PER_CAPITA', 'PER_GDP', 'PERCENTAGE_CHANGE'].includes(metricSelected) &&
     chartSelected.value !== 'line'
   ) {
-    const metricOption = CALCULATION_OPTIONS[metricSelected];
+    const metricOption = GHG_CALCULATION_OPTIONS[metricSelected];
     conflicts.push(
       `${metricOption.label} metric is not allowed with ${chartSelected.label} chart`
     );

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -16,7 +16,7 @@ export const ESP_HOST = ESP_API.replace('/api/v1', '');
 
 export const SOCIAL_APP_NAMES = ['twitter', 'facebook', 'google'];
 
-export const CALCULATION_OPTIONS = {
+export const GHG_CALCULATION_OPTIONS = {
   ABSOLUTE_VALUE: {
     label: 'Total',
     value: 'ABSOLUTE_VALUE'
@@ -36,6 +36,21 @@ export const CALCULATION_OPTIONS = {
   PERCENTAGE_CHANGE: {
     label: 'Percentage change from prior year',
     value: 'PERCENTAGE_CHANGE'
+  }
+};
+
+export const CALCULATION_OPTIONS = {
+  ABSOLUTE_VALUE: {
+    label: 'Total',
+    value: 'ABSOLUTE_VALUE'
+  },
+  PER_CAPITA: {
+    label: 'per Capita',
+    value: 'PER_CAPITA'
+  },
+  PER_GDP: {
+    label: 'per GDP',
+    value: 'PER_GDP'
   }
 };
 

--- a/app/javascript/app/utils/ghg-emissions.js
+++ b/app/javascript/app/utils/ghg-emissions.js
@@ -1,6 +1,6 @@
 import {
   DEFAULT_EMISSIONS_SELECTIONS,
-  CALCULATION_OPTIONS
+  GHG_CALCULATION_OPTIONS
 } from 'data/constants';
 import kebabCase from 'lodash/kebabCase';
 
@@ -32,11 +32,11 @@ export const getGhgEmissionDefaultSlugs = (source, meta) => {
 
 export const calculatedRatio = (selected, calculationData, x) => {
   if (!calculationData || !calculationData[x]) return 1;
-  if (selected === CALCULATION_OPTIONS.PER_GDP.value) {
+  if (selected === GHG_CALCULATION_OPTIONS.PER_GDP.value) {
     // GDP is in dollars and we want to display it in million dollars
     return calculationData[x][0].gdp / 1000000;
   }
-  if (selected === CALCULATION_OPTIONS.PER_CAPITA.value) {
+  if (selected === GHG_CALCULATION_OPTIONS.PER_CAPITA.value) {
     return calculationData[x][0].population;
   }
   return 1;


### PR DESCRIPTION
Only the GHG emissions page has cumulative and percentage change calculations. Also compare page was using some conditions based on these calculation options.

Please check all charts: Country GHG chart, Compare GHG chart and GHG emissions chart