### PR TITLE
Feature/custom compare sectoral framework fixes

### DIFF
--- a/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
+++ b/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
@@ -13,19 +13,7 @@ const getSectors = state =>
   (state.customCompareAccordion && state.customCompareAccordion.data
     ? state.customCompareAccordion.data.sectors
     : {});
-const getSearch = (state, { search }) => search;
-
-export const getSelectedTargets = createSelector([getSearch], search => {
-  if (!search) return null;
-  const queryTargets = search.targets ? search.targets.split(',') : [];
-  return [1, 2, 3].map((value, i) => {
-    const target =
-      queryTargets && queryTargets[i] && queryTargets[i].split('-');
-    const country = target && target[0];
-    const document = target && target[1];
-    return { country, document };
-  });
-});
+export const getSelectedTargets = (state, { targets }) => targets;
 
 export const parseIndicatorsDefs = createSelector(
   [getIndicators, getCategories, getSelectedTargets],

--- a/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion.js
+++ b/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import qs from 'query-string';
 import CustomCompareAccordionProvider from 'providers/custom-compare-accordion-provider';
 
 import {
@@ -11,34 +10,47 @@ import {
 } from './custom-compare-accordion-selectors';
 import CustomCompareAccordionComponent from './custom-compare-accordion-component';
 
-const mapStateToProps = (state, { location, category }) => {
-  const search = qs.parse(location.search);
+const targetsToURLParams = targets => {
+  const parsedTargets =
+    targets &&
+    targets.map(({ country, document }) => `${country}-${document}`).join(',');
+  return parsedTargets;
+};
+
+const mapStateToProps = (state, { category, targets }) => {
   const isSectoralInformation = category === 'sectoral_information';
   return {
     data: isSectoralInformation
-      ? getSectoralInformationData(state, { search, category })
-      : getData(state, { search, category }),
+      ? getSectoralInformationData(state, { category, targets })
+      : getData(state, { category, targets }),
     loading:
       state.customCompareAccordion && state.customCompareAccordion.loading,
     category,
-    locationsAndDocuments: search && search.targets,
+    targets,
     isSectoralInformation
   };
 };
 
-const CustomCompareAccordion = props => (
-  <React.Fragment>
-    <CustomCompareAccordionComponent {...props} />
-    <CustomCompareAccordionProvider
-      locationsDocuments={props.locationsAndDocuments}
-      category={props.category}
-    />
-  </React.Fragment>
-);
+const CustomCompareAccordion = props => {
+  const targetsURLParams = targetsToURLParams(props.targets);
+  return (
+    <React.Fragment>
+      <CustomCompareAccordionComponent
+        locationsDocuments={targetsURLParams}
+        {...props}
+      />
+      <CustomCompareAccordionProvider
+        locationsDocuments={targetsURLParams}
+        category={props.category}
+      />
+    </React.Fragment>
+  );
+};
 
 CustomCompareAccordion.propTypes = {
   category: PropTypes.string,
-  locationsAndDocuments: PropTypes.string
+  locationsAndDocuments: PropTypes.string,
+  targets: PropTypes.array
 };
 
 export default withRouter(

--- a/app/javascript/app/pages/custom-compare/custom-compare-component.jsx
+++ b/app/javascript/app/pages/custom-compare/custom-compare-component.jsx
@@ -84,7 +84,8 @@ const CustomComparisonComponent = props => {
     backButtonLink,
     accordionDataLoading,
     selectedCountries,
-    documentsListLoading
+    documentsListLoading,
+    selectedTargets
   } = props;
 
   return (
@@ -126,7 +127,7 @@ const CustomComparisonComponent = props => {
             ))}
         </div>
       </div>
-      {renderRoutes(route.routes)}
+      {renderRoutes(route.routes, { targets: selectedTargets })}
       <NdcCompareAllTargetsProvider />
       <CountriesDocumentsProvider location={selectedCountries} />
     </div>
@@ -174,7 +175,8 @@ CustomComparisonComponent.propTypes = {
   backButtonLink: PropTypes.string,
   accordionDataLoading: PropTypes.bool,
   selectedCountries: PropTypes.string,
-  documentsListLoading: PropTypes.bool
+  documentsListLoading: PropTypes.bool,
+  selectedTargets: PropTypes.array
 };
 
 export default CustomComparisonComponent;

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -72,7 +72,13 @@ export const getDocumentsOptionsByCountry = createSelector(
         const countryDocument =
           countriesDocumentsData &&
           countriesDocumentsData[iso3] &&
-          countriesDocumentsData[iso3].find(d => d.slug === slug);
+          countriesDocumentsData[iso3]
+            .filter(
+              d =>
+                d.slug !== 'second_ndc' ||
+                (d.slug === 'second_ndc' && !!d.submission_date)
+            ) // filter out 'intends to submit' second NDC
+            .find(d => d.slug === slug);
         return createDropdownOption(countryDocument, '');
       }).filter(Boolean);
 

--- a/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
+++ b/app/javascript/app/pages/custom-compare/custom-compare-selectors.js
@@ -55,30 +55,6 @@ const getCountryOptions = createSelector([getCountries], countries => {
   }));
 });
 
-export const getSelectedTargets = createSelector([getQuery], query => {
-  if (!query) return null;
-  const queryTargets = query.targets ? query.targets.split(',') : [];
-  return [1, 2, 3].map((value, i) => {
-    // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
-    const target =
-      queryTargets && queryTargets[i] && queryTargets[i].split(/-(.+)/);
-    const country = target && target[0].replace('-', '');
-    const document = target && target[1];
-    return { key: `target${i}`, country, document };
-  });
-});
-
-export const getSelectedCountries = createSelector(
-  [getSelectedTargets],
-  selectedTargets => {
-    if (!selectedTargets) return null;
-    const selectedCountries = selectedTargets
-      .map(({ country }) => country)
-      .join(',');
-    return selectedCountries;
-  }
-);
-
 export const getDocumentsOptionsByCountry = createSelector(
   [getIndicatorsData, getCountriesDocuments, getCountriesDocumentsData],
   (indicators, countriesDocuments, countriesDocumentsData) => {
@@ -119,6 +95,48 @@ export const getDocumentsOptionsByCountry = createSelector(
   }
 );
 
+export const getSelectedTargets = createSelector(
+  [getQuery, getDocumentsOptionsByCountry],
+  (query, documentOptions) => {
+    if (!query || !documentOptions) return null;
+    const queryTargets = query.targets ? query.targets.split(',') : [];
+    return [1, 2, 3].map((value, i) => {
+      // targets are saved as a string 'ISO3-DOCUMENT', e.g. 'USA-NDC'
+      const target =
+        queryTargets && queryTargets[i] && queryTargets[i].split('-');
+      const country = target && target[0].replace('-', '');
+      const document = target && target[1];
+
+      let defaultDocument;
+      if (['framework', 'sectoral'].includes(document)) {
+        const defaultOption =
+          documentOptions[country] &&
+          documentOptions[country].find(
+            ({ optGroup }) => optGroup === document
+          );
+        defaultDocument = defaultOption && defaultOption.value;
+      }
+
+      return {
+        key: `target${i}`,
+        country,
+        document: defaultDocument || document
+      };
+    });
+  }
+);
+
+export const getSelectedCountries = createSelector(
+  [getSelectedTargets],
+  selectedTargets => {
+    if (!selectedTargets) return null;
+    const selectedCountries = selectedTargets
+      .map(({ country }) => country)
+      .join(',');
+    return selectedCountries;
+  }
+);
+
 export const getFiltersData = createSelector(
   [getCountryOptions, getDocumentsOptionsByCountry, getSelectedTargets],
   (countryOptions, documentOptions, targets) => {
@@ -138,20 +156,11 @@ export const getFiltersData = createSelector(
         documentOptions[country] &&
         documentOptions[country].find(({ value }) => value === document);
 
-      const defaultDocument =
-        documentOptions &&
-        document &&
-        documentOptions[country] &&
-        documentOptions[country].find(({ optGroup }) => {
-          const documentsGroup = document.split('-')[0];
-          return optGroup === documentsGroup;
-        });
-
       return {
         key,
         countryValue: countryOptions.find(({ value }) => country === value),
         contriesOptions: countryOptions,
-        documentValue: selectedDocument || defaultDocument,
+        documentValue: selectedDocument,
         documentOptions: documentOptions ? documentOptions[country] : []
       };
     });

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -88,8 +88,11 @@ export const getSelectedTableTargets = createSelector(
   selectedTargets => {
     if (!selectedTargets) return [];
     const selectedTableTargets = selectedTargets.map(target => {
-      const sp = target.split('-')[1].split('_');
-      if (sp.length > 1 && ['sectoral', 'framework'].includes(sp[0])) {
+      const documentTarget = target.split('-')[1].split('_');
+      if (
+        documentTarget.length > 1 &&
+        ['sectoral', 'framework'].includes(documentTarget[0])
+      ) {
         return target.split('_')[0];
       }
       return target;

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-selectors.js
@@ -87,9 +87,13 @@ export const getSelectedTableTargets = createSelector(
   [getSelectedTargets],
   selectedTargets => {
     if (!selectedTargets) return [];
-    const selectedTableTargets = selectedTargets.map(
-      target => target.split('_')[0]
-    );
+    const selectedTableTargets = selectedTargets.map(target => {
+      const sp = target.split('-')[1].split('_');
+      if (sp.length > 1 && ['sectoral', 'framework'].includes(sp[0])) {
+        return target.split('_')[0];
+      }
+      return target;
+    });
     return selectedTableTargets;
   }
 );

--- a/app/javascript/app/routes/app-routes/custom-compare-routes/custom-compare-routes.js
+++ b/app/javascript/app/routes/app-routes/custom-compare-routes/custom-compare-routes.js
@@ -6,11 +6,11 @@ import CompareAccordion from 'components/custom-compare-accordion';
 export default [
   {
     path: '/custom-compare/overview',
-    component: () =>
-      createElement(CompareAccordion, {
-        category: 'overview',
-        compare: true
-      }),
+    component: ({ targets }) => createElement(CompareAccordion, {
+      category: 'overview',
+      compare: true,
+      targets
+    }),
     exact: true,
     anchor: true,
     label: 'Overview',
@@ -18,10 +18,11 @@ export default [
   },
   {
     path: '/custom-compare/mitigation',
-    component: () =>
+    component: ({ targets }) =>
       createElement(CompareAccordion, {
         category: 'mitigation',
-        compare: true
+        compare: true,
+        targets
       }),
     exact: true,
     anchor: true,
@@ -30,10 +31,11 @@ export default [
   },
   {
     path: '/custom-compare/adaptation',
-    component: () =>
+    component: ({ targets }) =>
       createElement(CompareAccordion, {
         category: 'adaptation',
-        compare: true
+        compare: true,
+        targets
       }),
     exact: true,
     anchor: true,
@@ -42,10 +44,11 @@ export default [
   },
   {
     path: '/custom-compare/sectoral-information',
-    component: () =>
+    component: ({ targets }) =>
       createElement(CompareAccordion, {
         category: 'sectoral_information',
-        compare: true
+        compare: true,
+        targets
       }),
     exact: true,
     anchor: true,


### PR DESCRIPTION
This PR fixes the issue with the selection of the `sectoral` and `framework` targets on the `Compare All Targets` page. The problem is that by selecting these, we don't select any specific document. After clicking on the `Compare` button, we need to find default docs at the `Custom compare` page and then fetch the data for the comparison.
It also hides all the`second_ndc` options without `sumbmission_date` specified.
[PIVOTAL](https://www.pivotaltracker.com/story/show/173564472)

The most significant change here is with the `custom-compare-accordion` component - now we don't take the selected targets from the URL; instead, we pass them through props from the parent, `custom-compare` page.

_**BUG**: `Custom compare` page keeps the selected filters but doesn't fetch the data, only after a manual change of the filter_
![jxvyt-qmk4u](https://user-images.githubusercontent.com/15097138/86122716-91cc2980-bad8-11ea-9890-af8e1bb717ef.gif)

So now, after opening the `Custom compare` page, all filters should be on place, and all the data will be fetched automatically