### PR TITLE
Fix/overview use slugs

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -61,13 +61,13 @@ export const commitmentsData = [
   {
     title: 'Other climate commitments',
     description:
-      'Aside from commitments made through NDCs and LTS, some parties also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these targets are not explicitly for the Paris Agreement, they indicate parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
+      'Aside from commitments made through NDCs and LTS, some Parties also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these commitments are not official submissions to the Paris Agreement, they indicate Parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
     hint:
-      'See how many parties have submitted additional commitments and explore the details by clicking on each box.',
+      'See how many Parties have submitted additional commitments and explore the details by clicking on each box.',
     color: '#2EC9DF',
     questions: [
       {
-        questionText: 'How many parties have a net zero emission target?',
+        questionText: 'How many Parties have a net zero emission target?',
         link: 'https://eciu.net/netzerotracker',
         slug: 'lts_zero',
         answerLabel: 'Net-zero target included',
@@ -76,7 +76,7 @@ export const commitmentsData = [
       },
       {
         questionText:
-          'How many parties have an economy-wide target in a national law or policy?',
+          'How many Parties have an economy-wide target in a national law or policy?',
         answerLabel: ['In Policy Document', 'In Law'],
         link: 'https://climate-laws.org/',
         slug: 'nz_status',

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section.js
@@ -4,14 +4,21 @@ import actions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-
 import Component from './ndcs-overview-section-component';
 import { commitmentsData } from './ndcs-overview-section-data';
 
 const NdcsOverviewSection = props => {
   useEffect(() => {
     const { fetchNDCS } = props;
-    fetchNDCS(true);
+    const indicatorSlugs = [];
+    commitmentsData.forEach(d => {
+      d.questions.forEach(q => {
+        if (q.slug && !indicatorSlugs.includes(q.slug)) {
+          indicatorSlugs.push(q.slug);
+        }
+      });
+    });
+    fetchNDCS({ overrideFilter: true, indicatorSlugs });
   }, []);
 
   const handleInfoClick = source => {

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -1,6 +1,5 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
-import isEmpty from 'lodash/isEmpty';
 
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
@@ -9,38 +8,35 @@ const fetchNDCSInit = createAction('fetchNDCSInit');
 const fetchNDCSReady = createAction('fetchNDCSReady');
 const fetchNDCSFail = createAction('fetchNDCSFail');
 
-const fetchNDCS = createThunkAction(
-  'fetchNDCS',
-  overrideFilter => (dispatch, state) => {
-    const { ndcs } = state();
-    if (
-      ndcs &&
-      (isEmpty(ndcs.data) || isEmpty(ndcs.data.indicators)) &&
-      !ndcs.loading
-    ) {
-      dispatch(fetchNDCSInit());
-      fetch(
-        `/api/v1/ndcs${
-          overrideFilter
-            ? ''
-            : '?filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
-        }`
-      )
-        .then(response => {
-          if (response.ok) return response.json();
-          throw Error(response.statusText);
-        })
-        .then(data => indcTransform(data))
-        .then(data => {
-          dispatch(fetchNDCSReady(data));
-        })
-        .catch(error => {
-          console.warn(error);
-          dispatch(fetchNDCSFail());
-        });
-    }
+const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
+  const { overrideFilter, indicatorSlugs } = props || {};
+  const { ndcs } = state();
+  const indicatorsParam = indicatorSlugs
+    ? `${overrideFilter ? '?' : '&'}&indicators=${indicatorSlugs.join(',')}`
+    : '';
+  if (ndcs && !ndcs.loading) {
+    dispatch(fetchNDCSInit());
+    fetch(
+      `/api/v1/ndcs${
+        overrideFilter
+          ? ''
+          : '?filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
+      }${indicatorsParam}`
+    )
+      .then(response => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then(data => indcTransform(data))
+      .then(data => {
+        dispatch(fetchNDCSReady(data));
+      })
+      .catch(error => {
+        console.warn(error);
+        dispatch(fetchNDCSFail());
+      });
   }
-);
+});
 
 export default {
   fetchNDCS,


### PR DESCRIPTION
- Update texts
- Capitalize 'Parties'
- Request only selected indicators for the Overview page.

This last one has a problem. Now that we fetch only selected indicators (and categories on the NDC explore page) we can't preserve the NDC data on the store as we did before. So we will have to find some other solution, either some kind of cache or checking if we have the data we need before fetching.

After this is merged for example on NDC content it will fetch always the NDC data no matter if we have got the data before