### PR TITLE
Split data selectors and use tablet data without Others

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -3,17 +3,20 @@ import { toPlural } from 'utils/ghg-emissions';
 import { generateLinkToDataExplorer } from 'utils/data-explorer';
 
 // meta data for selectors
-export const getData = ({ emissions }) => (emissions && emissions.data) || [];
-export const getMeta = ({ ghgEmissionsMeta }) =>
-  (ghgEmissionsMeta && ghgEmissionsMeta.meta) || null;
-export const getRegions = ({ regions }) => (regions && regions.data) || null;
-export const getCountries = ({ countries }) =>
-  (countries && countries.data) || null;
+export const getData = state =>
+  (state && state.emissions && state.emissions.data) || [];
+export const getMeta = state =>
+  (state && state.ghgEmissionsMeta && state.ghgEmissionsMeta.meta) || null;
+export const getRegions = state =>
+  (state && state.regions && state.regions.data) || null;
+export const getCountries = state =>
+  (state && state.countries && state.countries.data) || null;
 export const getSources = createSelector(
   getMeta,
   meta => (meta && meta.data_source) || null
 );
-export const getWBData = ({ wbCountryData }) => wbCountryData.data || null;
+export const getWBData = state =>
+  (state && state.wbCountryData && state.wbCountryData.data) || null;
 
 // values from search
 export const getSearch = (state, { search }) => search || null;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
@@ -1,0 +1,142 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import { GHG_TABLE_HEADER } from 'data/constants';
+import { europeSlug } from 'app/data/european-countries';
+import {
+  getRegions,
+  getCountries,
+  getData,
+  getDataZoomYears
+} from './ghg-emissions-selectors-get';
+import {
+  getModelSelected,
+  getMetricSelected,
+  getCalculationSelected,
+  getOptionsSelected,
+  getOptions
+} from './ghg-emissions-selectors-filters';
+import {
+  getUnit,
+  getCalculationData,
+  getChartDataFunction,
+  getShouldExpandRegions,
+  getSortedDataFunction,
+  getYColumnOptionsFunction,
+  getLegendDataSelectedFunction,
+  getExpandedLegendSectorsSelected,
+  getExpandedLegendGasesSelected,
+  getExpandedLegendRegionsSelectedFunction
+} from './ghg-emissions-selectors-data';
+
+// Reused selectors without Others option
+
+const getExpandedLegendRegionsSelected = createSelector(
+  [getOptions, getOptionsSelected, getShouldExpandRegions, getData],
+  getExpandedLegendRegionsSelectedFunction
+);
+
+const getLegendDataSelectedWithoutOthers = createSelector(
+  [
+    getModelSelected,
+    getOptions,
+    getOptionsSelected,
+    getExpandedLegendRegionsSelected,
+    getExpandedLegendSectorsSelected,
+    getExpandedLegendGasesSelected
+  ],
+  getLegendDataSelectedFunction
+);
+
+const getYColumnOptionsWithoutOthers = createSelector(
+  [getLegendDataSelectedWithoutOthers],
+  getYColumnOptionsFunction
+);
+const getSortedDataWithoutOthers = createSelector(
+  getData,
+  getSortedDataFunction
+);
+const getChartDataWithoutOthers = createSelector(
+  [
+    getSortedDataWithoutOthers,
+    getRegions,
+    getModelSelected,
+    getYColumnOptionsWithoutOthers,
+    getMetricSelected,
+    getCalculationData,
+    getCalculationSelected,
+    getDataZoomYears
+  ],
+  getChartDataFunction
+);
+
+// Table selectors
+
+export const getTableData = createSelector(
+  [
+    getChartDataWithoutOthers,
+    getMetricSelected,
+    getModelSelected,
+    getYColumnOptionsWithoutOthers,
+    getDataZoomYears
+  ],
+  (data, metric, model, yColumnOptions, dataZoomSelectedYears) => {
+    if (!data || !model || !data.length || !yColumnOptions) return null;
+    const isAbsoluteValue = metric === 'ABSOLUTE_VALUE';
+    const scale = isAbsoluteValue ? 1000000 : 1; // to convert tCO2e to MtCO2e if not gdp or population metric
+    const scaleString = isAbsoluteValue ? 'Mt' : 't';
+    const formatValue = value => value && Number((value / scale).toFixed(2));
+    const unit = `${scaleString}${getUnit(metric)}`;
+    const filteredYearValue = (d, c) => {
+      if (dataZoomSelectedYears) {
+        const { min, max } = dataZoomSelectedYears;
+        if ((min && d.x < min) || (max && d.x > max)) {
+          return {};
+        }
+      }
+      return { [String(d.x)]: formatValue(d[c.value]) }; // year: value
+    };
+    return yColumnOptions.map(c => ({
+      [GHG_TABLE_HEADER[model]]: c.label,
+      unit,
+      ...data.reduce(
+        (acc, d) => ({
+          ...acc,
+          ...filteredYearValue(d, c)
+        }),
+        {}
+      )
+    }));
+  }
+);
+
+export const getTitleLinks = createSelector(
+  [getTableData, getModelSelected, getRegions, getCountries],
+  (data, model, regions, countries) => {
+    if (
+      !data ||
+      isEmpty(data) ||
+      !regions ||
+      !countries ||
+      model !== 'regions'
+    ) {
+      return null;
+    }
+    const allRegions = regions
+      .filter(r => r.iso_code3 === europeSlug)
+      .concat(countries);
+    const returnData = data.map(d => {
+      const region = allRegions.find(
+        r => r.wri_standard_name === d[GHG_TABLE_HEADER.regions]
+      );
+      return region && region.iso_code3
+        ? [
+          {
+            columnName: GHG_TABLE_HEADER.regions,
+            url: `/countries/${region.iso_code3}`
+          }
+        ]
+        : [];
+    });
+    return returnData;
+  }
+);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -18,10 +18,12 @@ import {
   getLegendDataOptions,
   getLegendDataSelected,
   getLoading,
-  getTableData,
-  getDataZoomData,
-  getTitleLinks
+  getDataZoomData
 } from './ghg-emissions-selectors-data';
+import {
+  getTableData,
+  getTitleLinks
+} from './ghg-emissions-selectors-table-data';
 import { getProviderFilters } from './ghg-emissions-selectors-providers';
 
 export const getGHGEmissions = createStructuredSelector({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/84922626-66077780-b0c6-11ea-9682-4cf915c56648.png)

We needed the complete information for the table when we selected World and other regions with many results. Now the table has a different selectors file with some reused selectors but without the 'Others' item.

Try: http://localhost:3000/ghg-emissions?breakBy=regions&regions=WORLD