### PR TITLE
Sets a default for document slug

### DIFF
--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -41,7 +41,8 @@ module Api
           values = if instance_options[:locations_documents]
                      object.values_for instance_options[:locations_documents]
                    else
-                     object.values.includes(:location, :document, :label)
+                     object.values.includes(:location, :document, :label).
+                       where(document_id: instance_options[:documents])
                    end
           indexed_data = IndexedSerializer.serialize_collection(
             values,


### PR DESCRIPTION
This PR aims to reduce the size of the response of the `/api/v1/ndcs` calls. We already had the possibility of filtering these calls by document, by passing `document=indc` as a parameter to the call. But when the parameter was not passed it was defaulting to all of the values. This PR sets a default to `first_ndc`. By doing this it reduced the response size by half, so using it alongside of the `subcategory` can have a really positive impact in performance.

But this change has some caveats, as by setting a default it means that where we were relying on the whole data being available, it no longer is, so we need to test it carefully.

The `document` filter supports multiple values, so where needed we could pass a comma separated list of document slugs: e.g.: `document=first_ndc,indc` .

One thing still outstanding related with these document slugs is the first page of the NDC Country page: http://localhost:3000/ndcs/country/BRA/?document=first_ndc, we are not passing the document slug to the `content_overview` endpoint, so we are always displaying the same data. We should update it to call the dataset with the selected document_slug. 

Álvaro if you feel that this would require more information or is too much trouble, we can also ignore it!