### PR TITLE
Feature/fetch ndcs by category

### DIFF
--- a/app/javascript/app/components/footer/site-map-footer/site-map-footer-data.js
+++ b/app/javascript/app/components/footer/site-map-footer/site-map-footer-data.js
@@ -11,8 +11,8 @@ export const siteMapData = [
     links: [
       { title: 'Country Profiles', href: '/countries' },
       { title: 'Agriculture Sector', href: '/sectors/agriculture' },
-      { title: 'NDCs', href: '/ndcs-content' },
       ...exploreTools,
+      { title: '2020 NDC Tracker', href: '/2020-ndc-tracker' },
       { title: 'NDC-SDG Linkages', href: '/ndcs-sdg' },
       { title: 'Historical GHG Emissions', href: '/ghg-emissions' },
       { title: 'Pathways', href: '/pathways' }

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -72,7 +72,11 @@ const renderLegend = (legendData, emissionsCardData) => (
         legendData.map(l => (
           <LegendItem
             key={l.name}
-            hoverIndex={getHoverIndex(emissionsCardData, l)}
+            hoverIndex={
+              emissionsCardData &&
+              emissionsCardData.data &&
+              getHoverIndex(emissionsCardData, l)
+            }
             name={l.name}
             number={l.countriesNumber}
             value={l.value}

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -77,6 +77,8 @@ class LTSExploreMapContainer extends PureComponent {
   }
 
   componentWillMount() {
+    // Note: This fetch is not filtered by category like the NDC as the data is not so big
+    // If it starts getting big copy the logic in ndcs-explore-map.js with the lts emissions indicator
     this.props.fetchLTS();
   }
 
@@ -126,7 +128,7 @@ class LTSExploreMapContainer extends PureComponent {
             getHoverIndex(emissionsCardData, hoveredlegendData)
           );
         }
-      } else {
+      } else if (legendData) {
         // This is the last legend item aggregating all the no data geographies
         selectActiveDonutIndex(
           getHoverIndex(emissionsCardData, legendData[legendData.length - 1])

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -74,7 +74,11 @@ const renderLegend = (legendData, emissionsCardData) => (
         legendData.map(l => (
           <LegendItem
             key={l.name}
-            hoverIndex={getHoverIndex(emissionsCardData, l)}
+            hoverIndex={
+              emissionsCardData &&
+              emissionsCardData.data &&
+              getHoverIndex(emissionsCardData, l)
+            }
             name={l.name}
             number={l.partiesNumber}
             value={l.value}
@@ -162,7 +166,9 @@ function NDCSExploreMap(props) {
                         hideResetButton
                         plain
                         showTooltip={
-                          selectedCategory && selectedCategory.label.length > 14
+                          selectedCategory &&
+                          selectedCategory.label &&
+                          selectedCategory.label.length > 14
                         }
                       />
                       <Dropdown
@@ -174,6 +180,7 @@ function NDCSExploreMap(props) {
                         plain
                         showTooltip={
                           selectedIndicator &&
+                          selectedIndicator.label &&
                           selectedIndicator.label.length > 14
                         }
                       />

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -16,7 +16,7 @@ import {
   getLabels
 } from 'components/ndcs/shared/utils';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
-import { DEFAULT_CATEGORY_SLUG } from 'constants';
+import { DEFAULT_CATEGORY_SLUG } from 'data/constants';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -244,6 +244,7 @@ export const getEmissionsCardData = createSelector(
     if (!legend || !selectedIndicator || !indicators) {
       return null;
     }
+
     const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
     if (!emissionsIndicator) return null;
     const data = sortBy(

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -16,6 +16,7 @@ import {
   getLabels
 } from 'components/ndcs/shared/utils';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
+import { DEFAULT_CATEGORY_SLUG } from 'constants';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -26,6 +27,7 @@ const getIndicatorsData = state => state.indicators || null;
 const getCountriesDocumentsData = state =>
   state.countriesDocuments.data || null;
 const getZoom = state => state.map.zoom || null;
+
 export const getDonutActiveIndex = state =>
   state.exploreMap.activeIndex || null;
 
@@ -81,7 +83,8 @@ export const getSelectedCategory = createSelector(
   (selected, categories = []) => {
     if (!categories || !categories.length) return null;
     const defaultCategory =
-      categories.find(cat => cat.value === 'unfccc_process') || categories[0];
+      categories.find(cat => cat.value === DEFAULT_CATEGORY_SLUG) ||
+      categories[0];
     if (selected) {
       return (
         categories.find(category => category.value === selected) ||
@@ -218,7 +221,7 @@ export const getLegend = createSelector(
 export const getTooltipCountryValues = createSelector(
   [getIndicatorsData, getSelectedIndicator],
   (indicators, selectedIndicator) => {
-    if (!indicators || !selectedIndicator) {
+    if (!indicators || !selectedIndicator || !selectedIndicator.locations) {
       return null;
     }
     const tooltipCountryValues = {};

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -8,7 +8,7 @@ import { isCountryIncluded } from 'app/utils';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { IGNORED_COUNTRIES_ISOS } from 'data/ignored-countries';
 import { getHoverIndex } from 'components/ndcs/shared/utils';
-
+import { DEFAULT_CATEGORY_SLUG } from 'constants';
 import fetchActions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
 import exploreMapActions from 'components/ndcs/shared/explore-map/explore-map-actions';
@@ -85,8 +85,26 @@ class NDCSExploreMapContainer extends PureComponent {
     };
   }
 
-  componentWillMount() {
-    this.props.fetchNDCS();
+  componentDidMount() {
+    const { location } = this.props;
+    const search = qs.parse(location.search);
+
+    this.props.fetchNDCS({
+      subcategory: (search && search.category) || DEFAULT_CATEGORY_SLUG
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    const { selectedCategory: prevSelectedCategory } = prevProps;
+    const { selectedCategory } = this.props;
+
+    if (
+      selectedCategory &&
+      (prevSelectedCategory && prevSelectedCategory.value) !==
+        selectedCategory.value
+    ) {
+      this.props.fetchNDCS({ subcategory: selectedCategory.value });
+    }
   }
 
   handleSearchChange = query => {
@@ -210,6 +228,7 @@ NDCSExploreMapContainer.propTypes = {
   fetchNDCS: PropTypes.func.isRequired,
   query: PropTypes.object,
   summaryData: PropTypes.array,
+  selectedCategory: PropTypes.array,
   emissionsCardData: PropTypes.array,
   indicator: PropTypes.object,
   selectActiveDonutIndex: PropTypes.func.isRequired,

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -8,7 +8,7 @@ import { isCountryIncluded } from 'app/utils';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { IGNORED_COUNTRIES_ISOS } from 'data/ignored-countries';
 import { getHoverIndex } from 'components/ndcs/shared/utils';
-import { DEFAULT_CATEGORY_SLUG } from 'constants';
+import { DEFAULT_CATEGORY_SLUG } from 'data/constants';
 import fetchActions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
 import exploreMapActions from 'components/ndcs/shared/explore-map/explore-map-actions';
@@ -37,15 +37,6 @@ const mapStateToProps = (state, { location }) => {
   const { countries } = state;
   const search = qs.parse(location.search);
 
-  const mapCategories = {};
-  if (data.categories) {
-    Object.keys(data.categories).forEach(id => {
-      if (data.categories[id].type === 'map') {
-        mapCategories[id] = data.categories[id];
-      }
-    });
-  }
-
   const ndcsExploreWithSelection = {
     ...state,
     ...data,
@@ -53,7 +44,6 @@ const mapStateToProps = (state, { location }) => {
     query: search.search,
     categorySelected: search.category,
     indicatorSelected: search.indicator,
-    categories: mapCategories,
     emissions: state.emissions,
     search
   };
@@ -88,22 +78,24 @@ class NDCSExploreMapContainer extends PureComponent {
   componentDidMount() {
     const { location } = this.props;
     const search = qs.parse(location.search);
-
     this.props.fetchNDCS({
-      subcategory: (search && search.category) || DEFAULT_CATEGORY_SLUG
+      subcategory: (search && search.category) || DEFAULT_CATEGORY_SLUG,
+      additionalIndicatorSlug: 'ndce_ghg'
     });
   }
 
   componentDidUpdate(prevProps) {
     const { selectedCategory: prevSelectedCategory } = prevProps;
     const { selectedCategory } = this.props;
-
     if (
       selectedCategory &&
       (prevSelectedCategory && prevSelectedCategory.value) !==
         selectedCategory.value
     ) {
-      this.props.fetchNDCS({ subcategory: selectedCategory.value });
+      this.props.fetchNDCS({
+        subcategory: selectedCategory.value,
+        additionalIndicatorSlug: 'ndce_ghg'
+      });
     }
   }
 
@@ -148,7 +140,7 @@ class NDCSExploreMapContainer extends PureComponent {
             getHoverIndex(emissionsCardData, hoveredlegendData)
           );
         }
-      } else {
+      } else if (legendData) {
         // This is the last legend item aggregating all the no data geographies
         selectActiveDonutIndex(
           getHoverIndex(emissionsCardData, legendData[legendData.length - 1])

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -90,6 +90,7 @@ const addIndicatorColumn = createSelector(
       !data ||
       isEmpty(data) ||
       !selectedIndicator ||
+      !selectedIndicator.locations ||
       !selectedIndicatorHeader
     ) {
       return null;

--- a/app/javascript/app/components/ndcs/shared/utils.js
+++ b/app/javascript/app/components/ndcs/shared/utils.js
@@ -87,6 +87,9 @@ export const getLabels = (
 };
 
 export const getHoverIndex = (emissionsCardData, hoveredlegendData) => {
+  if (!emissionsCardData || !emissionsCardData.length) {
+    return null;
+  }
   const hoveredLegendName = hoveredlegendData.name;
   const hoveredEmissionsItem = emissionsCardData.data.find(d =>
     d.name.toLowerCase().startsWith(hoveredLegendName.toLowerCase())

--- a/app/javascript/app/components/ndcs/shared/utils.js
+++ b/app/javascript/app/components/ndcs/shared/utils.js
@@ -87,9 +87,6 @@ export const getLabels = (
 };
 
 export const getHoverIndex = (emissionsCardData, hoveredlegendData) => {
-  if (!emissionsCardData || !emissionsCardData.length) {
-    return null;
-  }
   const hoveredLegendName = hoveredlegendData.name;
   const hoveredEmissionsItem = emissionsCardData.data.find(d =>
     d.name.toLowerCase().startsWith(hoveredLegendName.toLowerCase())

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -355,3 +355,5 @@ export const AGRICULTURE_INDICATORS_MAP_BUCKETS = {
     5: { name: '> 50%', index: 4 }
   }
 };
+
+export const DEFAULT_CATEGORY_SLUG = 'unfccc_process';

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -9,20 +9,23 @@ const fetchNDCSReady = createAction('fetchNDCSReady');
 const fetchNDCSFail = createAction('fetchNDCSFail');
 
 const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
-  const { overrideFilter, indicatorSlugs } = props || {};
+  const { overrideFilter, indicatorSlugs, subcategory } = props || {};
   const { ndcs } = state();
-  const indicatorsParam = indicatorSlugs
-    ? `${overrideFilter ? '?' : '&'}&indicators=${indicatorSlugs.join(',')}`
-    : '';
+  const params = [];
+
+  if (indicatorSlugs) {
+    params.push(`indicators=${indicatorSlugs.join(',')}`);
+  }
+  if (overrideFilter) {
+    params.push('filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer');
+  }
+  if (subcategory) {
+    params.push(`subcategory=${subcategory}`);
+  }
+
   if (ndcs && !ndcs.loading) {
     dispatch(fetchNDCSInit());
-    fetch(
-      `/api/v1/ndcs${
-        overrideFilter
-          ? ''
-          : '?filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
-      }${indicatorsParam}`
-    )
+    fetch(`/api/v1/ndcs${params.length ? `?${params.join('&')}` : ''}`)
       .then(response => {
         if (response.ok) return response.json();
         throw Error(response.statusText);

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -9,23 +9,58 @@ const fetchNDCSReady = createAction('fetchNDCSReady');
 const fetchNDCSFail = createAction('fetchNDCSFail');
 
 const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
-  const { overrideFilter, indicatorSlugs, subcategory } = props || {};
+  const {
+    overrideFilter,
+    indicatorSlugs,
+    subcategory,
+    additionalIndicatorSlug
+  } = props || {};
   const { ndcs } = state();
   const params = [];
 
   if (indicatorSlugs) {
     params.push(`indicators=${indicatorSlugs.join(',')}`);
   }
-  if (overrideFilter) {
+  if (!overrideFilter) {
     params.push('filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer');
   }
   if (subcategory) {
     params.push(`subcategory=${subcategory}`);
   }
-
   if (ndcs && !ndcs.loading) {
     dispatch(fetchNDCSInit());
     fetch(`/api/v1/ndcs${params.length ? `?${params.join('&')}` : ''}`)
+      .then(response => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then(data => indcTransform(data))
+      .then(data => {
+        dispatch(fetchNDCSReady(data));
+      })
+      .catch(error => {
+        console.warn(error);
+        dispatch(fetchNDCSFail());
+      });
+  }
+
+  // Used for indicators like ndce_ghg (emissions) that are needed but not included on category filtered calls
+  if (
+    additionalIndicatorSlug &&
+    ndcs &&
+    (!ndcs.data.indicators ||
+      !Object.values(ndcs.data.indicators).find(
+        i => i.slug === additionalIndicatorSlug
+      ))
+  ) {
+    dispatch(fetchNDCSInit());
+    fetch(
+      `/api/v1/ndcs?indicators=${additionalIndicatorSlug}${
+        overrideFilter
+          ? ''
+          : '&filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
+      }`
+    )
       .then(response => {
         if (response.ok) return response.json();
         throw Error(response.statusText);

--- a/app/javascript/app/pages/ndcs/ndcs-reducers.js
+++ b/app/javascript/app/pages/ndcs/ndcs-reducers.js
@@ -1,3 +1,5 @@
+import uniqBy from 'lodash/uniqBy';
+
 export const initialState = {
   loading: false,
   loaded: false,
@@ -12,18 +14,30 @@ const setLoaded = (state, loaded) => ({ ...state, loaded });
 export default {
   fetchNDCSInit: state => setLoading(state, true),
   fetchNDCSReady: (state, { payload }) =>
-    setLoaded(
-      setLoading(
-        {
-          ...state,
-          data: {
-            ...state.data,
-            ...payload
-          }
-        },
-        false
-      ),
-      true
-    ),
+    (!state.data || !payload
+      ? null
+      : setLoaded(
+        setLoading(
+          {
+            ...state,
+            data: {
+              categories: {
+                ...state.data.categories,
+                ...payload.categories
+              },
+              sectors: {
+                ...state.data.sectors,
+                ...payload.sectors
+              },
+              indicators: uniqBy(
+                (state.data.indicators || []).concat(payload.indicators),
+                'id'
+              )
+            }
+          },
+          false
+        ),
+        true
+      )),
   fetchNDCSFail: state => setError(state, true)
 };


### PR DESCRIPTION
On NDC explore page we used to fetch all NDC data and now we filter by category.

- The default category is hardcoded in data/constants 
- The NDC store now doesn't delete data only stores new unique indicators by id
- This functionality is not copied to LTS as we don't have much data on the initial fetch
- A cache needs to be implemented to avoid double calls and requesting again the same data (We have a task on PT for this)
- An extra call to pick the emissions indicator is made with the prop additionalIndicatorSlug
- There are some categories that still have 2+ MB so the call is still slow

![image](https://user-images.githubusercontent.com/9701591/86762477-f7736500-c046-11ea-9609-c2f1388b50e7.png)

Extra: Update footer sitemap

![image](https://user-images.githubusercontent.com/9701591/86763268-808a9c00-c047-11ea-81df-b4b5a938a981.png)

