### PR TITLE
Dont add EU emissions to donut chart

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -260,29 +260,18 @@ export const getIndicatorEmissionsData = (
   const data = legend.map(legendItem => {
     let legendItemValue = 0;
     const locationEntries = Object.entries(selectedIndicator.locations);
-    const europeanLocationIsos = Object.keys(
-      selectedIndicator.locations
-    ).filter(iso => europeanCountries.includes(iso));
     locationEntries.forEach(entry => {
       const [locationIso, { label_id: labelId }] = entry;
       if (
         labelId === parseInt(legendItem.id, 10) &&
         emissionPercentages[locationIso]
       ) {
-        if (locationIso === europeSlug) {
-          const EUTotal = parseFloat(emissionPercentages[europeSlug].value);
-          const europeanLocationsValue = europeanLocationIsos.reduce(
-            (acc, iso) => acc + parseFloat(emissionPercentages[iso].value),
-            0
-          );
-          legendItemValue += EUTotal - europeanLocationsValue; // To avoid double counting
-        } else {
+        if (locationIso !== europeSlug) {
           legendItemValue += parseFloat(emissionPercentages[locationIso].value);
         }
       }
     });
     summedPercentage += legendItemValue;
-
     return {
       name: legendItem.name,
       value: legendItemValue
@@ -335,7 +324,6 @@ export const getEmissionsCardData = createSelector(
       minAngle: 3,
       ...getLabels(legend, NO_DOCUMENT_SUBMITTED, true)
     };
-
     return {
       config,
       data


### PR DESCRIPTION
Don't merge yet: WRI will have to agree that we should change this. EU emissions are now not counted on overview and tracker, so we can only merge this after WRI approval.

![image](https://user-images.githubusercontent.com/9701591/83044876-14c71380-a045-11ea-9b95-7a21bd2eafe3.png)
