### PR TITLE
Adds caching to the /api/v1/ndcs endpoint

### DIFF
--- a/app/models/indc/indicator.rb
+++ b/app/models/indc/indicator.rb
@@ -19,7 +19,7 @@ module Indc
                else
                  values
                end
-      result = result.includes(:document, :location).joins(:document, :location)
+      result = result.joins(:document, :location)
       where_clause = locations_documents.map do |loc, doc|
         "(locations.iso_code3 = '#{loc}' AND indc_documents.slug = '#{doc}')"
       end.join(' OR ')

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -31,7 +31,7 @@ module Api
                      object.labels
                    end
           IndexedSerializer.serialize(
-            object.labels,
+            labels,
             serializer: LabelSerializer,
             &:id
           )
@@ -41,7 +41,7 @@ module Api
           values = if instance_options[:locations_documents]
                      object.values_for instance_options[:locations_documents]
                    else
-                     object.values.includes(:location, :document, :label)
+                     object.values
                    end
           indexed_data = IndexedSerializer.serialize_collection(
             values,


### PR DESCRIPTION
This PR adds caching to the /api/v1/ndcs, it also removes some includes clauses that was slowing things down. So overall should be quicker!

To test the caching locally you'll need to run `bundle exec rails dev:cache` and to turn that off just use the same command again. =)