### PR TITLE
Links indc_submissions with indc_documents

### DIFF
--- a/app/models/indc/document.rb
+++ b/app/models/indc/document.rb
@@ -1,5 +1,6 @@
 class Indc::Document < ApplicationRecord
   has_many :values, class_name: 'Indc::Value'
+  has_many :submissions, class_name: 'Indc::Submission'
   has_many :locations, through: :values
 
   def as_json(_={})

--- a/app/models/indc/submission.rb
+++ b/app/models/indc/submission.rb
@@ -1,6 +1,7 @@
 module Indc
   class Submission < ApplicationRecord
     belongs_to :location
+    belongs_to :document, class_name: 'Indc::Document', optional: true
 
     validates :submission_type, presence: true
     validates :language, presence: true

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -8,8 +8,10 @@ module Api
           object.data.map do |datum|
             [datum.iso_code3,
              ::Indc::Document.joins(values: :location).
-             where(locations: {iso_code3: datum.iso_code3}).
-             order(:ordering).distinct.to_a
+               joins('LEFT OUTER JOIN indc_submissions ON indc_submissions.document_id = indc_documents.id AND indc_submissions.location_id = locations.id').
+               where(locations: {iso_code3: datum.iso_code3}).
+               select('indc_documents.*, indc_submissions.submission_date').
+               order(:ordering).distinct.to_a
              ]
           end.to_h
         end

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -159,12 +159,14 @@ class ImportIndc
   end
 
   def submission_attributes(location, submission)
+    doc_slug = submission[:type]&.parameterize&.gsub('-', '_')
     {
       location: location,
       submission_type: submission[:type],
       language: submission[:language],
       submission_date: submission[:date_of_submission],
-      url: submission[:url]
+      url: submission[:url],
+      document_id: ::Indc::Document.find_by(slug: doc_slug)&.id
     }
   end
 

--- a/db/migrate/20200521120158_add_document_id_to_indc_submissions.rb
+++ b/db/migrate/20200521120158_add_document_id_to_indc_submissions.rb
@@ -1,0 +1,5 @@
+class AddDocumentIdToIndcSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :indc_submissions, :document, foreign_key: { to_table: :indc_documents }
+  end
+end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -11,7 +11,7 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,7 +30,7 @@ CREATE FUNCTION public.emissions_filter_by_year_range(emissions jsonb, start_yea
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
@@ -1125,7 +1125,8 @@ CREATE TABLE public.indc_submissions (
     submission_date date NOT NULL,
     url text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    document_id bigint
 );
 
 
@@ -3400,6 +3401,13 @@ CREATE UNIQUE INDEX index_indc_sources_on_name ON public.indc_sources USING btre
 
 
 --
+-- Name: index_indc_submissions_on_document_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_indc_submissions_on_document_id ON public.indc_submissions USING btree (document_id);
+
+
+--
 -- Name: index_indc_submissions_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3711,6 +3719,14 @@ ALTER TABLE ONLY public.indc_sectors
 
 ALTER TABLE ONLY public.ndcs
     ADD CONSTRAINT fk_rails_19d1c9c3f7 FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: indc_submissions fk_rails_1d04ac5809; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.indc_submissions
+    ADD CONSTRAINT fk_rails_1d04ac5809 FOREIGN KEY (document_id) REFERENCES public.indc_documents(id);
 
 
 --
@@ -4243,6 +4259,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200317210227'),
 ('20200317210928'),
 ('20200423085052'),
-('20200503165104');
+('20200503165104'),
+('20200521120158');
 
 


### PR DESCRIPTION
Includes submission date on the /api/v1/ndcs/countries_documents?location=USA
endpoint.

To test you need to run:

```
bundle exec rails db:migrate
bundle exec rails indc:import
```

When hitting this endpoint:

`/api/v1/ndcs/countries_documents?location=USA` , with our without filter you will get the submission date for each of the countries document, on the `data` object.