### PR TITLE
Adds LTS Content overview for Summary tab and Country page

### DIFF
--- a/app/controllers/api/v1/lts_controller.rb
+++ b/app/controllers/api/v1/lts_controller.rb
@@ -1,0 +1,36 @@
+module Api
+  module V1
+    LtsOverview = Struct.new(:values) do
+      alias_method :read_attribute_for_serialization, :send
+    end
+
+    class LtsController < Api::V1::NdcsController
+      SUMMARY_INDICATORS = [
+        'lts_vision',
+        'lts_document',
+        'lts_date',
+        'lts_target',
+        'lts_m_tt',
+        'lts_a_otc'
+      ].freeze
+
+      def content_overview
+        location = Location.find_by!(iso_code3: params[:code])
+
+        values = ::Indc::Value.
+          includes(:indicator, :location).
+          where(
+            indc_indicators: {
+              slug: SUMMARY_INDICATORS
+            }, locations: {
+              iso_code3: params[:code]
+            }
+          ).
+          order('indc_indicators.name')
+
+        render json: LtsOverview.new(values),
+               serializer: Api::V1::Indc::LtsOverviewSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/indc/lts_overview_serializer.rb
+++ b/app/serializers/api/v1/indc/lts_overview_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    module Indc
+      class LtsOverviewSerializer < ActiveModel::Serializer
+        has_many :values,
+                 serializer: Api::V1::Indc::ValueOverviewSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,11 @@ Rails.application.routes.draw do
         get :countries_documents, on: :collection, controller: :ndc_documents, action: :index
       end
 
+      resources :lts, param: :code, only: [:index] do
+        get :content_overview, on: :member, controller: :lts,
+          action: :content_overview
+      end
+
       resources :adaptations, only: [:index]
       resources :quantifications, only: [:index]
 


### PR DESCRIPTION
This enables the following endpoint to be used on the
LTS Country page summary tab:

* http://localhost:3000/api/v1/lts/USA/content_overview

This endpoint should also be used on the main country page for the
LTS Content Overview.

As a bonus I also added an LTS indicator URL that works just like the
NDCs indicator one, if we want to update the various pages of the LTS
Explorer to use a more semantically accurate URL:

* http://localhost:3000/api/v1/lts?location=CAN&category=mitigation&source=LTS&filter=overview

It works exactly like the existing, with the same parameters.

* http://localhost:3000/api/v1/ndcs?location=CAN&category=mitigation&source=CAIT&filter=overview