### PR TITLE
Feature/ndcs cache

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -157,8 +157,11 @@ export const getSelectedIndicator = createSelector(
   [state => state.indicatorSelected, getCategoryIndicators],
   (selected, indicators = []) => {
     if (!indicators || !indicators.length) return {};
-    const defaultSelection =
-      indicators.find(i => i.value === 'submission') || indicators[0];
+    let defaultSelection = indicators.find(i => i.value === 'submission');
+    if (!defaultSelection) {
+      const firstParentIndicator = indicators.find(i => i.groupParent);
+      defaultSelection = firstParentIndicator || indicators[0];
+    }
     return selected
       ? indicators.find(indicator => indicator.value === selected) ||
           defaultSelection

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -60,7 +60,7 @@ export const commitmentsData = [
   {
     title: 'Other climate commitments',
     description:
-      'Aside from commitments made through NDCs and LTS, some Parties also have net-zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these commitments are not official submissions to the Paris Agreement, they indicate Parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
+      'Aside from commitments made through NDCs and LTS, some Parties also have net zero emission targets. Many have also enacted national climate policies and laws, which incorporate either economy-wide and/or sectoral targets. While these commitments are not official submissions to the Paris Agreement, they indicate Parties’ commitment to climate action and may align with commitments under the Paris Agreement.',
     hint:
       'See how many Parties have submitted additional commitments and explore the details by clicking on each box.',
     color: '#2EC9DF',

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -49,8 +49,7 @@ export const commitmentsData = [
         answerLabel: 'Intends to Enhance Ambition or Action in 2020 NDC'
       },
       {
-        questionText:
-          'How many Parties have submitted an updated or second NDC?',
+        questionText: 'How many Parties submitted an updated or second NDC?',
         link: '/2020-ndc-tracker',
         slug: 'ndce_status_2020',
         metadataSlug: 'ndc_cw',

--- a/app/javascript/app/pages/lts-explore/lts-explore-actions.js
+++ b/app/javascript/app/pages/lts-explore/lts-explore-actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
+import { apiWithCache } from 'services/api';
 
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
@@ -17,9 +18,10 @@ const fetchLTS = createThunkAction('fetchLTS', () => (dispatch, state) => {
     !LTS.loading
   ) {
     dispatch(fetchLTSInit());
-    fetch('/api/v1/lts?source=LTS&filter=map')
+    apiWithCache
+      .get('/api/v1/lts?source=LTS&filter=map')
       .then(response => {
-        if (response.ok) return response.json();
+        if (response.data) return response.data;
         throw Error(response.statusText);
       })
       .then(data => indcTransform(data))

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Button from 'components/button';
 import Header from 'components/header';
 import Intro from 'components/intro';
+import ButtonGroup from 'components/button-group';
 import Icon from 'components/icon';
 import cx from 'classnames';
 import layout from 'styles/layout.scss';
@@ -16,6 +17,7 @@ import { NCS_COMPARE_ALL } from 'data/SEO';
 import { MetaDescription, SocialMetadata } from 'components/seo';
 import NdcCompareAllTargetsProvider from 'providers/ndc-compare-all-targets-provider';
 import CountriesDocumentsProvider from 'providers/countries-documents-provider';
+import ModalMetadata from 'components/modal-metadata';
 
 import CompareAllTable from './ndc-compare-all-targets-table/ndc-compare-all-targets-table';
 import styles from './ndc-compare-all-targets-styles.scss';
@@ -59,7 +61,8 @@ const NDCCompareAllTargets = props => {
     setColumnWidth,
     handleTargetsChange,
     selectedTargets,
-    selectedTableTargets
+    selectedTableTargets,
+    handleInfoClick
   } = props;
   return (
     <React.Fragment>
@@ -91,6 +94,15 @@ const NDCCompareAllTargets = props => {
           <div className={styles.legendAndActions}>
             {renderLegend()}
             <div className={styles.buttonAndSearch}>
+              <ButtonGroup
+                className={styles.colEnd}
+                buttonsConfig={[
+                  {
+                    type: 'info',
+                    onClick: handleInfoClick
+                  }
+                ]}
+              />
               <Button
                 variant="secondary"
                 className={styles.actionButton}
@@ -133,6 +145,7 @@ const NDCCompareAllTargets = props => {
       </div>
       <NdcCompareAllTargetsProvider />
       <CountriesDocumentsProvider />
+      <ModalMetadata />
     </React.Fragment>
   );
 };
@@ -143,6 +156,7 @@ NDCCompareAllTargets.propTypes = {
   tableData: PropTypes.array,
   query: PropTypes.string,
   handleSearchChange: PropTypes.func.isRequired,
+  handleInfoClick: PropTypes.func.isRequired,
   handleTargetsChange: PropTypes.func.isRequired,
   noContentMsg: PropTypes.string,
   columns: PropTypes.array,

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-styles.scss
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-styles.scss
@@ -34,7 +34,7 @@
   }
 
   @media #{$tablet-landscape} {
-    @include columns((3.5, 3.5, 5));
+    @include columns((1.5, 3, 3, 4.5));
   }
 }
 

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
 import { setColumnWidth as setColumnWidthUtil } from 'utils/table';
+import { actions as modalMetadataActions } from 'components/modal-metadata';
 import NDCCompareAllComponent from './ndc-compare-all-targets-component';
 
 import {
@@ -63,6 +64,22 @@ const NDCCompareAllContainer = props => {
     });
   };
 
+  const handleInfoClick = () => {
+    // TODO: Missing pledges slug
+    props.setModalMetadata({
+      category: 'Compare all targets',
+      slugs: [
+        'ndc_cw',
+        'ndc_wb',
+        'ndc_die',
+        'ndc_lts',
+        'national_laws_politices'
+      ],
+      customTitle: 'Compare all targets',
+      open: true
+    });
+  };
+
   const noContentMsg = query ? 'No data for this search' : 'No data';
 
   return createElement(NDCCompareAllComponent, {
@@ -71,7 +88,8 @@ const NDCCompareAllContainer = props => {
     handleSearchChange,
     tableData,
     setColumnWidth,
-    handleTargetsChange
+    handleTargetsChange,
+    handleInfoClick
   });
 };
 
@@ -84,5 +102,5 @@ NDCCompareAllContainer.propTypes = {
 };
 
 export default withRouter(
-  connect(mapStateToProps, null)(NDCCompareAllContainer)
+  connect(mapStateToProps, modalMetadataActions)(NDCCompareAllContainer)
 );

--- a/app/javascript/app/pages/ndcs-enhancements/ndcs-enhancements-actions.js
+++ b/app/javascript/app/pages/ndcs-enhancements/ndcs-enhancements-actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
+import { apiWithCache } from 'services/api';
 
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
@@ -20,9 +21,10 @@ const fetchNDCSEnhancements = createThunkAction(
       !ndcsEnhancements.loading
     ) {
       dispatch(fetchNDCSEnhancementsInit());
-      fetch('/api/v1/ndcs?category=overview')
+      apiWithCache
+        .get('/api/v1/ndcs?category=overview')
         .then(response => {
-          if (response.ok) return response.json();
+          if (response.data) return response.data;
           throw Error(response.statusText);
         })
         .then(data => indcTransform(data))

--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -1,5 +1,6 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
+import { apiWithCache } from 'services/api';
 
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
@@ -29,9 +30,10 @@ const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
   }
   if (ndcs && !ndcs.loading) {
     dispatch(fetchNDCSInit());
-    fetch(`/api/v1/ndcs${params.length ? `?${params.join('&')}` : ''}`)
-      .then(response => {
-        if (response.ok) return response.json();
+    apiWithCache
+      .get(`/api/v1/ndcs${params.length ? `?${params.join('&')}` : ''}`)
+      .then(async response => {
+        if (response.data) return response.data;
         throw Error(response.statusText);
       })
       .then(data => indcTransform(data))
@@ -54,15 +56,16 @@ const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
       ))
   ) {
     dispatch(fetchNDCSInit());
-    fetch(
-      `/api/v1/ndcs?indicators=${additionalIndicatorSlug}${
-        overrideFilter
-          ? ''
-          : '&filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
-      }`
-    )
+    apiWithCache
+      .get(
+        `/api/v1/ndcs?indicators=${additionalIndicatorSlug}${
+          overrideFilter
+            ? ''
+            : '&filter=map&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
+        }`
+      )
       .then(response => {
-        if (response.ok) return response.json();
+        if (response.data) return response.data;
         throw Error(response.statusText);
       })
       .then(data => indcTransform(data))

--- a/app/javascript/app/providers/countries-documents-provider/countries-documents-provider-actions.js
+++ b/app/javascript/app/providers/countries-documents-provider/countries-documents-provider-actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
+import { apiWithCache } from 'services/api';
 
 export const fetchCountriesDocumentsInit = createAction(
   'fetchCountriesDocumentsInit'
@@ -26,9 +27,10 @@ export const fetchCountriesDocuments = createThunkAction(
         location ? `?location=${location}` : ''
       }`;
       dispatch(fetchCountriesDocumentsInit());
-      fetch(url)
+      apiWithCache
+        .get(url)
         .then(response => {
-          if (response.ok) return response.json();
+          if (response.data) return response.data;
           throw Error(response.statusText);
         })
         .then(data => {

--- a/app/javascript/app/providers/ndc-compare-all-targets-provider/ndc-compare-all-targets-provider-actions.js
+++ b/app/javascript/app/providers/ndc-compare-all-targets-provider/ndc-compare-all-targets-provider-actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import isEmpty from 'lodash/isEmpty';
+import { apiWithCache } from 'services/api';
 
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
@@ -19,9 +20,10 @@ const fetchCompareAll = createThunkAction(
       !compareAll.loading
     ) {
       dispatch(fetchCompareAllInit());
-      fetch('/api/v1/ndcs?&source[]=CAIT&source[]=LTS')
+      apiWithCache
+        .get('/api/v1/ndcs?&source[]=CAIT&source[]=LTS')
         .then(response => {
-          if (response.ok) return response.json();
+          if (response.data) return response.data;
           throw Error(response.statusText);
         })
         .then(data => indcTransform(data))

--- a/app/javascript/app/services/api.js
+++ b/app/javascript/app/services/api.js
@@ -1,4 +1,5 @@
 import isFunction from 'lodash/isFunction';
+import { setup } from 'axios-cache-adapter';
 
 const { ESP_API } = process.env;
 const { CW_API } = process.env;
@@ -73,3 +74,11 @@ const cwConfig = {
 };
 
 export const CWAPI = new API(CW_API, cwConfig);
+
+// Create `axios` instance with pre-configured `axios-cache-adapter` attached to it
+export const apiWithCache = setup({
+  cache: {
+    maxAge: 15 * 60 * 1000,
+    exclude: { query: false }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "private": true,
   "dependencies": {
     "autoprefixer": "9.8.0",
+    "axios": "^0.19.2",
+    "axios-cache-adapter": "^2.5.0",
     "babel-core": "6.25.0",
     "babel-eslint": "8.1.2",
     "babel-loader": "7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,6 +542,21 @@ aws4@^1.6.0, aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
 
+axios-cache-adapter@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/axios-cache-adapter/-/axios-cache-adapter-2.5.0.tgz#e68be61e8c1cd7f31e4e7cfcbfd0435404ae67ef"
+  integrity sha512-YcMPdMoqmSLoZx7A5YD/PdYGuX6/Y9M2tHBhaIXvXrPeGgNnbW7nb3+uArWlT53WGHLfclnu2voMmS7jGXVg6A==
+  dependencies:
+    cache-control-esm "1.0.0"
+    lodash "^4.17.11"
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
@@ -1743,6 +1758,11 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-control-esm@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cache-control-esm/-/cache-control-esm-1.0.0.tgz#417647ecf1837a5e74155f55d5a4ae32a84e2581"
+  integrity sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g==
 
 cacheable-request@^2.1.1:
   version "2.1.4"
@@ -2985,6 +3005,13 @@ date-fns@^1.27.2:
 debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -4591,6 +4618,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.10.0"
@@ -6771,6 +6805,11 @@ lodash@4.17.4:
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.4, lodash@~4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+
+lodash@^4.17.11:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lodash@~4.13.x:
   version "4.13.1"


### PR DESCRIPTION
This PR uses 'axios-cache-adapter' to create a new service on the existing api service file and use it in most of the ndcs pages.
This package stores the cache for the request so once we don't have to repeat them. 
This improvement doesn't help with the first fetch but will create a better experience after that.
Try: NDCS Explore => fetch a category go to another and back. It should load instantly.

Also, add an info button to compare all with metadata:

![image](https://user-images.githubusercontent.com/9701591/87286516-40209780-c4f9-11ea-9443-d758da26ffa3.png)
![image](https://user-images.githubusercontent.com/9701591/87286525-41ea5b00-c4f9-11ea-9acd-0d126a269c44.png)

Also, updated some text on the overview page according to feedback