### PR TITLE
Add modal to CSV download

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -22,6 +22,7 @@ import Table from 'components/table';
 import GhgMultiselectDropdown from 'components/ghg-multiselect-dropdown';
 import ghgTableTheme from 'styles/themes/table/ghg-table-theme.scss';
 import ModalPngDownload from 'components/modal-png-download';
+import ModalDownload from 'components/modal-download';
 import { TabletPortraitOnly, TabletLandscape } from 'components/responsive';
 import { toPlural } from 'utils/ghg-emissions';
 import { format } from 'd3-format';
@@ -90,7 +91,7 @@ function GhgEmissions(props) {
     providerFilters,
     dataZoomData,
     handlePngDownloadModal,
-    handleDownloadDataClick,
+    handleDownloadModalOpen,
     handleInfoClick,
     setColumnWidth,
     downloadLink,
@@ -113,7 +114,7 @@ function GhgEmissions(props) {
     {
       type: 'downloadCSV',
       tooltipText: 'Download data in csv',
-      onClick: handleDownloadDataClick
+      onClick: handleDownloadModalOpen
     },
     {
       type: 'addToUser'
@@ -130,7 +131,7 @@ function GhgEmissions(props) {
       options: [
         {
           label: 'Download current data (CSV)',
-          action: handleDownloadDataClick
+          action: handleDownloadModalOpen
         },
         {
           label: 'Save as image (PNG)',
@@ -414,6 +415,7 @@ function GhgEmissions(props) {
       </ModalPngDownload>
       <ModalShare analyticsName={'GHG Emissions'} />
       <ModalMetadata />
+      <ModalDownload />
     </div>
   );
 }
@@ -433,7 +435,7 @@ GhgEmissions.propTypes = {
   legendSelected: PropTypes.array,
   handleChange: PropTypes.func.isRequired,
   handleInfoClick: PropTypes.func.isRequired,
-  handleDownloadDataClick: PropTypes.func.isRequired,
+  handleDownloadModalOpen: PropTypes.func.isRequired,
   handlePngDownloadModal: PropTypes.func.isRequired,
   setYears: PropTypes.func.isRequired,
   setColumnWidth: PropTypes.func.isRequired,

--- a/app/javascript/app/components/modal-download/modal-download-actions.js
+++ b/app/javascript/app/components/modal-download/modal-download-actions.js
@@ -5,6 +5,7 @@ import {
   setStorageWithExpiration,
   getStorageWithExpiration
 } from 'utils/localStorage';
+import { invokeCSVDownload } from 'utils/csv';
 
 const USER_SURVEY_SPREADSHEET_URL = process.env.USER_SURVEY_SPREADSHEET_URL;
 
@@ -20,18 +21,27 @@ const saveSurveyData = createThunkAction(
       if (!getStorageWithExpiration('userSurvey')) {
         setStorageWithExpiration('userSurvey', true, 5);
       }
-      fetch(
-        `${USER_SURVEY_SPREADSHEET_URL}?${requestParams.join('&')}`
-      ).then(() => {
-        window.location.assign(modalDownload.downloadUrl);
-        handleAnalytics(
-          'Data Explorer',
-          'Download Data',
-          getUrlSection(modalDownload.downloadUrl)
+
+      if (modalDownload.CSVContent) {
+        invokeCSVDownload(modalDownload.CSVContent);
+        return dispatch(
+          setModalDownloadParams({ open: false, CSVContent: null })
         );
-        return dispatch(toggleModalDownload({ open: false }));
-      });
+      }
+
+      fetch(`${USER_SURVEY_SPREADSHEET_URL}?${requestParams.join('&')}`).then(
+        () => {
+          window.location.assign(modalDownload.downloadUrl);
+          handleAnalytics(
+            'Data Explorer',
+            'Download Data',
+            getUrlSection(modalDownload.downloadUrl)
+          );
+          return dispatch(toggleModalDownload({ open: false }));
+        }
+      );
     }
+    return undefined;
   }
 );
 

--- a/app/javascript/app/components/modal-download/modal-download-component.jsx
+++ b/app/javascript/app/components/modal-download/modal-download-component.jsx
@@ -106,7 +106,7 @@ class ModalDownload extends PureComponent {
             }
             value={this.state.country}
             hideResetButton
-            optional
+            required={requiredError}
           />
 
           <TextInput
@@ -128,7 +128,7 @@ class ModalDownload extends PureComponent {
             }
             value={this.state.sector}
             hideResetButton
-            optional
+            required={requiredError}
           />
 
           <TextInput

--- a/app/javascript/app/components/modal-download/modal-download-reducers.js
+++ b/app/javascript/app/components/modal-download/modal-download-reducers.js
@@ -2,14 +2,16 @@ export const initialState = {
   isOpen: false,
   requiredError: false,
   downloadUrl: '',
-  downloadSize: ''
+  downloadSize: '',
+  CSVContent: null
 };
 
 const setModalDownloadParams = (state, { payload }) => ({
   ...state,
   isOpen: payload.open,
   downloadUrl: payload.downloadUrl,
-  downloadSize: payload.size
+  downloadSize: payload.size,
+  CSVContent: payload.CSVContent
 });
 
 const setRequiredFieldsError = (state, { payload }) => {
@@ -25,7 +27,8 @@ const setRequiredFieldsError = (state, { payload }) => {
 
 const toggleModalDownload = (state, { payload }) => ({
   ...state,
-  isOpen: payload.open
+  isOpen: payload.open,
+  CSVContent: null // Delete CSV content if its not downloaded
 });
 
 export default {


### PR DESCRIPTION
This PR adds the survey modal for the CSV download option on the GHG emissions page
This modal shows only if we haven't already sent the survey
As the modal is an independent component I had to include the encoded CSV on the store temporarily for the download but is deleted if the user downloads or closes the modal.

![image](https://user-images.githubusercontent.com/9701591/87010309-a8ecd480-c1c6-11ea-8d6d-44b7e6021e68.png)
