### PR TITLE
include LSE data on the ndcs filtered response

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -31,6 +31,18 @@ module Api
       'a_water'
     ].freeze
 
+    LSE_INDICATORS_MAP = {
+      'nrm_summary': 'description',
+      'nrm_type_of_commitment': 'ghg_target',
+      'nrm_ghg_target_type': 'type',
+      'nrm_base_year': 'base_year_period',
+      'nrm_target_year': 'year',
+      'nrm_target_multiplicity': 'single_year',
+      'nrm_link': 'source'
+    }.freeze
+
+    LSE_API = 'https://climate-laws.org/cclow/api/targets'.freeze
+
     NdcIndicators = Struct.new(:indicators, :categories, :sectors) do
       alias_method :read_attribute_for_serialization, :send
     end
@@ -40,6 +52,8 @@ module Api
     end
 
     class NdcsController < ApiController
+      before_action :set_locations_documents, only: [:index]
+
       def index
         indicators = filtered_indicators
         categories = filtered_categories(indicators)
@@ -53,7 +67,8 @@ module Api
 
         render json: NdcIndicators.new(indicators, categories, sectors),
                serializer: Api::V1::Indc::NdcIndicatorsSerializer,
-               locations_documents: locations_documents
+               locations_documents: @locations_documents,
+               lse_data: get_lse_data
       end
 
       def content_overview
@@ -103,12 +118,29 @@ module Api
         end
       end
 
-      def locations_documents
+      def set_locations_documents
         return nil unless params[:locations_documents].present?
 
-        params[:locations_documents].split(',').map do |loc_doc|
+        @locations_documents = params[:locations_documents].split(',').map do |loc_doc|
           loc_doc.split('-')
         end
+        @indc_locations_documents = @locations_documents.select{ |ld| ld.size == 2}.presence
+        @lse_locations_documents = @locations_documents.select{ |ld| ld.size == 3}.presence
+      end
+
+      def get_lse_data
+        return nil unless @lse_locations_documents
+
+        lse_data = []
+        @lse_locations_documents.each do |iso, _, law_id|
+          laws_and_policies = SingleRecordFetcher.new(LSE_API, iso, iso).call
+          laws_and_policies["targets"].each do |t|
+            if t["sources"].map{|p| p["id"]}.include?(law_id.to_i)
+              lse_data << t
+            end
+          end
+        end
+        lse_data
       end
 
       def filtered_indicators
@@ -130,11 +162,17 @@ module Api
           indicators = indicators.where(source_id: source.map(&:id))
         end
 
-        if locations_documents
+        if @indc_locations_documents
           indicators = indicators.select('DISTINCT ON(COALESCE("normalized_slug", indc_indicators.slug)) indc_indicators.*')
           indicators = indicators.joins(values: [:location, :document]).
-            where(locations: {iso_code3: locations_documents.map(&:first)},
-                  indc_documents: {slug: locations_documents.map(&:second)})
+            where(locations: {iso_code3: @indc_locations_documents.map(&:first)},
+                  indc_documents: {slug: @indc_locations_documents.map(&:second)})
+        end
+
+        if !@indc_locations_documents && @lse_locations_documents
+          indicators = indicators.joins(values: [:location]).
+            where(slug: LSE_INDICATORS_MAP.keys).
+            where(locations: {iso_code3: @lse_locations_documents.map(&:first)})
         end
 
         if params[:indicators].present?

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -124,8 +124,8 @@ module Api
         @locations_documents = params[:locations_documents].split(',').map do |loc_doc|
           loc_doc.split('-')
         end
-        @indc_locations_documents = @locations_documents.select{ |ld| ld.size == 2}.presence
-        @lse_locations_documents = @locations_documents.select{ |ld| ld.size == 3}.presence
+        @indc_locations_documents = @locations_documents.select{ |ld| !['framework', 'sectoral'].include?(ld[1].split('_').first)}.presence
+        @lse_locations_documents = @locations_documents.select{ |ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.presence
       end
 
       def get_lse_data

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -132,7 +132,8 @@ module Api
         return nil unless @lse_locations_documents
 
         lse_data = []
-        @lse_locations_documents.each do |iso, _, law_id|
+        @lse_locations_documents.each do |iso, data|
+          _, law_id = data.split('_')
           laws_and_policies = SingleRecordFetcher.new(LSE_API, iso, iso).call
           laws_and_policies["targets"].each do |t|
             if t["sources"].map{|p| p["id"]}.include?(law_id.to_i)

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -135,8 +135,8 @@ module Api
         @lse_locations_documents.each do |iso, data|
           _, law_id = data.split('_')
           laws_and_policies = SingleRecordFetcher.new(LSE_API, iso, iso).call
-          laws_and_policies["targets"].each do |t|
-            if t["sources"].map{|p| p["id"]}.include?(law_id.to_i)
+          laws_and_policies['targets'].each do |t|
+            if t['sources'].map{|p| p['id']}.include?(law_id.to_i)
               lse_data << t
             end
           end

--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -32,13 +32,13 @@ module Api
     ].freeze
 
     LSE_INDICATORS_MAP = {
-      'nrm_summary': 'description',
-      'nrm_type_of_commitment': 'ghg_target',
-      'nrm_ghg_target_type': 'type',
-      'nrm_base_year': 'base_year_period',
-      'nrm_target_year': 'year',
-      'nrm_target_multiplicity': 'single_year',
-      'nrm_link': 'source'
+      nrm_summary: 'description',
+      nrm_type_of_commitment: 'ghg_target',
+      nrm_ghg_target_type: 'type',
+      nrm_base_year: 'base_year_period',
+      nrm_target_year: 'year',
+      nrm_target_multiplicity: 'single_year',
+      nrm_link: 'source'
     }.freeze
 
     LSE_API = 'https://climate-laws.org/cclow/api/targets'.freeze
@@ -171,8 +171,9 @@ module Api
         end
 
         if !@indc_locations_documents && @lse_locations_documents
+          indicators = indicators.select('DISTINCT ON(COALESCE("normalized_slug", indc_indicators.slug)) indc_indicators.*')
           indicators = indicators.joins(values: [:location]).
-            where(slug: LSE_INDICATORS_MAP.keys).
+            where(normalized_slug: LSE_INDICATORS_MAP.keys.map(&:to_s)).
             where(locations: {iso_code3: @lse_locations_documents.map(&:first)})
         end
 

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -87,8 +87,8 @@ export const getSelectedTableTargets = createSelector(
   [getSelectedTargets],
   selectedTargets => {
     if (!selectedTargets) return [];
-    const selectedTableTargets = selectedTargets.map(target =>
-      target.split('-', 2).join('-')
+    const selectedTableTargets = selectedTargets.map(
+      target => target.split('_')[0]
     );
     return selectedTableTargets;
   }

--- a/app/serializers/api/v1/indc/countries_documents_serializer.rb
+++ b/app/serializers/api/v1/indc/countries_documents_serializer.rb
@@ -76,7 +76,7 @@ module Api
 
             {
               id: source['id'],
-              slug: "framework-#{source['id']}",
+              slug: "framework_#{source['id']}",
               long_name: source['title'],
               url: source['link'],
               iso: target['iso_code3']
@@ -94,7 +94,7 @@ module Api
 
             {
               id: source['id'],
-              slug: "sectoral-#{source['id']}",
+              slug: "sectoral_#{source['id']}",
               long_name: source['title'],
               url: source['link'],
               iso: target['iso_code3']

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -50,7 +50,7 @@ module Api
             v.location.iso_code3
           end
           if instance_options[:lse_data] && LSE_INDICATORS_MAP.keys.include?(object.normalized_slug&.to_sym)
-            instance_options[:locations_documents].select{|ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.each do |iso, prefix, law_id|
+            instance_options[:locations_documents].select{|ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.each do |iso, slug|
               instance_options[:lse_data].group_by{|lse| lse['iso_code3']}.each do |iso_code, data|
                 next unless iso == iso_code
                 indexed_data[iso_code] ||= []
@@ -60,7 +60,7 @@ module Api
                 end
                 indexed_data[iso_code] << {
                   value: value.join('<br>'),
-                  document_slug: "#{prefix}_#{law_id}"
+                  document_slug: slug
                 }
               end
             end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -49,18 +49,22 @@ module Api
           ) do |v|
             v.location.iso_code3
           end
+
+          # inject laws data
           if instance_options[:lse_data] && LSE_INDICATORS_MAP.keys.include?(object.normalized_slug&.to_sym)
-            instance_options[:locations_documents].select{|ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.each do |iso, slug|
+            instance_options[:locations_documents].select{|ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.each do |iso, param_slug|
+              law_id = param_slug.split('_').last
               instance_options[:lse_data].group_by{|lse| lse['iso_code3']}.each do |iso_code, data|
                 next unless iso == iso_code
                 indexed_data[iso_code] ||= []
                 value = []
                 data.each do |target|
+                  next unless target['sources'].map{|p| p['id']}.include?(law_id.to_i)
                   value  << target[LSE_INDICATORS_MAP[object.normalized_slug.to_sym]]
                 end
                 indexed_data[iso_code] << {
                   value: value.join('<br>'),
-                  document_slug: slug
+                  document_slug: param_slug
                 }
               end
             end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -50,7 +50,7 @@ module Api
             v.location.iso_code3
           end
           if instance_options[:lse_data] && LSE_INDICATORS_MAP.keys.include?(object.normalized_slug&.to_sym)
-            instance_options[:locations_documents].select{|ld| ld.size == 3}.each do |iso, prefix, law_id|
+            instance_options[:locations_documents].select{|ld| ['framework', 'sectoral'].include?(ld[1].split('_').first)}.each do |iso, prefix, law_id|
               instance_options[:lse_data].group_by{|lse| lse['iso_code3']}.each do |iso_code, data|
                 next unless iso == iso_code
                 indexed_data[iso_code] ||= []
@@ -60,7 +60,7 @@ module Api
                 end
                 indexed_data[iso_code] << {
                   value: value.join('<br>'),
-                  document_slug: "#{prefix}-#{law_id}"
+                  document_slug: "#{prefix}_#{law_id}"
                 }
               end
             end


### PR DESCRIPTION
First draft of parsing the LSE data from the LSE API and including it with the NDCs.

Example request: 

http://localhost:3000/api/v1/ndcs?locations_documents=DZA-sectoral-1004,DZA-first_ndc&category=overview&filter=overview

Will include this:

```
{
"id": 21507,
"source": "CAIT",
"name": "Summary",
"slug": "nrm_summary",
"category_ids": [
3959
],
"labels": {},
"locations": {
"DZA": [
{
"value": "<p class=\"Default\">&ldquo;Une r&eacute;duction des &eacute;missions de gaz &agrave; effet de serre de 7 &agrave; 22%, &agrave; l&rsquo;horizon 2030, par rapport &agrave; un sc&eacute;nario de r&eacute;f&eacute;rence (Business As Usual - BAU), subordonn&eacute;e aux soutiens en mati&egrave;re de financements ext&eacute;rieurs, de d&eacute;veloppement et de transfert technologique et de renforcement des capacit&eacute;s.</p> <p>Les 7 % de r&eacute;duction des GES seront r&eacute;alis&eacute;s avec les moyens nationaux.&rdquo;</p> <p>A greenhouse gas emission reduction of 7% to 22% by 2030 compared to business as usual (BAU) levels, conditional on external assistance for the financing of the development and transfer of technologies and capacity building.</p> <p>A 7% GHG reduction will be achieved with domestic means.&nbsp;</p>",
"document_slug": "first_ndc"
},
{
"value": "LNG (liquified natural gas) to reach 20% share of car fleet by 2020<br>To install 22,000MW of power generating capacity from renewable sources between 2011 and 2030 (of which 12,000MW for internal usage and 10,000MW for export), meeting 20% of electricity generation from renewables by 2030<br>Wind to reach 3% of national power supply by 2030<br>Objectives of installed renewable energy power in 2013 (110 MW), 2015 (650 MW), 2020 (2 600 MW and potential for exportations fo 2 000 MW), 2030 (120 000 MW and 10 000 MW for exports)<br>Wind farms to be installed: 10 MW in 2013, 2x20 MW in 2015, total of 1700 MW in 2030<br>Uptake of share of national industrial capacity in the PV solar sector (targets set for 60% at 2013, 80% at 2020, over 80% at 2030) by 2013, 2020, 2030 against a 2011 baseline<br>Uptake of share of national industrial capacity in the wind power sector (50% at 2020, 80% at 2030) by 2020, 2030 against a 2011 baseline<br>Uptake of share of national industrial capacity in the heat solar sector (50% at 2020, 80% at 2030) by 2020, 2030 against a 2011 baseline<br>New PV projects of overall power at 800 MW by 2020, and 200 MW per annum over 2021-2030<br>Solar to reach 37% of national power supply by 2030",
"document_slug": "sectoral-1004"
}
]
}
},
```

Inside the indicators response.