### PR TITLE
Change order of 'Others' selection (calculation => sort => others)

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -168,6 +168,22 @@ function GhgEmissions(props) {
     );
   };
 
+  const handleLegendChange = v => {
+    // If there is only one region selected return the contracted region + new selected item
+    if (
+      toPlural(fieldToBreakBy) === 'regions' &&
+      selectedOptions.regionsSelected &&
+      selectedOptions.regionsSelected.length === 1
+    ) {
+      handleChange(
+        'regions',
+        selectedOptions.regionsSelected.concat(v[v.length - 1])
+      );
+    } else {
+      handleChange(toPlural(fieldToBreakBy), v);
+    }
+  };
+
   const renderPngChart = () => {
     const { chartTypeSelected } = selectedOptions;
     return (
@@ -181,8 +197,6 @@ function GhgEmissions(props) {
         loading={loading}
         lineType="linear"
         showUnit
-        onLegendChange={v => handleChange(toPlural(fieldToBreakBy), v)}
-        hideRemoveOptions={hideRemoveOptions}
       />
     );
   };
@@ -193,7 +207,7 @@ function GhgEmissions(props) {
       config={config}
       dataOptions={legendOptions}
       dataSelected={legendOptions}
-      hideRemoveOptions={hideRemoveOptions}
+      hideRemoveOptions
     />
   );
 
@@ -257,7 +271,7 @@ function GhgEmissions(props) {
           loading={loading}
           lineType="linear"
           showUnit
-          onLegendChange={v => handleChange(toPlural(fieldToBreakBy), v)}
+          onLegendChange={handleLegendChange}
           hideRemoveOptions={hideRemoveOptions}
           getCustomYLabelFormat={
             isPercentageChangeCalculation

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
@@ -5,78 +5,24 @@ import { europeSlug } from 'app/data/european-countries';
 import {
   getRegions,
   getCountries,
-  getData,
   getDataZoomYears
 } from './ghg-emissions-selectors-get';
 import {
   getModelSelected,
-  getMetricSelected,
-  getCalculationSelected,
-  getOptionsSelected,
-  getOptions
+  getMetricSelected
 } from './ghg-emissions-selectors-filters';
 import {
   getUnit,
-  getCalculationData,
-  getChartDataFunction,
-  getShouldExpandRegions,
-  getSortedDataFunction,
-  getYColumnOptionsFunction,
-  getLegendDataSelectedFunction,
-  getExpandedLegendSectorsSelected,
-  getExpandedLegendGasesSelected,
-  getExpandedLegendRegionsSelectedFunction
+  getChartData,
+  getYColumnOptions
 } from './ghg-emissions-selectors-data';
-
-// Reused selectors without Others option
-
-const getExpandedLegendRegionsSelected = createSelector(
-  [getOptions, getOptionsSelected, getShouldExpandRegions, getData],
-  getExpandedLegendRegionsSelectedFunction
-);
-
-const getLegendDataSelectedWithoutOthers = createSelector(
-  [
-    getModelSelected,
-    getOptions,
-    getOptionsSelected,
-    getExpandedLegendRegionsSelected,
-    getExpandedLegendSectorsSelected,
-    getExpandedLegendGasesSelected
-  ],
-  getLegendDataSelectedFunction
-);
-
-const getYColumnOptionsWithoutOthers = createSelector(
-  [getLegendDataSelectedWithoutOthers],
-  getYColumnOptionsFunction
-);
-const getSortedDataWithoutOthers = createSelector(
-  getData,
-  getSortedDataFunction
-);
-const getChartDataWithoutOthers = createSelector(
-  [
-    getSortedDataWithoutOthers,
-    getRegions,
-    getModelSelected,
-    getYColumnOptionsWithoutOthers,
-    getMetricSelected,
-    getCalculationData,
-    getCalculationSelected,
-    getDataZoomYears
-  ],
-  getChartDataFunction
-);
-
-// Table selectors
 
 export const getTableData = createSelector(
   [
-    getChartDataWithoutOthers,
+    getChartData,
     getMetricSelected,
     getModelSelected,
-    getYColumnOptionsWithoutOthers,
+    getYColumnOptions,
     getDataZoomYears
   ],
   (data, metric, model, yColumnOptions, dataZoomSelectedYears) => {

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -12,11 +12,11 @@ import {
 } from './ghg-emissions-selectors-filters';
 import {
   getChartConfig,
-  getChartData,
+  getSortedChartData,
   getChartDomain,
   getHideRemoveOptions,
-  getLegendDataOptions,
-  getLegendDataSelected,
+  getLegendDataOptionsWithOthers,
+  getLegendDataSelectedWithOthers,
   getLoading,
   getDataZoomData
 } from './ghg-emissions-selectors-data';
@@ -32,9 +32,9 @@ export const getGHGEmissions = createStructuredSelector({
   options: getOptions,
   selected: getOptionsSelected,
   filtersConflicts: getFiltersConflicts,
-  legendOptions: getLegendDataOptions,
-  legendSelected: getLegendDataSelected,
-  data: getChartData,
+  legendOptions: getLegendDataOptionsWithOthers,
+  legendSelected: getLegendDataSelectedWithOthers,
+  data: getSortedChartData,
   tableData: getTableData,
   titleLinks: getTitleLinks,
   domain: getChartDomain,


### PR DESCRIPTION
This PR solves two problems on the GHG chart:

- Fixes cumulative calculation chart. There was a clause missing for dataZoomYears.min
![image](https://user-images.githubusercontent.com/9701591/85223043-1bd10f80-b3c0-11ea-84f8-d3e011571933.png)

- More importantly, changes the order in which we calculate the 'Others' grouped values in the chart. 

Before, we grouped the values out of the 10 items into an 'Others' item, then sorted them and then did the calculations (like per capita).

Now, we do the calculations, then we sort the values and then we group the Others. This fixes the selection of shown countries when we have other calculations than 'Total' selected.

![image](https://user-images.githubusercontent.com/9701591/85400001-068ee900-b558-11ea-91c0-6a1f1a3d5b1f.png)


- Also, the legend selector is fixed so it has the same functionality as the dropdown. If we have an expanded region and we add a country or region it will contract the region and this prevents any 'Others' problem to happen. Previously the top 10 countries were added to the selection and this was really unexpected for the user.
 


