### PR TITLE
Enable filtering by multiple locations instead of just one

### DIFF
--- a/app/controllers/api/v1/ndc_documents_controller.rb
+++ b/app/controllers/api/v1/ndc_documents_controller.rb
@@ -9,7 +9,7 @@ module Api
       def index
         laws_info = SingleRecordFetcher.new(LSE_API, 'laws-info').call
 
-        laws_and_policies = fetch_laws_and_policies if params[:locations].present?
+        laws_and_policies = fetch_laws_and_policies if params[:location].present?
 
         render json: CountriesDocuments.new(set_locations(params), laws_info, laws_and_policies),
                serializer: Api::V1::Indc::CountriesDocumentsSerializer
@@ -19,14 +19,14 @@ module Api
 
       def set_locations(params)
         locs = Location.order(:wri_standard_name)
-        locs = locs.where(iso_code3: params[:locations].split(',')) if params[:locations].present?
+        locs = locs.where(iso_code3: params[:location].split(',')) if params[:location].present?
         locs
       end
 
       def fetch_laws_and_policies
         laws_and_policies = {}
         laws_and_policies['targets'] = []
-        params[:locations].split(',').each do |iso|
+        params[:location].split(',').each do |iso|
           iso = iso == 'EUU' ? 'EUR' : iso
           data = SingleRecordFetcher.new(LSE_API, iso, iso).call
           laws_and_policies['targets'] += data['targets']

--- a/app/controllers/api/v1/ndc_documents_controller.rb
+++ b/app/controllers/api/v1/ndc_documents_controller.rb
@@ -9,10 +9,7 @@ module Api
       def index
         laws_info = SingleRecordFetcher.new(LSE_API, 'laws-info').call
 
-        laws_and_policies = if params[:location].present?
-          iso = params[:location] == 'EUU' ? 'EUR' : params[:location]
-          SingleRecordFetcher.new(LSE_API, iso, iso).call
-        end
+        laws_and_policies = fetch_laws_and_policies if params[:locations].present?
 
         render json: CountriesDocuments.new(set_locations(params), laws_info, laws_and_policies),
                serializer: Api::V1::Indc::CountriesDocumentsSerializer
@@ -22,12 +19,19 @@ module Api
 
       def set_locations(params)
         locs = Location.order(:wri_standard_name)
-
-        if params[:location]
-          locs = locs.where(iso_code3: params[:location])
-        end
-
+        locs = locs.where(iso_code3: params[:locations].split(',')) if params[:locations].present?
         locs
+      end
+
+      def fetch_laws_and_policies
+        laws_and_policies = {}
+        laws_and_policies['targets'] = []
+        params[:locations].split(',').each do |iso|
+          iso = iso == 'EUU' ? 'EUR' : iso
+          data = SingleRecordFetcher.new(LSE_API, iso, iso).call
+          laws_and_policies['targets'] += data['targets']
+        end
+        laws_and_policies
       end
     end
   end

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -61,14 +61,14 @@ module Api
 
           object.laws_and_policies['targets'].map do |target|
             next if target['sources'].empty? || !target['sources'].first['framework']
-
             source = target['sources'].first
 
             {
               id: source['id'],
               slug: source['title'].parameterize,
               long_name: source['title'],
-              url: source['link']
+              url: source['link'],
+              iso: target['iso_code3']
             }
           end.compact.uniq
         end
@@ -85,7 +85,8 @@ module Api
               id: source['id'],
               slug: source['title'].parameterize,
               long_name: source['title'],
-              url: source['link']
+              url: source['link'],
+              iso: target['iso_code3']
             }
           end.compact.uniq
         end


### PR DESCRIPTION
This PR updates the countries_documents endpoint to allow filtering by multiple locations instead of one at a time, e.g.: `http://localhost:3000/api/v1/ndcs/countries_documents?location=BRA,USA`
