### PR TITLE
Fix second_ndc calculations on the NDCS-explore page

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -191,6 +191,7 @@ export const getLegend = createSelector(
     if (!indicator || !indicator.legendBuckets || !maximumCountries) {
       return null;
     }
+
     const bucketsWithId = Object.keys(indicator.legendBuckets).map(id => ({
       ...indicator.legendBuckets[id],
       id
@@ -287,16 +288,19 @@ export const getSummaryCardData = createSelector(
   [getIndicatorsData, getCountriesDocumentsData],
   (indicators, countriesDocuments) => {
     if (!indicators || !countriesDocuments) return null;
-    const getSubmissionIsos = slug =>
-      Object.keys(countriesDocuments).filter(iso =>
-        countriesDocuments[iso].some(doc => doc.slug === slug)
-      );
-    const firstNDCCountriesAndParties = getCountriesAndParties(
-      getSubmissionIsos('first_ndc')
+
+    const firstNDCIsos = Object.keys(countriesDocuments).filter(iso =>
+      countriesDocuments[iso].some(doc => doc.slug === 'first_ndc')
     );
-    const secondNDCCountriesAndParties = getCountriesAndParties(
-      getSubmissionIsos('second_ndc')
+    const firstNDCCountriesAndParties = getCountriesAndParties(firstNDCIsos);
+
+    const secondNDCIsos = Object.keys(countriesDocuments).filter(iso =>
+      countriesDocuments[iso].some(
+        doc => doc.slug === 'second_ndc' && !!doc.submission_date
+      )
     );
+    const secondNDCCountriesAndParties = getCountriesAndParties(secondNDCIsos);
+
     return [
       {
         value: firstNDCCountriesAndParties.partiesNumber,

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -59,7 +59,11 @@ const getCountryDocuments = createSelector(
   [getDocuments, getIso],
   (documents, iso) => {
     if (isEmpty(documents) || !iso || !documents[iso]) return null;
-    return documents[iso];
+    const submittedDocuments = documents[iso].filter(
+      ({ slug, submission_date }) =>
+        !(slug === 'second_ndc' && !submission_date)
+    );
+    return submittedDocuments;
   }
 );
 


### PR DESCRIPTION
This PR filters out the countries without the submission data of the secondNDC, on the NDCS Explore page:
[PIVOTAL](https://www.pivotaltracker.com/story/show/173564704)

**Test:** Go to the [NDCS Explore ](http://localhost:3000/ndcs-explore) page and check if numbers of the `Second NDC Submitted` documents on the summary component and on the legend are the same:
![image](https://user-images.githubusercontent.com/15097138/86270484-96bdd580-bbcb-11ea-9db3-d6765ff806d7.png)
