### PR TITLE
Feature/ghg filter table data

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -190,9 +190,35 @@ function GhgEmissionsContainer(props) {
     const defaultColumnOrder = [GHG_TABLE_HEADER[fieldToBreakBy], 'unit'];
     const stripHtmlFromUnit = d => ({ ...d, unit: stripHTML(d.unit) });
     const parsedTableData = tableData.map(stripHtmlFromUnit);
+    const encodeParam = param =>
+      param &&
+      castArray(param)
+        .map(r => r.label)
+        .join(', ');
+    const {
+      sourcesSelected,
+      regionsSelected,
+      sectorsSelected,
+      gasesSelected,
+      calculationSelected,
+      breakBySelected
+    } = selected;
+    const filterSelectionLabels = `Countries/Regions: ${encodeParam(
+      regionsSelected
+    )}. Sectors/Subsectors: ${encodeParam(
+      sectorsSelected
+    )}. Gases: ${encodeParam(gasesSelected)}. Calculation: ${encodeParam(
+      calculationSelected
+    )}. Show data by ${encodeParam(breakBySelected)}`;
+    const metadata = {
+      'Data source': selected && sourcesSelected.label,
+      'Data for': filterSelectionLabels
+    };
+
     const csvContentEncoded = encodeAsCSVContent(
       parsedTableData,
-      orderByColumns(defaultColumnOrder)
+      orderByColumns(defaultColumnOrder),
+      metadata
     );
     invokeCSVDownload(csvContentEncoded);
   };

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -48,7 +48,7 @@ class SimpleTable extends PureComponent {
       titleLinks
     } = this.props;
 
-    if (!data.length) return null;
+    if (!data || !data.length) return null;
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
     const activeColumnNames = activeColumns.map(c => c.value);
     const firstColumns =

--- a/app/javascript/app/components/table/table.js
+++ b/app/javascript/app/components/table/table.js
@@ -15,6 +15,16 @@ import {
 
 import Component from './table-component';
 
+const filterColumns = columns =>
+  (columns
+    ? columns
+      .filter(d => !d.endsWith('NotShow'))
+      .map(d => ({
+        label: toStartCase(d),
+        value: d
+      }))
+    : []);
+
 class TableContainer extends PureComponent {
   constructor(props) {
     super(props);
@@ -33,12 +43,7 @@ class TableContainer extends PureComponent {
       forcedColumnWidth,
       sortBy: sortBy || Object.keys(data[0])[0],
       sortDirection,
-      activeColumns: columns
-        .filter(d => !d.endsWith('NotShow'))
-        .map(d => ({
-          label: toStartCase(d),
-          value: d
-        })),
+      activeColumns: filterColumns(columns),
       columnsOptions: Object.keys(data[0])
         .filter(d => !d.endsWith('NotShow'))
         .map(d => ({
@@ -51,11 +56,16 @@ class TableContainer extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const { data, titleLinks } = this.props;
+    const columns = data ? Object.keys(data[0]) : [];
     if (
       !isEqual(nextProps.data !== data) ||
       !isEqual(nextProps.titleLinks, titleLinks)
     ) {
-      this.setState({ data: nextProps.data, titleLinks: nextProps.titleLinks });
+      this.setState({
+        data: nextProps.data,
+        titleLinks: nextProps.titleLinks,
+        activeColumns: filterColumns(columns)
+      });
     }
   }
 
@@ -105,7 +115,9 @@ class TableContainer extends PureComponent {
     const dataWithTitleLinks = [...data];
     this.setState({ data: sortedData, sortBy, sortDirection });
     data.forEach((d, i) => {
-      dataWithTitleLinks[i].titleLink = titleLinks[i];
+      if (titleLinks) {
+        dataWithTitleLinks[i].titleLink = titleLinks[i];
+      }
     });
     const sortedData = this.getDataSorted(
       dataWithTitleLinks,

--- a/app/javascript/app/utils/csv.js
+++ b/app/javascript/app/utils/csv.js
@@ -1,7 +1,8 @@
-export function encodeAsCSVContent(data, sortOrder) {
+export function encodeAsCSVContent(data, sortOrder, metadata) {
   let csvContent = 'data:text/csv;charset=utf-8,';
 
-  const escapeForCSV = value => (value && String(value).includes(',') ? `"${value}"` : value);
+  const escapeForCSV = value =>
+    (value && String(value).includes(',') ? `"${value}"` : value);
 
   const headers = Object.keys(data[0]).sort(sortOrder);
   const rows = [headers.join(',')];
@@ -9,6 +10,12 @@ export function encodeAsCSVContent(data, sortOrder) {
   data.forEach(row => {
     rows.push(headers.map(header => escapeForCSV(row[header])).join(','));
   });
+
+  if (metadata) {
+    Object.keys(metadata).forEach(key => {
+      rows.push([key, metadata[key]]);
+    });
+  }
 
   csvContent += rows.join('\r\n');
   return encodeURI(csvContent);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173331657
- Filter the GHG table on GHG emissions page when we make a selection on the Data zoom years. The downloaded data on the CSV also changes:
Try: Move the Data zoom handles and the table data columns should change.

![image](https://user-images.githubusercontent.com/9701591/84770374-bb189000-afd7-11ea-9f9f-1faa0f5fa2dd.png)

https://www.pivotaltracker.com/story/show/173331575
- Add metadata on the GHG CSV download on the last two rows in this format:

![image](https://user-images.githubusercontent.com/9701591/84770209-6d038c80-afd7-11ea-84a5-0f02fa4e5166.png)

Extra: Fix ndcs table. It was crashing when we sorted the countries

![image](https://user-images.githubusercontent.com/9701591/84770419-d1265080-afd7-11ea-9fa1-b16a36b27d46.png)
