### PR TITLE
Fix/remove not applicable

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -220,20 +220,24 @@ export const getLegend = createSelector(
       ...indicator.legendBuckets[id],
       id
     }));
-    const legendItems = bucketsWithId.map(label => {
+    const legendItems = [];
+    bucketsWithId.forEach(label => {
       let partiesNumber = Object.values(indicator.locations).filter(
         l => l.label_id === parseInt(label.id, 10)
       ).length;
       if (label.name === NOT_APPLICABLE_LABEL) {
         partiesNumber =
           maximumCountries - Object.values(indicator.locations).length;
+        if (partiesNumber === 0) {
+          return;
+        }
       }
-      return {
+      legendItems.push({
         ...label,
         value: percentage(partiesNumber, maximumCountries),
         partiesNumber,
         color: getColorByIndex(indicator.legendBuckets, label.index)
-      };
+      });
     });
     return legendItems.sort(sortByIndexAndNotInfo);
   }

--- a/app/javascript/app/data/ignored-countries.js
+++ b/app/javascript/app/data/ignored-countries.js
@@ -1,2 +1,2 @@
 // We won't show Taiwan and Western Sahara as an independent country
-export const IGNORED_COUNTRIES_ISOS = ['TWN', 'ESH'];
+export const IGNORED_COUNTRIES_ISOS = ['TWN', 'ESH', 'GRL'];


### PR DESCRIPTION
This PR hides the 'Not applicable' legend item for indicators that don't have it. The remaining percentage of the emissions donut will be shown as black as it doesn't have a legend item nor is represented on the map

Also, add Greenland to the list of non-hoverable countries

![image](https://user-images.githubusercontent.com/9701591/87064653-4f10fc80-c210-11ea-800a-64ee1a5a241c.png)

![image](https://user-images.githubusercontent.com/9701591/87064612-415b7700-c210-11ea-8d68-d23725278547.png)
