### PR TITLE
Sort explore-ndcs/-lts table data on load

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -142,7 +142,7 @@ const getFilteredData = createSelector(
   [addDocumentTarget, getDefaultColumns],
   (data, columnHeaders) => {
     if (!data || isEmpty(data)) return null;
-    return data.map(d => {
+    const filteredData = data.map(d => {
       const filteredAndChangedHeadersD = {};
       Object.keys(d).forEach(k => {
         const header = headerChanges[k] || k;
@@ -156,6 +156,7 @@ const getFilteredData = createSelector(
       });
       return filteredAndChangedHeadersD;
     });
+    return sortBy(filteredData, ['country']);
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-table/ndcs-enhancements-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-table/ndcs-enhancements-table.js
@@ -26,6 +26,7 @@ const mapStateToProps = (state, { location }) => {
     query: search.search,
     search
   };
+
   return {
     loading,
     query: ndcsEnhancementsWithSelection.query,

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, sortBy } from 'lodash';
 import { filterQuery } from 'app/utils';
 import { getMapIndicator } from 'components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors';
 import {
@@ -52,7 +52,12 @@ export const getDefaultColumns = createSelector(
 export const tableGetSelectedData = createSelector(
   [getIndicatorsParsed, getCountries],
   (indicators, countries) => {
-    if (!indicators || !indicators.length || !indicators[0].locations || !countries) {
+    if (
+      !indicators ||
+      !indicators.length ||
+      !indicators[0].locations ||
+      !countries
+    ) {
       return [];
     }
     const refIndicator =
@@ -86,7 +91,9 @@ const addIndicatorColumn = createSelector(
       isEmpty(data) ||
       !selectedIndicator ||
       !selectedIndicatorHeader
-    ) { return null; }
+    ) {
+      return null;
+    }
     const updatedTableData = data;
     return updatedTableData.map(countryRow => {
       const updatedCountryRow = { ...countryRow };
@@ -102,7 +109,7 @@ const getFilteredData = createSelector(
   [addIndicatorColumn, getDefaultColumns],
   (data, columnHeaders) => {
     if (!data || isEmpty(data)) return null;
-    return data.map(d => {
+    const filteredData = data.map(d => {
       const filteredAndChangedHeadersD = {};
       Object.keys(d).forEach(k => {
         const header = HEADER_CHANGES[k] || k;
@@ -116,6 +123,7 @@ const getFilteredData = createSelector(
       });
       return filteredAndChangedHeadersD;
     });
+    return sortBy(filteredData, ['country']);
   }
 );
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
@@ -46,7 +46,6 @@ class NDCSExploreTableContainer extends PureComponent {
     super(props);
     this.state = {};
   }
-
   setColumnWidth = column => {
     const { columns } = this.props;
     return setColumnWidth({


### PR DESCRIPTION
This small PR fixes the problem with the initial sorting of the data table on `explore-ndcs/ -lts` pages.
[PIVOTAL](https://www.pivotaltracker.com/story/show/173564731)

The sorting feature works well on the `Table` component, the thing is that there is no initial sorting after data the fetch.
The data is sorted by `iso` on the backend, so maybe that would be something we could change in the future @simaob? Like to sort by the data name of the country?

**Test:** Go to [ndc-explore](http://localhost:3000/ndcs-explore) and [lts-explore](http://localhost:3000/lts-explore) pages, and check if the rows are sorted by `country` column after first load. Also, check if manual sorting works ok.