### PR TITLE
adds second_ndc without submission_date if country intends to submit

### DIFF
--- a/app/models/indc/label.rb
+++ b/app/models/indc/label.rb
@@ -1,6 +1,7 @@
 module Indc
   class Label < ApplicationRecord
     belongs_to :indicator, class_name: 'Indc::Indicator'
+    has_many :indc_values, class_name: 'Indc::Value'
 
     validates :value, presence: true
     validates :index, presence: true

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -14,9 +14,12 @@ module Api
 
             ordering = docs.empty? ? 0 : docs.last['ordering']
 
+            # if country hasn't submitted a second_ndc, but they have expressed
+            # the intention of doing so, by responding 'enhance_2020', or 'intend_2020'
+            # on indicator with slug: ndce_status_2020 / ndce_status_2020_label
             if docs.select{|t| t['slug'] == 'second_ndc'}.empty? &&
-                ::Indc::Label.joins(indc_values: :location).where(slug: ['enhance_2020', 'intend_2020']).
-                  where(locations: {iso_code3: datum.iso_code3}).any?
+                ::Indc::Label.joins(:indicator, indc_values: :location).where(slug: ['enhance_2020', 'intend_2020']).
+                where(locations: {iso_code3: datum.iso_code3}).where(indc_indicators: {slug: 'ndce_status_2020'}).any?
               docs += ::Indc::Document.select('indc_documents.*, NULL AS submission_date').
                 where(slug: 'second_ndc')
             end


### PR DESCRIPTION
In the Compare All Targets page we have the blue option of "Intends to submit" this is to express the countries intentions, and we can use one of the data indicators to check this out.

This change checks if the country has submitted their second ndc, and if they haven't it checks if it they have filled the intention to do it, and adds that document to the countries list of submitted documents, but the submission_date set to null.

So we can use the same entry for the SecondNdc column on the front end, but if there's no submisison date we should use the "Intends to submit" circle, and not allow the selection.

Let me know if this is not clear!

The endpoint remains the same: http://localhost:3000/api/v1/ndcs/countries_documents