### PR TITLE
Fix z-index

### DIFF
--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.scss
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.scss
@@ -3,6 +3,7 @@
 .dataZoom {
   position: relative;
   margin-top: 20px;
+  z-index: $z-index-over-base;
 
   .selector {
     position: absolute;

--- a/app/javascript/app/styles/themes/chart/legend-chart.scss
+++ b/app/javascript/app/styles/themes/chart/legend-chart.scss
@@ -15,6 +15,11 @@
 }
 
 .legend {
+  // tagsContainer
+  > div > div {
+    z-index: 1;
+  }
+
   :global {
     .react-selectize-control {
       border: $dropdown-border !important;


### PR DESCRIPTION
Fix z-index on handle and tag selector on GHG chart

I didn't want to change the components again so I'm targeting the tagsContainer div with selectors
![image](https://user-images.githubusercontent.com/9701591/84993915-339f5e00-b14a-11ea-8dfd-1076b8e48d6a.png)
