### PR TITLE
Feature/data explorer use slugs in url

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -72,7 +72,6 @@ const getMetaForNoModelFilters = createSelector(
         slug: kebabCase(v)
       }));
     });
-    // console.log('noModelFiltersMeta:', noModelFiltersMeta);
     return noModelFiltersMeta;
   }
 );
@@ -124,12 +123,6 @@ export const getSourceOptions = createSelector(
     ) {
       return null;
     }
-    // console.log('getSourceOptions()',sectionMeta.data_sources.map(option => {
-    //   const updatedOption = option;
-    //   updatedOption.dataSourceId = option.id;
-    //   updatedOption.name = option.display_name;
-    //   return updatedOption;
-    // }));
     return sectionMeta.data_sources.map(option => {
       const updatedOption = option;
       updatedOption.dataSourceId = option.id;
@@ -149,7 +142,6 @@ const removeFiltersPrefix = (selectedFields, prefix) => {
 };
 
 const findSelectedValueObject = (meta, selectedId) =>
-  // console.log('meta: ', meta, ' selectedId: ', selectedId);
   meta.find(
     option =>
       option.iso_code === selectedId ||
@@ -157,9 +149,7 @@ const findSelectedValueObject = (meta, selectedId) =>
       option.name === selectedId ||
       String(option.slug) === selectedId ||
       String(option.id) === selectedId
-  )
-;
-
+  );
 const addTopEmittersMembers = (isosArray, regions, key) => {
   if (key === FILTER_NAMES.regions && isosArray.includes('TOP')) {
     const topRegion = regions.find(r => r.iso === 'TOP');
@@ -188,7 +178,6 @@ function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
       metadata.regions,
       key
     );
-    // console.log('selectedIds: ', selectedIds);
     const filters = [];
     if (metadataWithSubcategories[parsedKey]) {
       selectedIds.forEach(selectedId => {
@@ -199,7 +188,6 @@ function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
         if (foundSelectedOption) filters.push(foundSelectedOption);
       });
     }
-    // console.log('filters: ', filters);
 
     if (filters && filters.length > 0) {
       filterIds[parsedKey] = filters.map(
@@ -234,12 +222,9 @@ export const getFilterQuery = createSelector(
     const noExternalParams = !searchKeys.some(s =>
       s.startsWith(DATA_EXPLORER_EXTERNAL_PREFIX)
     );
-    console.log('filterDefaultKeys: ',filterDefaultKeys)
     const checkedDefaultParams = filterDefaultKeys.every(defaultKey =>
       parsedSearchKeys.includes(defaultKey, section)
     );
-    console.log('checkedDefaultParams: ',checkedDefaultParams)
-
     const isReadyForFetch = noExternalParams && checkedDefaultParams;
     if (!isReadyForFetch) return null;
     return filterQueryIds(sectionMeta, search, section, false);
@@ -297,7 +282,6 @@ const parseQuery = (filterQuery, section, sectionMeta) => {
       if (id) parsedQuery[parsedKey] = id;
     });
   }
-  console.log('parsedQuery: ',parsedQuery)
   return parsedQuery;
 };
 
@@ -312,9 +296,7 @@ export const getLink = createSelector(
       DATA_EXPLORER_SECTIONS[section].linkName ||
       DATA_EXPLORER_SECTIONS[section].moduleName;
     const subSection = moduleName === 'pathways' ? '/models' : '';
-    console.log(`/${
-      isPageContained ? `${CONTAINED_PATHNAME}/` : ''
-    }${moduleName}${subSection}${urlParameters}`)
+
     return `/${
       isPageContained ? `${CONTAINED_PATHNAME}/` : ''
     }${moduleName}${subSection}${urlParameters}`;
@@ -456,7 +438,6 @@ export const getFilterOptions = createSelector(
         filterOptions[f] = optionsArray;
       }
     });
-    // console.log('filterOptions: ', filterOptions);
     return filterOptions;
   }
 );
@@ -544,24 +525,21 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
-    // console.log('parsedFields: ', parsedFields);
     return parsedFields;
   }
 );
 
 const findFilterOptions = (options, selectedFilters) =>
-  // console.log('options:', options, ' selectedFilters:', selectedFilters);
-  options && options.filter(f =>
+  options &&
+  options.filter(f =>
     POSSIBLE_VALUE_FIELDS.find(field => {
       const value = f[field] && String(f[field]);
       return selectedFilters.includes(value);
     })
-  )
-;
-
+  );
 export const getSelectedFilters = createSelector(
-  [getSearch, getSection, getFilterOptions],
-  (search, section, filterOptions) => {
+  [getSearch, getSection, getFilterOptions, getMetaForNoModelFilters],
+  (search, section, filterOptions, noModelFiltersMeta) => {
     if (!search || !section || !filterOptions) return null;
     const selectedFields = search;
     const nonExternalKeys = Object.keys(selectedFields).filter(
@@ -573,29 +551,20 @@ export const getSelectedFilters = createSelector(
       sectionRelatedFields,
       section
     );
-    console.log('[getSelectedFilters()]:parsedSelectedFilters:',parsedSelectedFilters)
     const selectedFilterObjects = {};
     Object.keys(parsedSelectedFilters).forEach(filterKey => {
-      
       const filterId = parsedSelectedFilters[filterKey];
       const isNonColumnKey = NON_COLUMN_KEYS.includes(filterKey);
       const isNoModelColumnKey = isNoColumnField(section, filterKey);
-      if (isNonColumnKey || isNoModelColumnKey) {
-        // selectedFilterObjects[filterKey] = filterId;
-
-        const x = findFilterOptions(
-          filterOptions[filterKey],
-          [filterId]
-        );
-        console.log('[getSelectedFilters()]:test:', x);
-        selectedFilterObjects[filterKey] = x ||  [ALL_SELECTED_OPTION];
-
- 
-        // console.log('[getSelectedFilters()]:filterOptions',filterOptions);
-        // console.log('[getSelectedFilters()]:filterKey',filterKey);
-        // console.log('[getSelectedFilters()]:filterId',filterId);
-
-
+      if (isNonColumnKey) {
+        selectedFilterObjects[filterKey] = filterId;
+      } else if (isNoModelColumnKey) {
+        const noModelOptions =
+          noModelFiltersMeta[filterKey] &&
+          noModelFiltersMeta[filterKey]
+            .filter(f => f.slug === filterId)
+            .map(f => ({ label: f.title, value: f.slug }));
+        selectedFilterObjects[filterKey] = noModelOptions;
       } else if (filterId === ALL_SELECTED) {
         selectedFilterObjects[filterKey] = [ALL_SELECTED_OPTION];
       } else {
@@ -606,7 +575,6 @@ export const getSelectedFilters = createSelector(
         );
       }
     });
-    console.log('[getSelectedFilters()]:selectedFilterObjects: ', selectedFilterObjects);
     return selectedFilterObjects;
   }
 );
@@ -784,22 +752,17 @@ export const getSelectedOptions = createSelector(
     if (!selectedFields) return null;
     const selectedOptions = {};
     Object.keys(selectedFields).forEach(key => {
-      if (NON_COLUMN_KEYS.includes(key) || isNoColumnField(section, key)) {
-        console.log("[getSelectedFilters()]:selectedFields[key]: ",selectedFields[key])
-        // selectedOptions[key] = {
-        //   value: selectedFields[key][0].slug,
-        //   label: selectedFields[key][0].label
-        // };
-        selectedOptions[key] = parseMultipleLevelOptions(
-          selectedFields[key]
-        ).map(f => ({
-          value: f.slug,
-          label: f.label,
-          id: f.iso_code3 || f.id || f.dataSourceId,
-          ...f
-        }));
-                console.log("[getSelectedFilters()]:selectedOptions[key]: ",selectedOptions[key])
-
+      if (NON_COLUMN_KEYS.includes(key)) {
+        selectedOptions[key] = {
+          value: selectedFields[key],
+          label: selectedFields[key]
+        };
+      } else if (isNoColumnField(section, key)) {
+        selectedOptions[key] = selectedFields[key] &&
+          selectedFields[key][0] && {
+            value: selectedFields[key][0].value,
+            label: selectedFields[key][0].label
+          };
       } else {
         selectedOptions[key] = parseMultipleLevelOptions(
           selectedFields[key]
@@ -811,8 +774,6 @@ export const getSelectedOptions = createSelector(
         }));
       }
     });
-    console.log('selectedOptions: ',selectedOptions)
-
     return selectedOptions;
   }
 );
@@ -851,10 +812,6 @@ const getYearColumnKeys = createSelector(
   [parseData, getSection],
   (data, section) => {
     if (!data || !data.length || !section) return null;
-    // console.log(
-    //   'Object.keys(data[0]).filter(k => isANumber(k)): ',
-    //   Object.keys(data[0]).filter(k => isANumber(k))
-    // );
     return Object.keys(data[0]).filter(k => isANumber(k));
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -560,6 +560,7 @@ export const getSelectedFilters = createSelector(
         selectedFilterObjects[filterKey] = filterId;
       } else if (isNoModelColumnKey) {
         const noModelOptions =
+          noModelFiltersMeta &&
           noModelFiltersMeta[filterKey] &&
           noModelFiltersMeta[filterKey]
             .filter(f => f.slug === filterId)

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -77,7 +77,6 @@ const getMetaForNoModelFilters = createSelector(
 );
 
 const getSectionMeta = createSelector(
-  // HERE WE HAVE FILTERS!!!
   [getMeta, getRegions, getCountries, getSection, getMetaForNoModelFilters],
   (meta, regions, countries, section, noModelFiltersMeta) => {
     if (!meta || !meta[section] || !regions || !countries || !section) {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -365,6 +365,7 @@ const getValue = option =>
   option.iso ||
   option.iso_code ||
   option.iso_code3 ||
+  option.slug ||
   (option.id && String(option.id)) ||
   (option.dataSourceId && String(option.dataSourceId));
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,7 +47,7 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
-    // console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
+    console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
     // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
@@ -56,7 +56,7 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          // console.log('selected: ', selected);
+          console.log('selected: ', selected);
           handleFiltersChange({
             [field]: (selected && selected.slug) || selected.value
           });

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,8 +47,6 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
-    console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
-    // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
         key={label}
@@ -56,7 +54,6 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          console.log('selected: ', selected);
           handleFiltersChange({
             [field]: (selected && selected.slug) || selected.value
           });

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,6 +47,8 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
+    // console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
+    // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
         key={label}
@@ -54,7 +56,10 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          handleFiltersChange({ [field]: selected && selected.value });
+          // console.log('selected: ', selected);
+          handleFiltersChange({
+            [field]: (selected && selected.slug) || selected.value
+          });
           handleChangeSelectorAnalytics();
         }}
         value={value || null}
@@ -91,11 +96,11 @@ class DataExplorerFilters extends PureComponent {
             return option.length > 0 && last(option).value === ALL_SELECTED
               ? ALL_SELECTED
               : option
-                .map(o => o.value)
+                .map(o => o.slug)
                 .filter(v => v !== ALL_SELECTED)
                 .join();
           }
-          return option && option.value;
+          return option && option.slug;
         };
 
         return (

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -87,6 +87,9 @@ const getParamsToUpdate = (updatedFilters, section) => {
   const paramsToUpdate = [];
   Object.keys(updatedFilters).forEach(filterName => {
     const value = updatedFilters[filterName];
+    // console.log('updatedFilters: ', updatedFilters);
+    // console.log('filterName: ', filterName);
+
     const parsedValue = isArray(value) ? parsedMultipleValues(value) : value;
     const blankValue = NON_COLUMN_KEYS.includes(filterName) ? '' : ALL_SELECTED;
     paramsToUpdate.push({

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -123,22 +123,24 @@ class DataExplorerFiltersContainer extends PureComponent {
           defaultOptionsToUpdate[key] = FILTER_DEFAULTS[section][key];
         } else {
           const defaultValues = FILTER_DEFAULTS[section][key].split(',');
+          console.log('[updateDefaultFilters]: filterOptions[key]: ',filterOptions[key])
           const defaultOptions = filterOptions[key].filter(
             f =>
-              defaultValues.includes(f.value) || defaultValues.includes(f.label)
+              defaultValues.includes(f.slug) || defaultValues.includes(f.label)
           );
           let updatedOptions = '';
           if (
             defaultOptions &&
             defaultOptions.length &&
-            defaultOptions[0].value
+            defaultOptions[0].slug
           ) {
-            updatedOptions = defaultOptions.map(o => o.value).join(',');
+            updatedOptions = defaultOptions.map(o => o.slug).join(',');
           }
           defaultOptionsToUpdate[key] = updatedOptions;
         }
       }
     });
+    console.log('[updateDefaultFilters]: defaultOptionsToUpdate: ',defaultOptionsToUpdate)
     this.handleFiltersChange(defaultOptionsToUpdate, true);
   }
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -87,9 +87,6 @@ const getParamsToUpdate = (updatedFilters, section) => {
   const paramsToUpdate = [];
   Object.keys(updatedFilters).forEach(filterName => {
     const value = updatedFilters[filterName];
-    // console.log('updatedFilters: ', updatedFilters);
-    // console.log('filterName: ', filterName);
-
     const parsedValue = isArray(value) ? parsedMultipleValues(value) : value;
     const blankValue = NON_COLUMN_KEYS.includes(filterName) ? '' : ALL_SELECTED;
     paramsToUpdate.push({
@@ -123,7 +120,6 @@ class DataExplorerFiltersContainer extends PureComponent {
           defaultOptionsToUpdate[key] = FILTER_DEFAULTS[section][key];
         } else {
           const defaultValues = FILTER_DEFAULTS[section][key].split(',');
-          console.log('[updateDefaultFilters]: filterOptions[key]: ',filterOptions[key])
           const defaultOptions = filterOptions[key].filter(
             f =>
               defaultValues.includes(f.slug) || defaultValues.includes(f.label)
@@ -140,7 +136,6 @@ class DataExplorerFiltersContainer extends PureComponent {
         }
       }
     });
-    console.log('[updateDefaultFilters]: defaultOptionsToUpdate: ',defaultOptionsToUpdate)
     this.handleFiltersChange(defaultOptionsToUpdate, true);
   }
 

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -383,7 +383,13 @@ export const POSSIBLE_LABEL_FIELDS = [
   'number'
 ];
 
-export const POSSIBLE_VALUE_FIELDS = ['id', 'value', 'iso_code3', 'iso'];
+export const POSSIBLE_VALUE_FIELDS = [
+  'slug',
+  'id',
+  'value',
+  'iso_code3',
+  'iso'
+];
 
 export const FIELD_ALIAS = {
   'historical-emissions': { 'data-sources': 'Data sources' },


### PR DESCRIPTION
This PR updates the date-explorer page by replacing the ids with the slugs in the URL. This is the first PR of this feature, second PR is going to update all download links across the platform.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172835211)

**Test:** Check all sections and filters on the [data-explorer page](http://localhost:3000/data-explorer/historical-emissions).