### PR TITLE
include document_slug for ndc_content overview

### DIFF
--- a/app/serializers/api/v1/indc/value_overview_serializer.rb
+++ b/app/serializers/api/v1/indc/value_overview_serializer.rb
@@ -5,6 +5,7 @@ module Api
         attribute :slug
         attribute :name
         attribute :value
+        attribute :document_slug
 
         def name
           object.indicator.name
@@ -12,6 +13,10 @@ module Api
 
         def slug
           object.indicator.slug
+        end
+
+        def document_slug
+          object.document&.slug
         end
       end
     end


### PR DESCRIPTION
I realised that we are not including the document_slug for the content_overview endpoints, and that is needed to filter the Summary pages.

Just to remind you that you could also filter the request by document, see: http://localhost:3000/api/v1/ndcs/ARG/content_overview?document=indc