### PR TITLE
Add a wider border to split laws

### DIFF
--- a/app/javascript/app/styles/themes/table/compare-table-theme.scss
+++ b/app/javascript/app/styles/themes/table/compare-table-theme.scss
@@ -10,6 +10,11 @@
     border-bottom: none !important;
     text-decoration: underline !important;
   }
+
+  // Split laws from the rest
+  &:nth-child(8) {
+    border-left: 3px solid $gray2;
+  }
 }
 
 .headerRow {


### PR DESCRIPTION
This tiny PR adds a wider line to visually split the laws from the rest of columns on compare all page

![image](https://user-images.githubusercontent.com/9701591/87141296-2554e580-c2a3-11ea-8bab-bb72ffd1f018.png)
