### PR TITLE
Feature/ghg years to url

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -260,8 +260,19 @@ const getParsedFilterId = (
   return isArray(id) ? id.join(',') : id;
 };
 
-const parseQuery = (filterQuery, section, sectionMeta) => {
+const parseQuery = (filterQuery, section, sectionMeta, nonColumnQuery) => {
   const parsedQuery = {};
+
+  const nonColumnQueryKeys = Object.keys(nonColumnQuery);
+  if (nonColumnQueryKeys.length) {
+    nonColumnQueryKeys.forEach(key => {
+      const parsedKeyData = DATA_EXPLORER_TO_MODULES_PARAMS[section][key];
+      if (parsedKeyData) {
+        parsedQuery[key] = nonColumnQuery[key];
+      }
+    });
+  }
+
   if (filterQuery && !isEmpty(filterQuery)) {
     Object.keys(filterQuery).forEach(key => {
       const parsedKeyData = DATA_EXPLORER_TO_MODULES_PARAMS[section][key];
@@ -280,10 +291,15 @@ const parseQuery = (filterQuery, section, sectionMeta) => {
 };
 
 export const getLink = createSelector(
-  [getLinkFilterQuery, getSection, getSectionMeta],
-  (filterQuery, section, sectionMeta) => {
+  [getLinkFilterQuery, getNonColumnQuery, getSection, getSectionMeta],
+  (filterQuery, nonColumnQuery, section, sectionMeta) => {
     if (!section) return null;
-    const parsedQuery = parseQuery(filterQuery, section, sectionMeta);
+    const parsedQuery = parseQuery(
+      filterQuery,
+      section,
+      sectionMeta,
+      nonColumnQuery
+    );
     const stringifiedQuery = qs.stringify(parsedQuery);
     const urlParameters = stringifiedQuery ? `?${stringifiedQuery}` : '';
     const moduleName =

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -6,7 +6,7 @@ import pick from 'lodash/pick';
 import flatten from 'lodash/flatten';
 import qs from 'query-string';
 import { findEqual, isANumber, noEmptyValues } from 'utils/utils';
-import { isNoColumnField } from 'utils/data-explorer';
+import { isNoColumnField, isNonColumnKey } from 'utils/data-explorer';
 import { isPageContained } from 'utils/navigation';
 
 import sortBy from 'lodash/sortBy';
@@ -496,7 +496,9 @@ export const parseExternalParams = createSelector(
       );
       const keyWithoutSection = keyWithoutPrefix.replace(`${section}-`, '');
       let metaMatchingKey = keyWithoutSection.replace('-', '_');
-      if (metaMatchingKey !== 'undefined') {
+      if (isNonColumnKey(keyWithoutSection)) {
+        parsedFields[`${section}-${metaMatchingKey}`] = externalFields[k];
+      } else if (metaMatchingKey !== 'undefined') {
         if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const ids = externalFields[k].split(',');
         const filterObjects = sectionMeta[metaMatchingKey].filter(
@@ -547,9 +549,8 @@ export const getSelectedFilters = createSelector(
     const selectedFilterObjects = {};
     Object.keys(parsedSelectedFilters).forEach(filterKey => {
       const filterId = parsedSelectedFilters[filterKey];
-      const isNonColumnKey = NON_COLUMN_KEYS.includes(filterKey);
       const isNoModelColumnKey = isNoColumnField(section, filterKey);
-      if (isNonColumnKey || isNoModelColumnKey) {
+      if (isNonColumnKey(filterKey) || isNoModelColumnKey) {
         selectedFilterObjects[filterKey] = filterId;
       } else if (filterId === ALL_SELECTED) {
         selectedFilterObjects[filterKey] = [ALL_SELECTED_OPTION];
@@ -739,7 +740,7 @@ export const getSelectedOptions = createSelector(
     if (!selectedFields) return null;
     const selectedOptions = {};
     Object.keys(selectedFields).forEach(key => {
-      if (NON_COLUMN_KEYS.includes(key) || isNoColumnField(section, key)) {
+      if (isNonColumnKey(key) || isNoColumnField(section, key)) {
         selectedOptions[key] = {
           value: selectedFields[key],
           label: selectedFields[key]

--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-actions.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-actions.js
@@ -1,7 +1,0 @@
-import { createAction } from 'redux-actions';
-
-export const setYears = createAction('setYears');
-
-export default {
-  setYears
-};

--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-reducers.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom-reducers.js
@@ -1,7 +1,0 @@
-export const initialState = {
-  years: null
-};
-
-const setYears = (state, { payload }) => ({ ...state, years: payload });
-
-export default { setYears };

--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
@@ -6,7 +6,7 @@ import DataZoomComponent from './data-zoom-component';
 const PADDING = 20;
 
 function DataZoomContainer(props) {
-  const { data, onYearChange, position, setPosition, years } = props;
+  const { data, onYearChange, position = {}, setPosition, years } = props;
 
   const dataZoomRef = useRef();
   const [width, setWidth] = useState(0);
@@ -23,10 +23,10 @@ function DataZoomContainer(props) {
       setWidth(refWidth);
 
       // Calculate initial position if we have year url params
-      if (data && years.min > data[0].x) {
+      if (data && years && years.min > data[0].x) {
         position.min = getPosition(refWidth, years.min);
       }
-      if (data && years.max < data[data.length - 1].x) {
+      if (data && years && years.max < data[data.length - 1].x) {
         position.max = getPosition(refWidth, years.max);
       }
 

--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
@@ -6,12 +6,12 @@ import DataZoomComponent from './data-zoom-component';
 const PADDING = 20;
 
 function DataZoomContainer(props) {
-  const { data, onYearChange, position, setPosition } = props;
-
-  const steps = data && data.length - 1;
+  const { data, onYearChange, position, setPosition, years } = props;
 
   const dataZoomRef = useRef();
   const [width, setWidth] = useState(0);
+
+  // Set initial position and width
   useEffect(() => {
     if (dataZoomRef.current) {
       const debouncedSetWidth = debounce(
@@ -21,9 +21,18 @@ function DataZoomContainer(props) {
 
       const refWidth = dataZoomRef.current.offsetWidth;
       setWidth(refWidth);
+
+      // Calculate initial position if we have year url params
+      if (data && years.min > data[0].x) {
+        position.min = getPosition(refWidth, years.min);
+      }
+      if (data && years.max < data[data.length - 1].x) {
+        position.max = getPosition(refWidth, years.max);
+      }
+
       setPosition({
-        ...position,
-        max: refWidth - PADDING
+        min: position.min,
+        max: position.max || refWidth - PADDING
       });
 
       window.addEventListener('resize', debouncedSetWidth);
@@ -35,9 +44,20 @@ function DataZoomContainer(props) {
   }, [dataZoomRef]);
 
   const getYear = handleType => {
+    const steps = data && data.length - 1;
     const handleStep = (steps * position[handleType]) / (width - PADDING);
     const stepData = data && data[Math.floor(handleStep)];
     return stepData && stepData.x;
+  };
+
+  const getPosition = (elementWidth = width, year) => {
+    if (!data || !elementWidth) return null;
+    const max = elementWidth - PADDING;
+    const steps = data && data.length - 1;
+    const yearPositionLength = max / steps;
+    const minYear = data[0].x;
+    const yearPosition = (year - minYear) * yearPositionLength;
+    return yearPosition;
   };
 
   const handleStop = () => {
@@ -63,6 +83,7 @@ function DataZoomContainer(props) {
 
 DataZoomContainer.propTypes = {
   data: PropTypes.array,
+  years: PropTypes.object,
   onYearChange: PropTypes.func.isRequired,
   position: PropTypes.object.isRequired,
   setPosition: PropTypes.func.isRequired

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -94,6 +94,7 @@ function GhgEmissions(props) {
     handleInfoClick,
     setColumnWidth,
     downloadLink,
+    dataZoomYears,
     dataZoomPosition,
     setDataZoomPosition
   } = props;
@@ -268,6 +269,7 @@ function GhgEmissions(props) {
               <DataZoom
                 data={dataZoomData}
                 position={dataZoomPosition}
+                years={dataZoomYears}
                 setPosition={setDataZoomPosition}
                 onYearChange={(min, max) => setYears({ min, max })}
               />
@@ -426,6 +428,7 @@ GhgEmissions.propTypes = {
   downloadLink: PropTypes.string,
   hideRemoveOptions: PropTypes.bool,
   dataZoomPosition: PropTypes.object,
+  dataZoomYears: PropTypes.object,
   setDataZoomPosition: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -138,7 +138,8 @@ function GhgEmissions(props) {
         },
         {
           label: 'Go to data explorer',
-          link: downloadLink
+          link: downloadLink,
+          target: '_self'
         }
       ],
       reverseDropdown: false

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -26,7 +26,7 @@ export const getSelection = field =>
 
 export const getDataZoomYears = createSelector(getSearch, search => {
   if (!search) return null;
-  return { min: search['start-year'], max: search['end-year'] };
+  return { min: search.start_year, max: search.end_year };
 });
 
 export const getLinkToDataExplorer = createSelector([getSearch], search => {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -7,8 +7,6 @@ export const getData = ({ emissions }) => (emissions && emissions.data) || [];
 export const getMeta = ({ ghgEmissionsMeta }) =>
   (ghgEmissionsMeta && ghgEmissionsMeta.meta) || null;
 export const getRegions = ({ regions }) => (regions && regions.data) || null;
-export const getDataZoomYears = ({ dataZoom }) =>
-  (dataZoom && dataZoom.years) || null;
 export const getCountries = ({ countries }) =>
   (countries && countries.data) || null;
 export const getSources = createSelector(
@@ -25,6 +23,11 @@ export const getSelection = field =>
     if (field === 'location') return search.regions;
     return search[field] || search[toPlural(field)];
   });
+
+export const getDataZoomYears = createSelector(getSearch, search => {
+  if (!search) return null;
+  return { min: search['start-year'], max: search['end-year'] };
+});
 
 export const getLinkToDataExplorer = createSelector([getSearch], search => {
   const section = 'historical-emissions';

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-providers.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-providers.js
@@ -3,35 +3,43 @@ import uniq from 'lodash/uniq';
 import flatMap from 'lodash/flatMap';
 import { getOptionsSelected } from './ghg-emissions-selectors-filters';
 
-export const getProviderFilters = createSelector([getOptionsSelected], selectedOptions => {
-  if (!selectedOptions || !selectedOptions.sourcesSelected) return null;
+export const getProviderFilters = createSelector(
+  [getOptionsSelected],
+  selectedOptions => {
+    if (!selectedOptions || !selectedOptions.sourcesSelected) return null;
 
-  const {
-    sourcesSelected,
-    sectorsSelected,
-    gasesSelected,
-    regionsSelected,
-    breakBySelected
-  } = selectedOptions;
+    const {
+      sourcesSelected,
+      sectorsSelected,
+      gasesSelected,
+      regionsSelected,
+      breakBySelected
+    } = selectedOptions;
 
-  const breakBySector = breakBySelected && breakBySelected.value === 'sector';
-  const breakByGas = breakBySelected && breakBySelected.value === 'gas';
-  const parseValues = selected => uniq(selected.map(s => s.value)).join();
-  const withExpanded = optionsSelected => [
-    ...optionsSelected,
-    ...flatMap(optionsSelected, o => (o.expandsTo || []).map(value => ({ value })))
-  ];
+    const breakBySector = breakBySelected && breakBySelected.value === 'sector';
+    const breakByGas = breakBySelected && breakBySelected.value === 'gas';
+    const parseValues = selected => uniq(selected.map(s => s.value)).join();
+    const withExpanded = optionsSelected => [
+      ...optionsSelected,
+      ...flatMap(optionsSelected, o =>
+        (o.expandsTo || []).map(value => ({ value }))
+      )
+    ];
 
-  const filter = {
-    source: sourcesSelected.value,
-    gas: parseValues(breakByGas ? withExpanded(gasesSelected) : gasesSelected),
-    // we have data for sectors' totals so we are only get aggregated when breaking by sector
-    sector: parseValues(breakBySector ? withExpanded(sectorsSelected) : sectorsSelected),
-    location: parseValues(withExpanded(regionsSelected))
-  };
+    const filter = {
+      source: sourcesSelected.value,
+      gas: parseValues(
+        breakByGas ? withExpanded(gasesSelected) : gasesSelected
+      ),
+      // we have data for sectors' totals so we are only get aggregated when breaking by sector
+      sector: parseValues(
+        breakBySector ? withExpanded(sectorsSelected) : sectorsSelected
+      ),
+      location: parseValues(withExpanded(regionsSelected))
+    };
 
-  // do not allow empty filters
-  if (Object.keys(filter).some(k => !filter[k])) return null;
-
-  return filter;
-});
+    // do not allow empty filters
+    if (Object.keys(filter).some(k => !filter[k])) return null;
+    return filter;
+  }
+);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -37,11 +37,11 @@ function GhgEmissionsContainer(props) {
     const { min, max } = years || {};
     updateUrlParam([
       {
-        name: 'start-year',
+        name: 'start_year',
         value: min
       },
       {
-        name: 'end-year',
+        name: 'end_year',
         value: max
       }
     ]);
@@ -93,11 +93,11 @@ function GhgEmissionsContainer(props) {
       { name: 'sectors', value: null },
       { name: 'gases', value: null },
       {
-        name: 'start-year',
+        name: 'start_year',
         value: undefined
       },
       {
-        name: 'end-year',
+        name: 'end_year',
         value: undefined
       }
     ]);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -14,8 +14,6 @@ import { orderByColumns, stripHTML } from 'utils';
 import { GHG_TABLE_HEADER } from 'data/constants';
 import GhgEmissionsComponent from './ghg-emissions-component';
 import { getGHGEmissions } from './ghg-emissions-selectors/ghg-emissions-selectors';
-import actions from './data-zoom/data-zoom-actions';
-import reducers, { initialState } from './data-zoom/data-zoom-reducers';
 
 const mapStateToProps = (state, props) => {
   const { location } = props;
@@ -33,9 +31,21 @@ function GhgEmissionsContainer(props) {
     fieldToBreakBy,
     tableData,
     data,
-    setYears,
     dataZoomYears
   } = props;
+  const handleSetYears = years => {
+    const { min, max } = years || {};
+    updateUrlParam([
+      {
+        name: 'start-year',
+        value: min
+      },
+      {
+        name: 'end-year',
+        value: max
+      }
+    ]);
+  };
 
   // Data Zoom Logic
   const [updatedData, setUpdatedData] = useState(data);
@@ -47,18 +57,22 @@ function GhgEmissionsContainer(props) {
     DATA_ZOOM_START_POSITION
   );
   useEffect(() => {
+    if (!data) {
+      return undefined;
+    }
     if (dataZoomYears) {
       setUpdatedData(
-        data.filter(d => d.x >= dataZoomYears.min && d.x <= dataZoomYears.max)
+        data.filter(
+          d =>
+            (!dataZoomYears.min || d.x >= dataZoomYears.min) &&
+            (!dataZoomYears.max || d.x <= dataZoomYears.max)
+        )
       );
     } else {
       setUpdatedData(data);
     }
+    return undefined;
   }, [dataZoomYears, data]);
-  const resetDataZoom = () => {
-    setDataZoomPosition(DATA_ZOOM_START_POSITION);
-    setYears(null);
-  };
 
   useEffect(() => {
     const { sourceSelected } = selected;
@@ -77,9 +91,17 @@ function GhgEmissionsContainer(props) {
         value: category.name
       },
       { name: 'sectors', value: null },
-      { name: 'gases', value: null }
+      { name: 'gases', value: null },
+      {
+        name: 'start-year',
+        value: undefined
+      },
+      {
+        name: 'end-year',
+        value: undefined
+      }
     ]);
-    resetDataZoom();
+    setDataZoomPosition(DATA_ZOOM_START_POSITION);
     handleAnalytics('Historical Emissions', 'Source selected', category.label);
   };
 
@@ -195,8 +217,9 @@ function GhgEmissionsContainer(props) {
       handleDownloadDataClick={handleDownloadDataClick}
       handlePngDownloadModal={handlePngDownloadModal}
       setColumnWidth={setColumnWidth}
-      setYears={setYears}
+      setYears={handleSetYears}
       dataZoomPosition={dataZoomPosition}
+      dataZoomYears={dataZoomYears}
       setDataZoomPosition={setDataZoomPosition}
     />
   );
@@ -221,10 +244,8 @@ GhgEmissionsContainer.defaultProps = {
   search: undefined
 };
 
-export { actions, reducers, initialState };
-
 export default withRouter(
-  connect(mapStateToProps, { ...actions, ...modalActions, ...pngModalActions })(
+  connect(mapStateToProps, { ...modalActions, ...pngModalActions })(
     GhgEmissionsContainer
   )
 );

--- a/app/javascript/app/components/simple-menu/simple-menu-styles.scss
+++ b/app/javascript/app/components/simple-menu/simple-menu-styles.scss
@@ -136,6 +136,7 @@
         color: $gray1;
         vertical-align: text-bottom;
         text-transform: uppercase;
+        cursor: pointer;
 
         .documentLink {
           font-weight: bold;

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -181,19 +181,14 @@ export const DATA_EXPLORER_DEPENDENCIES = {
 };
 
 export const DATA_EXPLORER_EXTERNAL_PREFIX = 'external';
-export const MODULES_TO_DATA_EXPLORER_PARAMS = {
-  'historical-emissions': {
-    filter: 'filter',
-    source: 'data-sources',
-    breakBy: 'breakBy'
-  }
-};
 export const DATA_EXPLORER_TO_MODULES_PARAMS = {
   'historical-emissions': {
     data_sources: { key: 'source' },
     gases: { key: 'gases' },
     sectors: { key: 'sectors' },
-    regions: { key: 'regions' }
+    regions: { key: 'regions' },
+    start_year: { key: 'start_year' },
+    end_year: { key: 'end_year' }
   },
   'ndc-sdg-linkages': {
     goals: {

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -122,7 +122,6 @@ import * as myVisualisationsCreator from 'components/my-climate-watch/viz-creato
 import * as myVisualisationsGraphComponent from 'components/my-climate-watch/my-visualisations/my-cw-vis-graph';
 import * as ndcSdgLinkagesComponent from 'components/ndc-sdg/ndc-sdg-linkages-content';
 import * as HamburgerComponent from 'components/hamburger';
-import * as GHGComponent from 'components/ghg-emissions/ghg-emissions';
 import * as AnchorNavComponent from 'components/anchor-nav';
 import * as ExploreMapShared from 'components/ndcs/shared/explore-map';
 import * as ndcCountryAccordionComponent from 'components/ndcs/ndcs-country-accordion';
@@ -147,7 +146,6 @@ const componentsReducers = {
   espGraph: handleActions(espGraphComponent),
   ndcSdg: handleActions(ndcSdgLinkagesComponent),
   hamburger: handleActions(HamburgerComponent),
-  dataZoom: handleActions(GHGComponent),
   anchorNav: handleActions(AnchorNavComponent),
   exploreMap: handleActions(ExploreMapShared),
   ndcCountryAccordion: handleActions(ndcCountryAccordionComponent)

--- a/app/javascript/app/utils/data-explorer.js
+++ b/app/javascript/app/utils/data-explorer.js
@@ -1,9 +1,11 @@
 import invertBy from 'lodash/invertBy';
+import snakeCase from 'lodash/snakeCase';
 import qs from 'querystring';
 import {
   DATA_EXPLORER_TO_MODULES_PARAMS,
   FILTERS_DATA_WITHOUT_MODEL,
-  DATA_EXPLORER_EXTERNAL_PREFIX
+  DATA_EXPLORER_EXTERNAL_PREFIX,
+  NON_COLUMN_KEYS
 } from 'data/data-explorer-constants';
 import { replaceAll } from 'utils/utils';
 import { getStorageWithExpiration } from 'utils/localStorage';
@@ -76,6 +78,8 @@ export const isNoColumnField = (section, key) =>
   FILTERS_DATA_WITHOUT_MODEL[section] &&
   FILTERS_DATA_WITHOUT_MODEL[section].includes(key);
 
+export const isNonColumnKey = key =>
+  NON_COLUMN_KEYS.some(k => snakeCase(key).endsWith(k));
 export default {
   parseQuery,
   openDownloadModal,


### PR DESCRIPTION
This PR uses the URL to store the start and end year for the Data zoom.

![image](https://user-images.githubusercontent.com/9701591/84495968-68c03200-acac-11ea-9d4f-32c37873620b.png)

Try: Change the data zoom, the years should be stored on the URL
- If you reload the years should stay the same
- If you change the source the years should reset
- If you change another dropdown the years and DataZoom should stay the same
- If you use the link to data explorer the years should appear on the data explorer selection
![image](https://user-images.githubusercontent.com/9701591/84496323-0ca9dd80-acad-11ea-87df-eeb5940553d7.png)
- If you use the link from data explorer back to GHG emissions the Data zoom years should work
![image](https://user-images.githubusercontent.com/9701591/84496501-55fa2d00-acad-11ea-816d-265bc25b13a5.png)

Extra:
![image](https://user-images.githubusercontent.com/9701591/84496213-d8ceb800-acac-11ea-8616-d2daa67b2805.png)

- Cursor pointer in all the download menu items
- Data explorer link opens on the same window as is not an external link


