### PR TITLE
Adds ghg_sources information to regions endpoint

### DIFF
--- a/app/controllers/api/v1/locations/regions_controller.rb
+++ b/app/controllers/api/v1/locations/regions_controller.rb
@@ -10,7 +10,8 @@ module Api
 
           render json: regions,
                  each_serializer: Api::V1::LocationSerializer,
-                 topojson: params.key?(:topojson)
+                 topojson: params.key?(:topojson),
+                 ghg_sources: params.key?(:ghg_sources)
         end
       end
     end

--- a/app/models/historical_emissions/data_source.rb
+++ b/app/models/historical_emissions/data_source.rb
@@ -3,6 +3,7 @@ require_dependency 'historical_emissions'
 module HistoricalEmissions
   class DataSource < ApplicationRecord
     has_many :sectors, class_name: 'HistoricalEmissions::Sector'
+    has_many :records, class_name: 'HistoricalEmissions::Record'
     validates :name, presence: true
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,6 +5,9 @@ class Location < ApplicationRecord
   has_many :historical_emissions,
            class_name: 'HistoricalEmissions::Record',
            dependent: :destroy
+  has_many :data_sources,
+           class_name: 'HistoricalEmissions::DataSource',
+           through: :historical_emissions
   has_many :values, class_name: 'Indc::Value'
   has_many :indicators,
            class_name: 'Indc::Indicator',

--- a/app/serializers/api/v1/location_serializer.rb
+++ b/app/serializers/api/v1/location_serializer.rb
@@ -15,6 +15,11 @@ module Api
                if: -> { object.location_type != 'COUNTRY' }
 
       attribute :topojson, if: -> { instance_options[:topojson] }
+      attribute :ghg_sources, if: -> { instance_options[:ghg_sources] }
+
+      def ghg_sources
+        object.data_sources&.distinct&.pluck(:name)
+      end
     end
   end
 end

--- a/app/serializers/api/v1/location_serializer.rb
+++ b/app/serializers/api/v1/location_serializer.rb
@@ -18,7 +18,12 @@ module Api
       attribute :ghg_sources, if: -> { instance_options[:ghg_sources] }
 
       def ghg_sources
-        object.data_sources&.distinct&.pluck(:name)
+        sources = object.data_sources.distinct.pluck(:name)
+        return sources unless sources.empty? && object.members.any?
+
+        HistoricalEmissions::DataSource.joins(:records).
+          where(historical_emissions_records: {location_id: object.members.map(&:id)}).
+          distinct.pluck(:name)
       end
     end
   end


### PR DESCRIPTION
As discussed in this story: https://www.pivotaltracker.com/story/show/173197745
I've extended the existing regions endpoint to include information about the GHG emissions sources available for each country.

To avoid cluttering the endpoint unnecessarily I thought it would be best to use a param to request this, so I added `ghg_sources=true` as the param for this, to be appended to the endpoint. Let me know if this makes sense or if it's best to include it all the time?

thanks!