### PR TITLE
Inscrease size of the columns on the custom-compare page

### DIFF
--- a/app/javascript/app/components/definition-list/definition-list-styles.scss
+++ b/app/javascript/app/components/definition-list/definition-list-styles.scss
@@ -32,7 +32,7 @@
   font-weight: $font-weight-bold;
   font-family: $font-family-1;
   margin-left: 0;
-  flex: 0.6;
+  flex: 0.4;
 }
 
 .definitionDesc {

--- a/app/javascript/app/pages/custom-compare/custom-compare-styles.scss
+++ b/app/javascript/app/pages/custom-compare/custom-compare-styles.scss
@@ -24,7 +24,7 @@
   }
 
   @media #{$tablet-landscape} {
-    grid-template-columns: 0.6fr repeat(3, 1fr);
+    grid-template-columns: 0.4fr repeat(3, 1fr);
     grid-template-rows: auto;
     grid-template-areas: ". filter-1 filter-2 filter-3"; /* stylelint-disable-line declaration-block-no-redundant-longhand-properties */
     margin: 0;


### PR DESCRIPTION
This tiny PR increases the width of the data columns on the custom-compare page:
[PIVOTAL](https://www.pivotaltracker.com/story/show/173331384)

**BEFORE:**
![image](https://user-images.githubusercontent.com/15097138/85728140-eac24900-b6f7-11ea-87e0-ad49d66a4437.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/15097138/85727980-c7979980-b6f7-11ea-8a3d-e2c9233664fb.png)

The change is very subtle, but I don't think we can change it much more. There are rows where titles are very long, so they don't look good even now, see we can't shrink them more, e.g:
![image](https://user-images.githubusercontent.com/15097138/85728566-560c1b00-b6f8-11ea-9f68-6743df0979d0.png)

