### PR TITLE
Feature/tweak download links

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -145,8 +145,8 @@ const findSelectedValueObject = (meta, selectedId) =>
     option =>
       option.iso_code === selectedId ||
       option.iso_code3 === selectedId ||
+      option.slug === selectedId ||
       option.name === selectedId ||
-      String(option.slug) === selectedId ||
       String(option.id) === selectedId
   );
 const addTopEmittersMembers = (isosArray, regions, key) => {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -507,6 +507,7 @@ export const parseExternalParams = createSelector(
       if (metaMatchingKey !== 'undefined') {
         if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const ids = externalFields[k].split(',');
+        console.log('ids: ',ids, ' sectionMeta[metaMatchingKey]: ',sectionMeta[metaMatchingKey])
         const filterObjects = sectionMeta[metaMatchingKey].filter(
           i =>
             ids.map(f => parseInt(f, 10)).includes(i.id) ||
@@ -515,6 +516,7 @@ export const parseExternalParams = createSelector(
             ids.includes(i.iso) ||
             ids.includes(i.slug)
         );
+        console.log('filterObjects: ',filterObjects)
 
         const selectedIds = filterObjects.map(labelObject => {
           const label = POSSIBLE_VALUE_FIELDS.find(
@@ -525,6 +527,7 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
+    console.log('parseExternalParams: ',parsedFields)
     return parsedFields;
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -507,16 +507,14 @@ export const parseExternalParams = createSelector(
       if (metaMatchingKey !== 'undefined') {
         if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const ids = externalFields[k].split(',');
-        console.log('ids: ',ids, ' sectionMeta[metaMatchingKey]: ',sectionMeta[metaMatchingKey])
         const filterObjects = sectionMeta[metaMatchingKey].filter(
           i =>
             ids.map(f => parseInt(f, 10)).includes(i.id) ||
             ids.includes(i.number) ||
             ids.includes(i.iso_code3) ||
             ids.includes(i.iso) ||
-            ids.includes(i.slug)
+            ids.map(f => f.toLowerCase()).includes(i.slug)
         );
-        console.log('filterObjects: ',filterObjects)
 
         const selectedIds = filterObjects.map(labelObject => {
           const label = POSSIBLE_VALUE_FIELDS.find(
@@ -527,7 +525,6 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
-    console.log('parseExternalParams: ',parsedFields)
     return parsedFields;
   }
 );

--- a/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
+++ b/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
@@ -37,8 +37,12 @@ export function getPathwaysCategoryOptions(query, filtersMeta) {
   const scenarioIndicatorsIds = filtersMeta.scenarios.find(
     sc => sc.id === selectedScenarioId
   ).indicator_ids;
+
   const categories = scenarioIndicatorsIds.map(
-    indId => filtersMeta.indicators.find(ind => ind.id === indId).category
+    indId => {
+      const category = filtersMeta.indicators.find(ind => ind.id === indId).category;
+      return filtersMeta.categories.find(({ id }) => id === category.id);
+    }
   );
   return uniqBy(categories, 'id');
 }

--- a/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
+++ b/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
@@ -38,12 +38,11 @@ export function getPathwaysCategoryOptions(query, filtersMeta) {
     sc => sc.id === selectedScenarioId
   ).indicator_ids;
 
-  const categories = scenarioIndicatorsIds.map(
-    indId => {
-      const category = filtersMeta.indicators.find(ind => ind.id === indId).category;
-      return filtersMeta.categories.find(({ id }) => id === category.id);
-    }
-  );
+  const categories = scenarioIndicatorsIds.map(indId => {
+    const category = filtersMeta.indicators.find(ind => ind.id === indId)
+      .category;
+    return filtersMeta.categories.find(({ id }) => id === category.id);
+  });
   return uniqBy(categories, 'id');
 }
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -91,7 +91,7 @@ class EmissionPathwayGraph extends PureComponent {
                     },
                     {
                       type: 'download',
-                      section: 'ndcs-content',
+                      section: 'emission-pathways',
                       link: downloadLink
                     },
                     {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -209,7 +209,6 @@ export const getCategoryOptions = createSelector(
   [getIndicatorsWithData],
   indicators => {
     if (!indicators) return null;
-    // console.log('indicators: ',indicators)
     const categories = indicators
       .filter(i => i.category)
       .map(i => ({
@@ -588,9 +587,6 @@ export const getLinkToDataExplorer = createSelector(
     const section = 'emission-pathways';
     let dataExplorerSearch = search || {};
     if (!categorySelected || !allScenarios.length) return null;
-
-    dataExplorerSearch.categories = categorySelected.value || '';
-
     if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
       // Data Explorer dropdown and table in case there's no scenario selected

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -209,10 +209,13 @@ export const getCategoryOptions = createSelector(
   [getIndicatorsWithData],
   indicators => {
     if (!indicators) return null;
-    const categories = indicators.filter(i => i.category).map(i => ({
-      label: i.category.name,
-      value: i.category.id
-    }));
+    // console.log('indicators: ',indicators)
+    const categories = indicators
+      .filter(i => i.category)
+      .map(i => ({
+        label: i.category.name,
+        value: i.category.id
+      }));
     return uniqBy(categories, 'value');
   }
 );
@@ -580,23 +583,26 @@ export const getModalData = createSelector(
 );
 
 export const getLinkToDataExplorer = createSelector(
-  [getSearch, getAllScenarios],
-  (search, allScenarios) => {
+  [getSearch, getCategorySelected, getAllScenarios],
+  (search, categorySelected, allScenarios) => {
     const section = 'emission-pathways';
-    if (!allScenarios.length) return null;
+    let dataExplorerSearch = search || {};
+    if (!categorySelected || !allScenarios.length) return null;
+
+    dataExplorerSearch.categories = categorySelected.value || '';
+
     if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
       // Data Explorer dropdown and table in case there's no scenario selected
       const scenarioId = allScenarios.find(
         s => s.model.id === parseInt(search.model, 10)
       ).id;
-      const filtersWithScenario = {
+      dataExplorerSearch = {
         ...search,
         scenario: scenarioId
       };
-      return generateLinkToDataExplorer(filtersWithScenario, section);
     }
-    return generateLinkToDataExplorer(search, section);
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
   }
 );
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -6,7 +6,6 @@ import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
-import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -17,8 +16,7 @@ import {
   getMeta,
   getRegions,
   getSources,
-  getSelection,
-  getSearch
+  getSelection
 } from './ghg-emissions-selectors-get';
 
 const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
@@ -286,7 +284,6 @@ const getGasOptions = createSelector([getFieldOptions('gas')], options => {
   if (!options) return [];
 
   const valueByLabel = g => (options.find(opt => opt.label === g) || {}).value;
-
   return options.map(o => ({
     ...o,
     expandsTo:
@@ -339,7 +336,6 @@ const getFiltersSelected = field =>
     [getOptions, getSelection(field), getDefaults],
     (options, selected, defaults) => {
       if (!options || !defaults) return null;
-
       const fieldOptions =
         field === 'location' ? options.regions : options[toPlural(field)];
       const defaultSelection =
@@ -522,20 +518,3 @@ export const getOptionsSelected = createStructuredSelector({
   calculationSelected: getCalculationSelected,
   chartTypeSelected: getChartTypeSelected
 });
-
-export const getLinkToDataExplorer = createSelector(
-  [getSearch, getOptionsSelected],
-  (search, optionsSelected) => {
-    const section = 'historical-emissions';
-    // let dataExplorerSearch = search || {};
-    // if (selectedCategory && selectedIndicator) {
-    //   dataExplorerSearch = {
-    //     category: selectedCategory.value,
-    //     gases: gasesSelected.value,
-    //     ...search
-    //   };
-    // }
-    console.log('getLinkToDataExplorer: ',generateLinkToDataExplorer(search, section))
-    return generateLinkToDataExplorer(search, section);
-  }
-);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -17,7 +17,8 @@ import {
   getMeta,
   getRegions,
   getSources,
-  getSelection
+  getSelection,
+  getSearch
 } from './ghg-emissions-selectors-get';
 
 const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
@@ -523,8 +524,8 @@ export const getOptionsSelected = createStructuredSelector({
 });
 
 export const getLinkToDataExplorer = createSelector(
-  [getOptionsSelected],
-  (/* search, */ optionsSelected) => {
+  [getSearch, getOptionsSelected],
+  (search, optionsSelected) => {
     const section = 'historical-emissions';
     // let dataExplorerSearch = search || {};
     // if (selectedCategory && selectedIndicator) {
@@ -534,6 +535,7 @@ export const getLinkToDataExplorer = createSelector(
     //     ...search
     //   };
     // }
-    return generateLinkToDataExplorer({}, section);
+    console.log('getLinkToDataExplorer: ',generateLinkToDataExplorer(search, section))
+    return generateLinkToDataExplorer(search, section);
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -6,6 +6,7 @@ import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -520,3 +521,19 @@ export const getOptionsSelected = createStructuredSelector({
   calculationSelected: getCalculationSelected,
   chartTypeSelected: getChartTypeSelected
 });
+
+export const getLinkToDataExplorer = createSelector(
+  [getOptionsSelected],
+  (/* search, */ optionsSelected) => {
+    const section = 'historical-emissions';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        gases: gasesSelected.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer({}, section);
+  }
+);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -526,14 +526,14 @@ export const getLinkToDataExplorer = createSelector(
   [getOptionsSelected],
   (/* search, */ optionsSelected) => {
     const section = 'historical-emissions';
-    let dataExplorerSearch = search || {};
-    if (selectedCategory && selectedIndicator) {
-      dataExplorerSearch = {
-        category: selectedCategory.value,
-        gases: gasesSelected.value,
-        ...search
-      };
-    }
+    // let dataExplorerSearch = search || {};
+    // if (selectedCategory && selectedIndicator) {
+    //   dataExplorerSearch = {
+    //     category: selectedCategory.value,
+    //     gases: gasesSelected.value,
+    //     ...search
+    //   };
+    // }
     return generateLinkToDataExplorer({}, section);
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { toPlural } from 'utils/ghg-emissions';
-import { generateLinkToDataExplorer } from 'utils/data-explorer';
 
 // meta data for selectors
 export const getData = ({ emissions }) => (emissions && emissions.data) || [];
@@ -26,7 +25,23 @@ export const getSelection = field =>
     return search[field] || search[toPlural(field)];
   });
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'historical-emissions';
-  return generateLinkToDataExplorer(search, section);
-});
+// export const getLinkToDataExplorer = createSelector([getSearch], search => {
+//   const section = 'historical-emissions';
+//   return generateLinkToDataExplorer(search, section);
+// });
+
+// export const getLinkToDataExplorer = createSelector(
+//   [getSearch, getSelectedCategory, getSelectedIndicator],
+//   (search, selectedCategory, selectedIndicator) => {
+//     const section = 'historical-emissions';
+//     let dataExplorerSearch = search || {};
+//     if (selectedCategory && selectedIndicator) {
+//       dataExplorerSearch = {
+//         category: selectedCategory.value,
+//         indicator: selectedIndicator.value,
+//         ...search
+//       };
+//     }
+//     return generateLinkToDataExplorer(dataExplorerSearch, section);
+//   }
+// );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { toPlural } from 'utils/ghg-emissions';
-
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 // meta data for selectors
 export const getData = ({ emissions }) => (emissions && emissions.data) || [];
 export const getMeta = ({ ghgEmissionsMeta }) =>
@@ -25,23 +25,7 @@ export const getSelection = field =>
     return search[field] || search[toPlural(field)];
   });
 
-// export const getLinkToDataExplorer = createSelector([getSearch], search => {
-//   const section = 'historical-emissions';
-//   return generateLinkToDataExplorer(search, section);
-// });
-
-// export const getLinkToDataExplorer = createSelector(
-//   [getSearch, getSelectedCategory, getSelectedIndicator],
-//   (search, selectedCategory, selectedIndicator) => {
-//     const section = 'historical-emissions';
-//     let dataExplorerSearch = search || {};
-//     if (selectedCategory && selectedIndicator) {
-//       dataExplorerSearch = {
-//         category: selectedCategory.value,
-//         indicator: selectedIndicator.value,
-//         ...search
-//       };
-//     }
-//     return generateLinkToDataExplorer(dataExplorerSearch, section);
-//   }
-// );
+export const getLinkToDataExplorer = createSelector([getSearch], search => {
+  const section = 'historical-emissions';
+  return generateLinkToDataExplorer(search, section);
+});

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -1,11 +1,14 @@
 import { createStructuredSelector } from 'reselect';
-import { getSearch, getDataZoomYears } from './ghg-emissions-selectors-get';
+import {
+  getSearch,
+  getDataZoomYears,
+  getLinkToDataExplorer
+} from './ghg-emissions-selectors-get';
 import {
   getOptions,
   getOptionsSelected,
   getFiltersConflicts,
-  getModelSelected,
-  getLinkToDataExplorer
+  getModelSelected
 } from './ghg-emissions-selectors-filters';
 import {
   getChartConfig,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -1,14 +1,11 @@
 import { createStructuredSelector } from 'reselect';
-import {
-  getSearch,
-  getLinkToDataExplorer,
-  getDataZoomYears
-} from './ghg-emissions-selectors-get';
+import { getSearch, getDataZoomYears } from './ghg-emissions-selectors-get';
 import {
   getOptions,
   getOptionsSelected,
   getFiltersConflicts,
-  getModelSelected
+  getModelSelected,
+  getLinkToDataExplorer
 } from './ghg-emissions-selectors-filters';
 import {
   getChartConfig,

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -181,11 +181,6 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-// export const getLinkToDataExplorer = createSelector([getSearch], search => {
-//   const section = 'lts-content';
-//   return generateLinkToDataExplorer(search, section);
-// });
-
 export const getLinkToDataExplorer = createSelector(
   [getSearch, getSelectedCategory, getSelectedIndicator],
   (search, selectedCategory, selectedIndicator) => {

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -181,10 +181,26 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'lts-content';
-  return generateLinkToDataExplorer(search, section);
-});
+// export const getLinkToDataExplorer = createSelector([getSearch], search => {
+//   const section = 'lts-content';
+//   return generateLinkToDataExplorer(search, section);
+// });
+
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'lts-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 const percentage = (value, total) => (value * 100) / total;
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -176,10 +176,21 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'ndc-content';
-  return generateLinkToDataExplorer(search, section);
-});
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'ndc-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 const percentage = (value, total) => (value * 100) / total;
 

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -152,10 +152,21 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'ndc-content';
-  return generateLinkToDataExplorer(search, section);
-});
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'ndc-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 export default {
   getCategories,


### PR DESCRIPTION
This PR fixes download links, adjusting them to the updated URL structure of the data-explorer (slugs instead of ids)
[PIVOTAL](https://www.pivotaltracker.com/story/show/172835211)

**Test:** To test it check all download links that lead to the data-explorer page