### PR TITLE
show the scope value instead of sector as it has more details

### DIFF
--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
@@ -144,7 +144,7 @@ class LawsAndPolicies extends PureComponent {
               <CardRow
                 rowData={{
                   title: 'Targets',
-                  subtitle: currentSector && currentSector.label,
+                  subtitle: ndcContent.scope,
                   value: ndcContent.description
                 }}
               />

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies.js
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies.js
@@ -27,7 +27,7 @@ const mapStateToProps = (state, { location, match }) => {
   const getTargetsData = getAllData(lawsAndPoliciesData);
 
   const countryData = {
-    countries: state.countries.data,
+    countries: state.countries,
     iso
   };
 


### PR DESCRIPTION
This is a simple change but fixes the confusion found here: https://basecamp.com/1756858/projects/13795275/todos/418613657 , or at least part of it=)

It updates the country page lse block:

http://localhost:3000/countries/IND?sector=energy#laws-and-policies

![Screenshot 2020-06-18 at 12 00 25](https://user-images.githubusercontent.com/10764/85012714-55eda780-b15b-11ea-952e-dd61ecc1def5.png)
