### PR TITLE
Fix/description links

### DIFF
--- a/app/javascript/app/pages/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/ghg-emissions-component.jsx
@@ -19,25 +19,29 @@ class GhgEmissions extends PureComponent {
   render() {
     const { route } = this.props;
     // Intro component is parsing html from the description so a react component won't work here
-    const renderLink = (text, link) =>
-      `<a href=${link} title=${text}>${text}</a>`;
+    const renderLink = (text, title, link) =>
+      `<a href=${link} title="${title}">${text}</a>`;
     const description =
       FEATURE_NEW_GHG &&
       `Climate change causing greenhouse gas emissions
       ${renderLink(
     'have increased 50 fold',
+    'Climate change causing greenhouse gas emissions have increased 50 fold',
     '/ghg-emissions?chartType=area&source=PIK'
   )}
-        since the late 1800s. Energy makes up ${renderLink(
+      since the late 1800s. Energy makes up ${renderLink(
     'nearly two-thirds of global emissions, followed by agriculture.',
+    'Energy makes up nearly two-thirds of global emissions, followed by agriculture.',
     '/ghg-emissions?breakBy=sector&chartType=percentage&source=CAIT'
   )}
         Within the energy sector, ${renderLink(
     'electricity and heat generation make up the largest portion of emissions, followed by transportation and manufacturing.',
+    'Within the energy sector electricity and heat generation make up the largest portion of emissions, followed by transportation and manufacturing.',
     '/ghg-emissions?breakBy=sector&chartType=percentage&sectors=building%2Cfugitive-emissions%2Cmanufacturing-construction%2Cother-fuel-combustion%2Ctransportation%2Celectricity-heat'
   )}
           In 2014, 60% of global greenhouse gas emissions came ${renderLink(
     'from just 10 countries',
+    'In 2014, 60% of global greenhouse gas emissions came from just 10 countries',
     '/ghg-emissions?chartType=percentage'
   )}, while the 100 least-emitting contributed less than 3%.`;
 

--- a/app/javascript/app/pages/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/ghg-emissions-component.jsx
@@ -18,6 +18,29 @@ class GhgEmissions extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
     const { route } = this.props;
+    // Intro component is parsing html from the description so a react component won't work here
+    const renderLink = (text, link) =>
+      `<a href=${link} title=${text}>${text}</a>`;
+    const description =
+      FEATURE_NEW_GHG &&
+      `Climate change causing greenhouse gas emissions
+      ${renderLink(
+    'have increased 50 fold',
+    '/ghg-emissions?chartType=area&source=PIK'
+  )}
+        since the late 1800s. Energy makes up ${renderLink(
+    'nearly two-thirds of global emissions, followed by agriculture.',
+    '/ghg-emissions?breakBy=sector&chartType=percentage&source=CAIT'
+  )}
+        Within the energy sector, ${renderLink(
+    'electricity and heat generation make up the largest portion of emissions, followed by transportation and manufacturing.',
+    '/ghg-emissions?breakBy=sector&chartType=percentage&sectors=building%2Cfugitive-emissions%2Cmanufacturing-construction%2Cother-fuel-combustion%2Ctransportation%2Celectricity-heat'
+  )}
+          In 2014, 60% of global greenhouse gas emissions came ${renderLink(
+    'from just 10 countries',
+    '/ghg-emissions?chartType=percentage'
+  )}, while the 100 least-emitting contributed less than 3%.`;
+
     return (
       <div>
         <MetaDescription
@@ -33,10 +56,7 @@ class GhgEmissions extends PureComponent {
             <div className={cx(layout.content, styles.header)}>
               <Intro
                 title="Historical GHG Emissions"
-                description={
-                  FEATURE_NEW_GHG &&
-                  'Climate change causing greenhouse gas emissions have increased 50 fold since the late 1800s. Energy makes up nearly two-thirds of global emissions, followed by agriculture. Within the energy sector, electricity and heat generation make up the largest portion of emissions, followed by transportation and manufacturing. In 2014, 60% of global greenhouse gas emissions came from just 10 countries, while the 100 least-emitting contributed less than 3%. '
-                }
+                description={description}
               />
             </div>
           </Header>

--- a/app/javascript/app/pages/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/pages/ghg-emissions/ghg-emissions-styles.scss
@@ -2,6 +2,7 @@
 
 .header {
   padding-bottom: 64px;
+
   a {
     color: $white;
     text-decoration: underline;

--- a/app/javascript/app/pages/ghg-emissions/ghg-emissions-styles.scss
+++ b/app/javascript/app/pages/ghg-emissions/ghg-emissions-styles.scss
@@ -2,4 +2,12 @@
 
 .header {
   padding-bottom: 64px;
+  a {
+    color: $white;
+    text-decoration: underline;
+
+    &:hover {
+      color: $theme-secondary;
+    }
+  }
 }


### PR DESCRIPTION
Added description links linking to the same page with some params. I styled them with some hover

![image](https://user-images.githubusercontent.com/9701591/85390885-ba3cac80-b549-11ea-8965-1ef23d4dde93.png)
