### PR TITLE
Feature/integrate laws target data

### DIFF
--- a/app/controllers/api/v1/lse_laws_and_policies_controller.rb
+++ b/app/controllers/api/v1/lse_laws_and_policies_controller.rb
@@ -6,7 +6,7 @@ module Api
       def show
         id = params[:id] == 'EUU' ? 'EUR' : params[:id]
 
-        laws_and_policies = SingleRecordFetcher.new(LSE_API, id).call
+        laws_and_policies = SingleRecordFetcher.new(LSE_API, id, id).call
         render json: laws_and_policies
       end
     end

--- a/app/controllers/api/v1/ndc_documents_controller.rb
+++ b/app/controllers/api/v1/ndc_documents_controller.rb
@@ -1,11 +1,15 @@
 module Api
   module V1
-    CountriesDocuments = Struct.new(:data) do
+    CountriesDocuments = Struct.new(:data, :laws_info) do
       alias_method :read_attribute_for_serialization, :send
     end
     class NdcDocumentsController < ApiController
+      LSE_API = 'https://climate-laws.org/cclow/api/targets'.freeze
+
       def index
-        render json: CountriesDocuments.new(set_locations(params)),
+        laws_info = SingleRecordFetcher.new(LSE_API, 'laws-info').call
+
+        render json: CountriesDocuments.new(set_locations(params), laws_info),
                serializer: Api::V1::Indc::CountriesDocumentsSerializer
       end
 

--- a/app/controllers/api/v1/ndc_documents_controller.rb
+++ b/app/controllers/api/v1/ndc_documents_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    CountriesDocuments = Struct.new(:data, :laws_info) do
+    CountriesDocuments = Struct.new(:data, :laws_info, :laws_and_policies) do
       alias_method :read_attribute_for_serialization, :send
     end
     class NdcDocumentsController < ApiController
@@ -9,7 +9,12 @@ module Api
       def index
         laws_info = SingleRecordFetcher.new(LSE_API, 'laws-info').call
 
-        render json: CountriesDocuments.new(set_locations(params), laws_info),
+        laws_and_policies = if params[:location].present?
+          iso = params[:location] == 'EUU' ? 'EUR' : params[:location]
+          SingleRecordFetcher.new(LSE_API, iso, iso).call
+        end
+
+        render json: CountriesDocuments.new(set_locations(params), laws_info, laws_and_policies),
                serializer: Api::V1::Indc::CountriesDocumentsSerializer
       end
 

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -55,11 +55,37 @@ module Api
         end
 
         def laws
-          {}
+          return {} unless object.laws_and_policies && object.laws_and_policies['targets']
+
+          object.laws_and_policies['targets'].map do |target|
+            next if target['sources'].empty? || target['sources'].first['type'] != 'law'
+
+            source = target['sources'].first
+
+            {
+              id: source['id'],
+              slug: source['title'].parameterize,
+              long_name: source['title'],
+              url: source['link']
+            }
+          end.compact.uniq
         end
 
         def policies
-          {}
+          return {} unless object.laws_and_policies && object.laws_and_policies['targets']
+
+          object.laws_and_policies['targets'].map do |target|
+            next if target['sources'].empty? || target['sources'].first['type'] == 'law'
+
+            source = target['sources'].first
+
+            {
+              id: source['id'],
+              slug: source['title'].parameterize,
+              long_name: source['title'],
+              url: source['link']
+            }
+          end.compact.uniq
         end
       end
     end

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -6,13 +6,29 @@ module Api
 
         def data
           object.data.map do |datum|
-            [datum.iso_code3,
-             ::Indc::Document.joins(values: :location).
+            docs = ::Indc::Document.joins(values: :location).
                joins('LEFT OUTER JOIN indc_submissions ON indc_submissions.document_id = indc_documents.id AND indc_submissions.location_id = locations.id').
                where(locations: {iso_code3: datum.iso_code3}).
                select('indc_documents.*, indc_submissions.submission_date').
                order(:ordering).distinct.to_a
-             ]
+
+            if object.laws_info[datum.iso_code3]
+              ordering = docs.empty? ? 0 : docs.last["ordering"]
+              docs += object.laws_info[datum.iso_code3].map do |key, val|
+                next unless val
+                ordering += 1
+                {
+                  id: nil,
+                  ordering: ordering,
+                  slug: key.gsub('in_', ''),
+                  long_name: key.gsub('in_', '').titleize,
+                  description: "Targets in #{key.gsub('in_', '').titleize}",
+                  is_ndc: false
+                }
+              end.compact
+            end
+
+            [datum.iso_code3, docs]
           end.to_h
         end
 

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -23,7 +23,8 @@ module Api
                   slug: key.gsub('in_', ''),
                   long_name: key.gsub('in_', '').titleize,
                   description: "Targets in #{key.gsub('in_', '').titleize}",
-                  is_ndc: false
+                  is_ndc: false,
+                  submission_date: nil
                 }
               end.compact
             end

--- a/app/services/single_record_fetcher.rb
+++ b/app/services/single_record_fetcher.rb
@@ -1,14 +1,16 @@
 class SingleRecordFetcher
-  attr_reader :url, :id
+  attr_reader :url, :id, :cache_key
 
-  def initialize(url, id)
+  def initialize(url, cache_key, id=nil)
     @id = id
     @url = url
+    @cache_key = cache_key
   end
 
   def call
-    Rails.cache.fetch("#{id}/laws_and_policies", expires: 7.days) do
-      response = Net::HTTP.get(URI("#{url}/#{id}"))
+    Rails.cache.fetch("#{cache_key}/laws_and_policies", expires: 7.days) do
+      path = [url, id].compact.join('/')
+      response = Net::HTTP.get(URI("#{path}"))
       JSON.parse(response)
     end
   end


### PR DESCRIPTION
This PR brings Climate Laws and Policies information to the `http://localhost:3000/api/v1/ndcs/countries_documents` endpoint, to be used on the Compare All Targets page, as well as the comparison page.

On the http://localhost:3000/api/v1/ndcs/countries_documents main endpoint the response will include new information on the data block, that tells us if there are targets in Laws and Policies for each country, e.g.:

![Screenshot 2020-05-26 at 10 58 12](https://user-images.githubusercontent.com/10764/82887376-d1cf4800-9f3f-11ea-8e48-6d910383f3ff.png)

These will come always at the bottom of that data object, and if one of them is not included be it Laws or Policies it means that there aren't any targets on those for that country.

Then on the filtered endpoint: http://localhost:3000/api/v1/ndcs/countries_documents?location=USA, we include information about the Laws and Policies of a given country, e.g.:

![Screenshot 2020-05-26 at 10 59 42](https://user-images.githubusercontent.com/10764/82887512-06430400-9f40-11ea-818e-80ddee953531.png)

This can then be used on the documents dropdown of the comparison page. The laws and policies are only included when filtering by a location, to keep the response smaller (otherwise there would be 2k laws and policies).

Let me know if this works for the front end integration.

The next step will be to fetch the data for the accordions. For that I'm wondering how to pass to the backend the pair of country-law/policy . Wondering if we should use something like: `USA-law-3834` or just `USA-3834`. Would this work for you guys?

Let me know!