### PR TITLE
Fix/map categories

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -16,7 +16,10 @@ import {
   getLabels
 } from 'components/ndcs/shared/utils';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
-import { DEFAULT_CATEGORY_SLUG } from 'data/constants';
+import {
+  DEFAULT_NDC_EXPLORE_CATEGORY_SLUG,
+  CATEGORY_SOURCES
+} from 'data/constants';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -28,7 +31,12 @@ const getCategoriesData = createSelector(
     if (!categories) return null;
     const mapCategories = {};
     Object.keys(categories).forEach(key => {
-      if (categories[key].type === 'map') {
+      const category = categories[key];
+      if (
+        category.type === 'map' &&
+        category.sources.length &&
+        category.sources.every(s => CATEGORY_SOURCES.NDC_EXPLORE.includes(s))
+      ) {
         mapCategories[key] = categories[key];
       }
     });
@@ -96,7 +104,7 @@ export const getSelectedCategory = createSelector(
   (selected, categories = []) => {
     if (!categories || !categories.length) return null;
     const defaultCategory =
-      categories.find(cat => cat.value === DEFAULT_CATEGORY_SLUG) ||
+      categories.find(cat => cat.value === DEFAULT_NDC_EXPLORE_CATEGORY_SLUG) ||
       categories[0];
     if (selected) {
       return (

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -22,7 +22,20 @@ const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
-const getCategoriesData = state => state.categories || null;
+const getCategoriesData = createSelector(
+  state => state.categories,
+  categories => {
+    if (!categories) return null;
+    const mapCategories = {};
+    Object.keys(categories).forEach(key => {
+      if (categories[key].type === 'map') {
+        mapCategories[key] = categories[key];
+      }
+    });
+    return mapCategories;
+  }
+);
+
 const getIndicatorsData = state => state.indicators || null;
 const getCountriesDocumentsData = state =>
   state.countriesDocuments.data || null;

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -8,7 +8,7 @@ import { isCountryIncluded } from 'app/utils';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { IGNORED_COUNTRIES_ISOS } from 'data/ignored-countries';
 import { getHoverIndex } from 'components/ndcs/shared/utils';
-import { DEFAULT_CATEGORY_SLUG } from 'data/constants';
+import { DEFAULT_NDC_EXPLORE_CATEGORY_SLUG } from 'data/constants';
 import fetchActions from 'pages/ndcs/ndcs-actions';
 import { actions as modalActions } from 'components/modal-metadata';
 import exploreMapActions from 'components/ndcs/shared/explore-map/explore-map-actions';
@@ -79,7 +79,8 @@ class NDCSExploreMapContainer extends PureComponent {
     const { location } = this.props;
     const search = qs.parse(location.search);
     this.props.fetchNDCS({
-      subcategory: (search && search.category) || DEFAULT_CATEGORY_SLUG,
+      subcategory:
+        (search && search.category) || DEFAULT_NDC_EXPLORE_CATEGORY_SLUG,
       additionalIndicatorSlug: 'ndce_ghg'
     });
   }

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table.js
@@ -28,7 +28,6 @@ const mapStateToProps = (state, { location }) => {
     search,
     categorySelected: search.category,
     indicatorSelected: search.indicator,
-    categories: data.categories,
     emissions: state.emissions
   };
   return {

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -10,11 +10,29 @@ import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import worldPaths from 'app/data/world-50m-paths';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 
+import { CATEGORY_SOURCES } from 'data/constants';
 import { COUNTRY_STYLES } from 'components/ndcs/shared/constants';
 
 const getSearch = state => state.search || null;
 const getCountries = state => state.countries || null;
-const getCategoriesData = state => state.categories || null;
+const getCategoriesData = createSelector(
+  state => state.categories,
+  categories => {
+    if (!categories) return null;
+    const mapCategories = {};
+    Object.keys(categories).forEach(key => {
+      const category = categories[key];
+      if (
+        category.type === 'map' &&
+        category.sources.length &&
+        category.sources.every(s => CATEGORY_SOURCES.NDC_CONTENT.includes(s))
+      ) {
+        mapCategories[key] = categories[key];
+      }
+    });
+    return mapCategories;
+  }
+);
 const getIndicatorsData = state => state.indicators || null;
 
 export const getISOCountries = createSelector([getCountries], countries =>

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -356,4 +356,9 @@ export const AGRICULTURE_INDICATORS_MAP_BUCKETS = {
   }
 };
 
-export const DEFAULT_CATEGORY_SLUG = 'unfccc_process';
+export const DEFAULT_NDC_EXPLORE_CATEGORY_SLUG = 'unfccc_process';
+
+export const CATEGORY_SOURCES = {
+  NDC_EXPLORE: ['CAIT', 'WB', 'NDC Explorer'],
+  NDC_CONTENT: ['CAIT', 'WB', 'NDC Explorer']
+};


### PR DESCRIPTION
This PR fixes the problem with storing all the NDC data on the store without deleting it. 
Now we filter the categories that we want to display on NDC Explore and NDC content. By doing this the flow is much clearer. 
We might want to include at some point the LTS data into the NDC storage because is actually just another source.

Try: Go to overview => go to NDC Explore or NDC content => It should show only the correct categories

Note: We seem to be displaying 'NDC Explore' source categories on the NDC content. Not sure if this is a bug. It can be solved easily now.