### PR TITLE
Add zoom to 2020 ndc tracker and show it on menu

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
@@ -124,14 +124,14 @@ const NDCSEnhancementsViz = ({
                 tooltipId={TOOLTIP_ID}
                 onCountryEnter={handleCountryEnter}
                 onCountryFocus={handleCountryEnter}
-                dragEnable={false}
+                zoomEnable
                 customCenter={!isTablet ? [10, -10] : null}
               />
               {countryData && tooltipValues && (
                 <NDCSEnhancementsTooltip
                   id={TOOLTIP_ID}
-                  tooltipValues={tooltipValues}>
-                </NDCSEnhancementsTooltip>
+                  tooltipValues={tooltipValues}
+                />
               )}
               {indicator && (
                 <MapLegend

--- a/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
+++ b/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
@@ -23,7 +23,7 @@ export default [
     label: 'Explore NDCS',
     activeId
   },
-  !FEATURE_LTS_EXPLORE && {
+  {
     path: '/2020-ndc-tracker',
     label: '2020 NDC Tracker',
     activeId


### PR DESCRIPTION
THis PR enables zoom for 2020-NDC-Tracker and puts it back on the menu even if we have the LTS_EXPLORE feature on

![image](https://user-images.githubusercontent.com/9701591/85610520-5ef8e000-b657-11ea-9bcc-d11a2c9f06c3.png)
