### PR TITLE
Fix/embed meta and share modals

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-actions/countries-actions-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-actions/countries-actions-component.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Switch } from 'cw-components';
+import ModalMetadata from 'components/modal-metadata';
+import ModalShare from 'components/modal-share';
 import NdcsMap from './ndcs-map';
 import NdcsTable from './ndcs-table';
 import styles from './countries-actions-styles';
@@ -28,8 +30,10 @@ class CountriesActions extends PureComponent {
     const {
       handleSwitchClick,
       query,
-      countriesCountWithProposedActions
+      countriesCountWithProposedActions,
+      location
     } = this.props;
+
     const switchOption = query.display || 'map';
     const Component = SwitchOptions[switchOption];
     const { m_agriculture, a_agriculture } = countriesCountWithProposedActions;
@@ -64,6 +68,10 @@ class CountriesActions extends PureComponent {
             />
           </div>
           <Component />
+          <ModalMetadata />
+          <ModalShare
+            analyticsName={`Agriculture countries ${location.hash}`}
+          />
         </div>
       </React.Fragment>
     );
@@ -73,6 +81,7 @@ class CountriesActions extends PureComponent {
 CountriesActions.propTypes = {
   handleSwitchClick: PropTypes.func.isRequired,
   query: PropTypes.object.isRequired,
+  location: PropTypes.object,
   countriesCountWithProposedActions: PropTypes.number
 };
 

--- a/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/countries-context-component.jsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Switch } from 'cw-components';
 import Loading from 'components/loading';
+import ModalMetadata from 'components/modal-metadata';
+import ModalShare from 'components/modal-share';
 import WbCountryDataProvider from 'providers/wb-country-data-provider';
 import AgricultureCountriesContextProvider from 'providers/agriculture-countries-context-provider';
 import ContextByCountry from './context-by-country';
@@ -28,7 +30,13 @@ const SwitchOptionsComponents = {
 
 class CountriesContext extends PureComponent {
   render() {
-    const { query, selectedCountry, handleSwitchClick, loading } = this.props;
+    const {
+      query,
+      selectedCountry,
+      handleSwitchClick,
+      loading,
+      location
+    } = this.props;
     const switchOption = (query && query.contextBy) || 'indicator';
 
     const Component = SwitchOptionsComponents[switchOption];
@@ -70,6 +78,8 @@ class CountriesContext extends PureComponent {
         <AgricultureCountriesContextProvider
           country={selectedCountry && selectedCountry.value}
         />
+        <ModalMetadata />
+        <ModalShare analyticsName={`Agriculture countries ${location.hash}`} />
       </div>
     );
   }
@@ -82,6 +92,7 @@ CountriesContext.propTypes = {
     label: PropTypes.string
   }),
   loading: PropTypes.bool,
+  location: PropTypes.object,
   handleSwitchClick: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -51,6 +51,7 @@ class EmissionPathwayGraph extends PureComponent {
       {
         type: 'share',
         shareUrl: '/embed/agriculture-emission/pathways',
+        analyticsGraphName: 'Drivers of Emissions',
         positionRight: true
       },
       {

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -50,7 +50,7 @@ class EmissionPathwayGraph extends PureComponent {
       },
       {
         type: 'share',
-        analyticsGraphName: 'Drivers of Emissions',
+        shareUrl: '/embed/agriculture-emission/pathways',
         positionRight: true
       },
       {

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agriculture-component.jsx
@@ -5,8 +5,6 @@ import Waypoint from 'react-waypoint';
 import Header from 'components/header';
 import Intro from 'components/intro';
 import AnchorNav from 'components/anchor-nav';
-import ModalMetadata from 'components/modal-metadata';
-import ModalShare from 'components/modal-share';
 import Sticky from 'react-stickynode';
 import cx from 'classnames';
 import { updateUrlHash } from 'utils/navigation';
@@ -66,8 +64,6 @@ class SectorsAgriculture extends PureComponent {
               <div className={styles.sectionComponent}>
                 <div id={section.hash} className={styles.sectionHash} />
                 <section.component />
-                <ModalMetadata />
-                <ModalShare analyticsName={`Agriculture ${section.hash}`} />
               </div>
             </Waypoint>
           ))}

--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -11,6 +11,7 @@ import CountryLtsOverview from 'components/country/country-lts-overview';
 import NDCSDGLinkages from 'components/country/country-ndc-sdg-linkages';
 import NdcSdgLinkagesContent from 'components/ndc-sdg/ndc-sdg-linkages-content';
 import EmissionPathwaysGraph from 'components/emission-pathways/emission-pathways-graph';
+import AgricultureEmissionPathwaysGraph from 'components/sectors-agriculture/drivers-of-emissions/emission-pathways-graph';
 import MyVisualisationsGraphComponent from 'components/my-climate-watch/my-visualisations/my-cw-vis-graph';
 import AgricultureEmissionPieChart from 'components/sectors-agriculture/drivers-of-emissions/card-pie-chart/card-pie-chart';
 import CountriesContext from 'components/sectors-agriculture/countries-context';
@@ -89,6 +90,11 @@ export default [
   {
     path: '/embed/agriculture-emission',
     component: AgricultureEmissionPieChart,
+    exact: true
+  },
+  {
+    path: '/embed/agriculture-emission/pathways',
+    component: AgricultureEmissionPathwaysGraph,
     exact: true
   },
   {


### PR DESCRIPTION
This small PR fixes broken metadata modals in embed view for agriculture page sections. 
[PIVOTAL](https://www.pivotaltracker.com/story/show/172996525)

**Test**: Go to `sectors/agriculture` page and test metadata modals in embed mode for each section.
**Note:** The first section `Drivers of emissions/Historical Emissions` enables sharing only the Piechart, not the entire section. I think it was a design decision back then, keep that in mind.