### PR TITLE
Feature/add laws and policies to compare all table

### DIFF
--- a/app/javascript/app/data/country-documents.js
+++ b/app/javascript/app/data/country-documents.js
@@ -1,26 +1,10 @@
-export const DOCUMENT_SLUGS = [
-  'pledges',
-  'indc',
-  'first_ndc',
-  'second_ndc',
-  'targets',
-  'lts'
-];
-
-export const DOCUMENTS_NAMES = [
-  'Pre-2020 Pledges',
-  'INDC',
-  'NDC',
-  '2nd NDC',
-  'Targets in National Policies',
-  'LTS'
-];
-
-export const DOCUMENTS_NAME_SLUG = {
+export const DOCUMENT_COLUMNS_SLUGS = {
   'Pre-2020 Pledges': 'pledges',
   INDC: 'indc',
   NDC: 'first_ndc',
   '2nd NDC': 'second_ndc',
   'Targets in National Policies': 'targets',
-  LTS: 'lts'
+  LTS: 'lts',
+  'Targets in Laws': 'laws',
+  'Targets in Policies': 'policies'
 };

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import qs from 'query-string';
 import { uniq } from 'lodash';
-import { DOCUMENT_SLUGS } from 'data/country-documents';
+import { DOCUMENT_COLUMNS_SLUGS } from 'data/country-documents';
 
 const getCountries = state => (state.countries && state.countries.data) || null;
 const getIndicatorsData = state =>
@@ -44,14 +44,16 @@ export const getDocumentsOptionsByCountry = createSelector(
       const countryDocuments =
         countriesDocuments && countriesDocuments[isoCode3];
 
-      const documents = DOCUMENT_SLUGS.map(slug => {
-        const countryDocument =
-          countryDocuments && countryDocuments.find(d => d.slug === slug);
-        if (countryDocument) {
-          return { label: countryDocument.long_name, value: slug };
-        }
-        return null;
-      }).filter(Boolean);
+      const documents = Object.values(DOCUMENT_COLUMNS_SLUGS)
+        .map(slug => {
+          const countryDocument =
+            countryDocuments && countryDocuments.find(d => d.slug === slug);
+          if (countryDocument) {
+            return { label: countryDocument.long_name, value: slug };
+          }
+          return null;
+        })
+        .filter(Boolean);
 
       return {
         ...acc,

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { filterQuery } from 'app/utils';
 import deburr from 'lodash/deburr';
 import isEmpty from 'lodash/isEmpty';
-import { DOCUMENTS_NAMES } from 'data/country-documents';
+import { DOCUMENT_COLUMNS_SLUGS } from 'data/country-documents';
 
 const getCountries = state => (state.countries && state.countries.data) || null;
 const getCountriesDocuments = state =>
@@ -37,16 +37,19 @@ const getData = createSelector(
           ? 'yes'
           : 'no');
 
+      const documentsColumns = Object.keys(DOCUMENT_COLUMNS_SLUGS).reduce(
+        (acc, nextColumn) => {
+          const slug = DOCUMENT_COLUMNS_SLUGS[nextColumn];
+          return { ...acc, [nextColumn]: getIconValue(slug) };
+        },
+        {}
+      );
+
       return {
         Country: { name: c.wri_standard_name, iso: c.iso_code3 },
         'Share of global GHG emissions':
           countryEmissions && countryEmissions.value,
-        'Pre-2020 Pledges': getIconValue('pledges'),
-        INDC: getIconValue('indc'),
-        NDC: getIconValue('first_ndc'),
-        '2nd NDC': getIconValue('second_ndc'),
-        'Targets in National Policies': getIconValue('targets'),
-        LTS: getIconValue('lts')
+        ...documentsColumns
       };
     });
     return rows;
@@ -55,7 +58,8 @@ const getData = createSelector(
 
 export const getColumns = createSelector([getData], rows => {
   if (!rows) return [];
-  return ['Country', 'Share of global GHG emissions', ...DOCUMENTS_NAMES];
+  const docoumentColumnNames = Object.keys(DOCUMENT_COLUMNS_SLUGS);
+  return ['Country', 'Share of global GHG emissions', ...docoumentColumnNames];
 });
 
 export const getFilteredDataBySearch = createSelector(

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -58,8 +58,8 @@ const getData = createSelector(
 
 export const getColumns = createSelector([getData], rows => {
   if (!rows) return [];
-  const docoumentColumnNames = Object.keys(DOCUMENT_COLUMNS_SLUGS);
-  return ['Country', 'Share of global GHG emissions', ...docoumentColumnNames];
+  const documentColumnNames = Object.keys(DOCUMENT_COLUMNS_SLUGS);
+  return ['Country', 'Share of global GHG emissions', ...documentColumnNames];
 });
 
 export const getFilteredDataBySearch = createSelector(

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-table/ndc-compare-all-targets-table-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-table/ndc-compare-all-targets-table-component.jsx
@@ -10,13 +10,13 @@ import { Table } from 'cw-components';
 import NoContent from 'components/no-content';
 import Loading from 'components/loading';
 import compareTableTheme from 'styles/themes/table/compare-table-theme.scss';
-import { DOCUMENTS_NAME_SLUG } from 'data/country-documents';
+import { DOCUMENT_COLUMNS_SLUGS } from 'data/country-documents';
 
 import styles from './ndc-compare-all-targets-table-styles.scss';
 
 const cellRenderer = (cell, selectedTargets, columns, setSelectedTargets) => {
   const { cellData, dataKey, columnIndex, rowData } = cell;
-  const id = `${rowData.Country.iso}-${DOCUMENTS_NAME_SLUG[dataKey]}`;
+  const id = `${rowData.Country.iso}-${DOCUMENT_COLUMNS_SLUGS[dataKey]}`;
   const isActive = selectedTargets.includes(id);
   const isLastColumn = columnIndex === columns.length - 1;
 

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -38,9 +38,9 @@ const NDCCompareAllContainer = props => {
       column,
       columns,
       tableWidth: 1170,
-      narrowColumnWidth: 134,
-      wideColumnWidth: 200,
-      narrowColumns: [0, 2, 3, 4, 5, 6],
+      narrowColumnWidth: 110,
+      wideColumnWidth: 130,
+      narrowColumns: [0, 2, 3, 4, 5, 6, 7, 8, 9],
       wideColumns: [1]
     });
 


### PR DESCRIPTION
This PR adds the `Targets in Laws` and `Targets in Policies` columns to the `Compare all targets` table. I also resized a bit the width of the document columns, to fit all into a screen without scrolling.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172736697)
![image](https://user-images.githubusercontent.com/15097138/83015260-745ef800-a020-11ea-9834-86afb12fe54c.png)

