### PR TITLE
Fix calculation of EUU emissions in lts question

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import isArray from 'lodash/isArray';
+import intersection from 'lodash/intersection';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 
 const getIndicators = state =>
@@ -58,7 +59,11 @@ export const getEmissionsPercentage = createSelector(
         // To avoid double counting in EUU
         if (iso === europeSlug) {
           const EUTotal = parseFloat(emissionPercentages[europeSlug].value);
-          const europeanLocationsValue = europeanLocationIsos.reduce(
+          const europeanLocationIsosInAnswer = intersection(
+            europeanLocationIsos,
+            positiveAnswerIsos
+          );
+          const europeanLocationsValue = europeanLocationIsosInAnswer.reduce(
             (acc, i) => acc + parseFloat(emissionPercentages[i].value),
             0
           );


### PR DESCRIPTION
The calculation to avoid double counting was substracting all EU countries and not the ones with an LTS document. This is corrected now and the number is correct.
https://basecamp.com/1756858/projects/13795275/messages/91610806

![image](https://user-images.githubusercontent.com/9701591/84758896-50128d80-afc6-11ea-8ec7-12a2786ac1f9.png)
