### PR TITLE
Update document slugs with 'sectoral' and 'framework'

### DIFF
--- a/app/javascript/app/data/country-documents.js
+++ b/app/javascript/app/data/country-documents.js
@@ -4,6 +4,6 @@ export const DOCUMENT_COLUMNS_SLUGS = {
   NDC: 'first_ndc',
   '2nd NDC': 'second_ndc',
   LTS: 'lts',
-  'Climate Framework Laws or Policies': 'laws',
-  'Sectoral Laws or Policies': 'policies'
+  'Climate Framework Laws or Policies': 'framework',
+  'Sectoral Laws or Policies': 'sectoral'
 };

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -37,8 +37,7 @@ const NDCCompareAllContainer = props => {
     setColumnWidthUtil({
       column,
       columns,
-      tableWidth: 1120,
-      narrowColumnWidth: 116,
+      narrowColumnWidth: 115,
       wideColumnWidth: 130,
       narrowColumns: [0, 2, 3, 4, 5, 6, 7, 8, 9],
       wideColumns: [1]

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -37,7 +37,8 @@ const NDCCompareAllContainer = props => {
     setColumnWidthUtil({
       column,
       columns,
-      narrowColumnWidth: 115,
+      tableWidth: 1120,
+      narrowColumnWidth: 116,
       wideColumnWidth: 130,
       narrowColumns: [0, 2, 3, 4, 5, 6, 7, 8, 9],
       wideColumns: [1]


### PR DESCRIPTION
This small PR updates the slugs on the `Compare All Targets` page for sectoral and framework columns.
![image](https://user-images.githubusercontent.com/15097138/84654826-2139e000-af10-11ea-99c0-ba9146e920d7.png)
