### PR TITLE
Fix/ndc country document

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -201,11 +201,7 @@ function CountryNdcOverview(props) {
       {FEATURE_NDC_FILTERING && <CountriesDocumentsProvider location={iso} />}
       <NdcContentOverviewProvider
         locations={[iso]}
-        document={
-          FEATURE_NDC_FILTERING &&
-          selectedDocument &&
-          selectedDocument.document_type
-        }
+        document={selectedDocument && selectedDocument.document_type}
       />
       {!hasSectors && !loading ? (
         <NoContent

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -1,8 +1,6 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 
-const FEATURE_NDC_FILTERING = process.env.FEATURE_NDC_FILTERING === 'true';
-
 const fetchNdcsCountryAccordionInit = createAction(
   'fetchNdcsCountryAccordionInit'
 );
@@ -17,8 +15,7 @@ const fetchNdcsCountryAccordion = createThunkAction(
   'fetchNdcsCountryAccordion',
   params => dispatch => {
     const { locations, category, compare, lts, document } = params;
-    const documentParam =
-      FEATURE_NDC_FILTERING && document ? `&document=${document}` : '';
+    const documentParam = document ? `&document=${document}` : '';
     if (locations) {
       dispatch(fetchNdcsCountryAccordionInit());
       fetch(

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -24,7 +24,10 @@ export const getDocumentSlug = createSelector(
     const selectedDocument = Object.values(documents).find(
       d => d.slug === searchDocument.split('-')[0]
     );
-    return (selectedDocument && selectedDocument.slug) || null;
+    if (selectedDocument) return selectedDocument.slug;
+    const documentValues = Object.values(documents);
+    const lastDocument = documentValues[documentValues.length - 1];
+    return lastDocument?.slug || null;
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-selectors.js
@@ -27,7 +27,7 @@ export const getDocumentSlug = createSelector(
     if (selectedDocument) return selectedDocument.slug;
     const documentValues = Object.values(documents);
     const lastDocument = documentValues[documentValues.length - 1];
-    return lastDocument?.slug || null;
+    return (lastDocument && lastDocument.slug) || null;
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -14,8 +14,6 @@ import {
   getDocumentSlug
 } from './ndcs-country-accordion-selectors';
 
-const FEATURE_NDC_FILTERING = process.env.FEATURE_NDC_FILTERING === 'true';
-
 const mapStateToProps = (state, { match, location, category }) => {
   const { iso } = match.params;
   const search = qs.parse(location.search);
@@ -60,13 +58,11 @@ class NdcsCountryAccordionContainer extends PureComponent {
       iso,
       document
     } = this.props;
+
     const newLocations =
       nextProps.iso || qs.parse(nextProps.location.search).locations;
     const oldLocations = iso || qs.parse(this.props.location.search).locations;
-    if (
-      newLocations !== oldLocations ||
-      (FEATURE_NDC_FILTERING && document !== nextProps.document)
-    ) {
+    if (newLocations !== oldLocations || document !== nextProps.document) {
       fetchNdcsCountryAccordion({
         locations: newLocations,
         category: nextProps.category,

--- a/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider-actions.js
+++ b/app/javascript/app/providers/ndc-content-overview-provider/ndc-content-overview-provider-actions.js
@@ -4,7 +4,6 @@ import { createThunkAction } from 'utils/redux';
 const getNdcContentOverviewInit = createAction('getNdcContentOverviewInit');
 const getNdcContentOverviewFail = createAction('getNdcContentOverviewFail');
 const getNdcContentOverviewReady = createAction('getNdcContentOverviewReady');
-const FEATURE_NDC_FILTERING = process.env.FEATURE_NDC_FILTERING === 'true';
 
 const getNdcContentOverview = createThunkAction(
   'getNdcContentOverview',
@@ -13,8 +12,7 @@ const getNdcContentOverview = createThunkAction(
     const promises = [];
     const locationsWithPromise = [];
     locations.forEach(location => {
-      const documentParam =
-        FEATURE_NDC_FILTERING && document ? `?document=${document}` : '';
+      const documentParam = document ? `?document=${document}` : '';
       promises.push(
         fetch(`/api/v1/ndcs/${location}/content_overview${documentParam}`).then(
           response => {


### PR DESCRIPTION
This is hard to check as the documents are very similar. The values of the NDC country pages (content overview = summary, and accordion = the rest) were not matching the selected / last indicator as the FEATURE_NDC_FILTERING tag was preventing it. The selection on the dropdown was right but not the data.

Now if you go to any country on the NDC page you would be able to see the last document or the document selected data