### PR TITLE
Order donut chart data by value

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -17,6 +17,7 @@ import ExploreMapTooltip from 'components/ndcs/shared/explore-map-tooltip';
 import ModalShare from 'components/modal-share';
 import Sticky from 'react-stickynode';
 import cx from 'classnames';
+import { getHoverIndex } from 'components/ndcs/shared/utils';
 
 import layout from 'styles/layout.scss';
 import newMapTheme from 'styles/themes/map/map-new-zoom-controls.scss';
@@ -64,14 +65,14 @@ const renderSummary = summaryData => (
   </div>
 );
 
-const renderLegend = legendData => (
+const renderLegend = (legendData, emissionsCardData) => (
   <div className={styles.legendCardContainer}>
     <div className={styles.legendContainer}>
       {legendData &&
-        legendData.map((l, index) => (
+        legendData.map(l => (
           <LegendItem
             key={l.name}
-            index={index}
+            hoverIndex={getHoverIndex(emissionsCardData, l)}
             name={l.name}
             number={l.countriesNumber}
             value={l.value}
@@ -199,7 +200,8 @@ function LTSExploreMap(props) {
                           {summaryCardData && renderSummary(summaryCardData)}
                           {emissionsCardData &&
                             renderDonutChart(emissionsCardData)}
-                          {legendData && renderLegend(legendData)}
+                          {legendData &&
+                            renderLegend(legendData, emissionsCardData)}
                         </React.Fragment>
                       )}
                     </div>

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -327,7 +327,10 @@ export const getEmissionsCardData = createSelector(
     );
 
     // Remove extra No document submitted. TODO: Fix in data
-    data = data.filter(d => d.name !== 'noDocumentSubmitted');
+    data = sortBy(
+      data.filter(d => d.name !== 'noDocumentSubmitted'),
+      'value'
+    );
     const config = {
       animation: true,
       innerRadius: 50,

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -10,6 +10,7 @@ import { IGNORED_COUNTRIES_ISOS } from 'data/ignored-countries';
 import { actions as fetchActions } from 'pages/lts-explore';
 import { actions as modalActions } from 'components/modal-metadata';
 import exploreMapActions from 'components/ndcs/shared/explore-map/explore-map-actions';
+import { getHoverIndex } from 'components/ndcs/shared/utils';
 
 import Component from './lts-explore-map-component';
 import {
@@ -106,7 +107,8 @@ class LTSExploreMapContainer extends PureComponent {
     const {
       tooltipCountryValues,
       legendData,
-      selectActiveDonutIndex
+      selectActiveDonutIndex,
+      emissionsCardData
     } = this.props;
     const iso = geography.properties && geography.properties.id;
 
@@ -120,11 +122,15 @@ class LTSExploreMapContainer extends PureComponent {
           l => parseInt(l.id, 10) === tooltipValue.labelId
         );
         if (hoveredlegendData) {
-          selectActiveDonutIndex(legendData.indexOf(hoveredlegendData));
+          selectActiveDonutIndex(
+            getHoverIndex(emissionsCardData, hoveredlegendData)
+          );
         }
       } else {
         // This is the last legend item aggregating all the no data geographies
-        selectActiveDonutIndex(legendData.length - 1);
+        selectActiveDonutIndex(
+          getHoverIndex(emissionsCardData, legendData[legendData.length - 1])
+        );
       }
 
       const tooltipValues = {
@@ -198,6 +204,7 @@ LTSExploreMapContainer.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   isoCountries: PropTypes.array.isRequired,
+  emissionsCardData: PropTypes.object.isRequired,
   setModalMetadata: PropTypes.func.isRequired,
   fetchLTS: PropTypes.func.isRequired,
   query: PropTypes.string,

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -10,6 +10,7 @@ import ModalMetadata from 'components/modal-metadata';
 import { PieChart } from 'cw-components';
 import CustomTooltip from 'components/ndcs/shared/donut-tooltip';
 import ExploreMapTooltip from 'components/ndcs/shared/explore-map-tooltip';
+import { getHoverIndex } from 'components/ndcs/shared/utils';
 import HandIconInfo from 'components/ndcs/shared/hand-icon-info';
 import CustomInnerHoverLabel from 'components/ndcs/shared/donut-custom-label';
 import LegendItem from 'components/ndcs/shared/legend-item';
@@ -66,14 +67,14 @@ const renderSummary = summaryData => (
   </div>
 );
 
-const renderLegend = legendData => (
+const renderLegend = (legendData, emissionsCardData) => (
   <div className={styles.legendCardContainer}>
     <div className={styles.legendContainer}>
       {legendData &&
-        legendData.map((l, index) => (
+        legendData.map(l => (
           <LegendItem
             key={l.name}
-            index={index}
+            hoverIndex={getHoverIndex(emissionsCardData, l)}
             name={l.name}
             number={l.partiesNumber}
             value={l.value}
@@ -200,7 +201,8 @@ function NDCSExploreMap(props) {
                           {summaryCardData && renderSummary(summaryCardData)}
                           {emissionsCardData &&
                             renderDonutChart(emissionsCardData)}
-                          {legendData && renderLegend(legendData)}
+                          {legendData &&
+                            renderLegend(legendData, emissionsCardData)}
                         </React.Fragment>
                       )}
                     </div>

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -242,10 +242,9 @@ export const getEmissionsCardData = createSelector(
     }
     const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
     if (!emissionsIndicator) return null;
-    const data = getIndicatorEmissionsData(
-      emissionsIndicator,
-      selectedIndicator,
-      legend
+    const data = sortBy(
+      getIndicatorEmissionsData(emissionsIndicator, selectedIndicator, legend),
+      'value'
     );
 
     const config = {

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -7,6 +7,7 @@ import { handleAnalytics } from 'utils/analytics';
 import { isCountryIncluded } from 'app/utils';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { IGNORED_COUNTRIES_ISOS } from 'data/ignored-countries';
+import { getHoverIndex } from 'components/ndcs/shared/utils';
 
 import fetchActions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
@@ -106,12 +107,12 @@ class NDCSExploreMapContainer extends PureComponent {
       );
     }
   };
-
   handleCountryEnter = geography => {
     const {
       tooltipCountryValues,
       legendData,
-      selectActiveDonutIndex
+      selectActiveDonutIndex,
+      emissionsCardData
     } = this.props;
     const iso = geography.properties && geography.properties.id;
 
@@ -125,11 +126,15 @@ class NDCSExploreMapContainer extends PureComponent {
           l => parseInt(l.id, 10) === tooltipValue.labelId
         );
         if (hoveredlegendData) {
-          selectActiveDonutIndex(legendData.indexOf(hoveredlegendData));
+          selectActiveDonutIndex(
+            getHoverIndex(emissionsCardData, hoveredlegendData)
+          );
         }
       } else {
         // This is the last legend item aggregating all the no data geographies
-        selectActiveDonutIndex(legendData.length - 1);
+        selectActiveDonutIndex(
+          getHoverIndex(emissionsCardData, legendData[legendData.length - 1])
+        );
       }
 
       const tooltipValues = {
@@ -205,6 +210,7 @@ NDCSExploreMapContainer.propTypes = {
   fetchNDCS: PropTypes.func.isRequired,
   query: PropTypes.object,
   summaryData: PropTypes.array,
+  emissionsCardData: PropTypes.array,
   indicator: PropTypes.object,
   selectActiveDonutIndex: PropTypes.func.isRequired,
   legendData: PropTypes.array,

--- a/app/javascript/app/components/ndcs/shared/legend-item/legend-item-component.jsx
+++ b/app/javascript/app/components/ndcs/shared/legend-item/legend-item-component.jsx
@@ -9,12 +9,12 @@ const LegendItem = ({
   value,
   color,
   itemsName,
-  index,
+  hoverIndex,
   selectActiveDonutIndex
 }) => (
   <div
     className={styles.legendItem}
-    onMouseEnter={() => selectActiveDonutIndex(index)}
+    onMouseEnter={() => selectActiveDonutIndex(hoverIndex)}
   >
     <div className={styles.legendName}>
       <span className={styles.legendDot} style={{ backgroundColor: color }} />
@@ -34,7 +34,7 @@ LegendItem.propTypes = {
   number: PropTypes.number,
   itemsName: PropTypes.array,
   value: PropTypes.number,
-  index: PropTypes.number.isRequired,
+  hoverIndex: PropTypes.number.isRequired,
   color: PropTypes.string,
   selectActiveDonutIndex: PropTypes.func.isRequired
 };

--- a/app/javascript/app/components/ndcs/shared/utils.js
+++ b/app/javascript/app/components/ndcs/shared/utils.js
@@ -85,3 +85,11 @@ export const getLabels = (
     theme
   };
 };
+
+export const getHoverIndex = (emissionsCardData, hoveredlegendData) => {
+  const hoveredLegendName = hoveredlegendData.name;
+  const hoveredEmissionsItem = emissionsCardData.data.find(d =>
+    d.name.toLowerCase().startsWith(hoveredLegendName.toLowerCase())
+  );
+  return emissionsCardData.data.indexOf(hoveredEmissionsItem);
+};


### PR DESCRIPTION
This little PR orders the donut chart data on the NDC Explore and LTS Explore pages
Before:
![image](https://user-images.githubusercontent.com/9701591/86271220-cf11e380-bbcc-11ea-84ec-3607137561cd.png)
After:
![image](https://user-images.githubusercontent.com/9701591/86271231-d33e0100-bbcc-11ea-9745-2b559f899a9a.png)
