### PR TITLE
Overview text and indicator updates

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -24,7 +24,7 @@ export const commitmentsData = [
         answerLabel: 'first_ndc'
       },
       {
-        questionText: 'How many Parties have submitted Long-Term Strategies?',
+        questionText: 'How many Parties submitted Long-Term Strategies?',
         link: '/lts-explore?indicator=lts_submission ',
         slug: 'lts_submission',
         metadataSlug: 'ndc_lts',
@@ -68,18 +68,16 @@ export const commitmentsData = [
     questions: [
       {
         questionText: 'How many Parties have a net zero emission target?',
+        answerLabel: ['In Policy Document', 'In Law'],
         link: 'https://eciu.net/netzerotracker',
-        slug: 'lts_zero',
-        answerLabel: 'Net-zero target included',
+        slug: 'nz_status',
         metadataSlug: 'eciu',
         hasExternalLink: true
       },
       {
         questionText:
           'How many Parties have an economy-wide target in a national law or policy?',
-        answerLabel: ['In Policy Document', 'In Law'],
         link: 'https://climate-laws.org/',
-        slug: 'nz_status',
         metadataSlug: 'national_laws_politices',
         hasExternalLink: true
       }


### PR DESCRIPTION
This PR updates some text and changes the indicator information of the second to last question (It was assigned to the last one). Now the last one is missing a slug we will fix this on a different PR

![image](https://user-images.githubusercontent.com/9701591/86352493-2c0da800-bc66-11ea-9ac6-e857f5d0d97e.png)
![image](https://user-images.githubusercontent.com/9701591/86352527-36c83d00-bc66-11ea-8fe3-6f05d65e95e7.png)
![image](https://user-images.githubusercontent.com/9701591/86352590-4d6e9400-bc66-11ea-8f90-dc7fd93671f1.png)
