### PR TITLE
Fix broken UNFCCC sources selection on the country-compare page

### DIFF
--- a/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
+++ b/app/javascript/app/components/compare/compare-ghg-chart/compare-ghg-chart-selectors.js
@@ -81,7 +81,8 @@ export const getSourceOptions = createSelector(getSources, sources => {
     label: d.label,
     value: d.value,
     source: d.source,
-    sectors: d.sector
+    sectors: d.sector,
+    name: d.name
   }));
 });
 
@@ -148,12 +149,14 @@ export const filterData = createSelector(
     // Filter by source and gas
     filteredData = filteredData.filter(
       d =>
-        d.source === source.label &&
+        d.source === source.name &&
         (d.gas === 'All GHG' || d.gas === 'Aggregate GHGs')
     );
 
     // Filter by sector
-    const defaultSector = [DEFAULT_EMISSIONS_SELECTIONS[source.label].sector];
+    const defaultSector = DEFAULT_EMISSIONS_SELECTIONS[source.name]
+      ? [DEFAULT_EMISSIONS_SELECTIONS[source.name].sector]
+      : [];
     const sectorFilters =
       sectors && sectors.length && sectorOptions.length !== sectors.length
         ? sectors.map(s => s.label)


### PR DESCRIPTION
This small PR fixes the application error when any of the `UNFCCC` sources is selected on the country compare page. The small change I've made there is to use `source.name` (slug) instead of `source.label`. For other sources the name and the label are the same, but for `UNFCCC Annex I` and `UNFCCC Non-Annex I` they are different.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172839719)

**Test:** Go to the [country compare page](http://localhost:3000/countries/compare?locations=DZA), and change selection to any of the UNFCCC sources - the console shouldn't throw any error and the page shouldn't crash.