### PR TITLE
Feature/data explorer url

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -145,8 +145,8 @@ const findSelectedValueObject = (meta, selectedId) =>
     option =>
       option.iso_code === selectedId ||
       option.iso_code3 === selectedId ||
+      option.slug === selectedId ||
       option.name === selectedId ||
-      String(option.slug) === selectedId ||
       String(option.id) === selectedId
   );
 const addTopEmittersMembers = (isosArray, regions, key) => {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -77,7 +77,6 @@ const getMetaForNoModelFilters = createSelector(
 );
 
 const getSectionMeta = createSelector(
-  // HERE WE HAVE FILTERS!!!
   [getMeta, getRegions, getCountries, getSection, getMetaForNoModelFilters],
   (meta, regions, countries, section, noModelFiltersMeta) => {
     if (!meta || !meta[section] || !regions || !countries || !section) {

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -525,6 +525,7 @@ export const parseExternalParams = createSelector(
       } else if (metaMatchingKey !== 'undefined') {
         if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const ids = externalFields[k].split(',');
+        console.log('ids: ',ids, ' sectionMeta[metaMatchingKey]: ',sectionMeta[metaMatchingKey])
         const filterObjects = sectionMeta[metaMatchingKey].filter(
           i =>
             ids.map(f => parseInt(f, 10)).includes(i.id) ||
@@ -533,6 +534,7 @@ export const parseExternalParams = createSelector(
             ids.includes(i.iso) ||
             ids.includes(i.slug)
         );
+        console.log('filterObjects: ',filterObjects)
 
         const selectedIds = filterObjects.map(labelObject => {
           const label = POSSIBLE_VALUE_FIELDS.find(
@@ -543,6 +545,7 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
+    console.log('parseExternalParams: ',parsedFields)
     return parsedFields;
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -577,6 +577,7 @@ export const getSelectedFilters = createSelector(
         selectedFilterObjects[filterKey] = filterId;
       } else if (isNoModelColumnKey) {
         const noModelOptions =
+          noModelFiltersMeta &&
           noModelFiltersMeta[filterKey] &&
           noModelFiltersMeta[filterKey]
             .filter(f => f.slug === filterId)

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -234,9 +234,12 @@ export const getFilterQuery = createSelector(
     const noExternalParams = !searchKeys.some(s =>
       s.startsWith(DATA_EXPLORER_EXTERNAL_PREFIX)
     );
+    console.log('filterDefaultKeys: ',filterDefaultKeys)
     const checkedDefaultParams = filterDefaultKeys.every(defaultKey =>
       parsedSearchKeys.includes(defaultKey, section)
     );
+    console.log('checkedDefaultParams: ',checkedDefaultParams)
+
     const isReadyForFetch = noExternalParams && checkedDefaultParams;
     if (!isReadyForFetch) return null;
     return filterQueryIds(sectionMeta, search, section, false);
@@ -305,6 +308,7 @@ const parseQuery = (filterQuery, section, sectionMeta, nonColumnQuery) => {
       if (id) parsedQuery[parsedKey] = id;
     });
   }
+  console.log('parsedQuery: ',parsedQuery)
   return parsedQuery;
 };
 
@@ -324,6 +328,9 @@ export const getLink = createSelector(
       DATA_EXPLORER_SECTIONS[section].linkName ||
       DATA_EXPLORER_SECTIONS[section].moduleName;
     const subSection = moduleName === 'pathways' ? '/models' : '';
+    console.log(`/${
+      isPageContained ? `${CONTAINED_PATHNAME}/` : ''
+    }${moduleName}${subSection}${urlParameters}`)
     return `/${
       isPageContained ? `${CONTAINED_PATHNAME}/` : ''
     }${moduleName}${subSection}${urlParameters}`;
@@ -562,7 +569,7 @@ export const parseExternalParams = createSelector(
 
 const findFilterOptions = (options, selectedFilters) =>
   // console.log('options:', options, ' selectedFilters:', selectedFilters);
-  options.filter(f =>
+  options && options.filter(f =>
     POSSIBLE_VALUE_FIELDS.find(field => {
       const value = f[field] && String(f[field]);
       return selectedFilters.includes(value);
@@ -584,9 +591,10 @@ export const getSelectedFilters = createSelector(
       sectionRelatedFields,
       section
     );
-
+    console.log('[getSelectedFilters()]:parsedSelectedFilters:',parsedSelectedFilters)
     const selectedFilterObjects = {};
     Object.keys(parsedSelectedFilters).forEach(filterKey => {
+      
       const filterId = parsedSelectedFilters[filterKey];
       const isNoModelColumnKey = isNoColumnField(section, filterKey);
       if (isNonColumnKey(filterKey) || isNoModelColumnKey) {
@@ -601,7 +609,7 @@ export const getSelectedFilters = createSelector(
         );
       }
     });
-    // console.log('selectedFilterObjects: ', selectedFilterObjects);
+    console.log('[getSelectedFilters()]:selectedFilterObjects: ', selectedFilterObjects);
     return selectedFilterObjects;
   }
 );
@@ -795,7 +803,7 @@ export const getSelectedOptions = createSelector(
         }));
       }
     });
-    // console.log('selectedOptions: ',selectedOptions)
+    console.log('selectedOptions: ',selectedOptions)
 
     return selectedOptions;
   }

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -525,16 +525,14 @@ export const parseExternalParams = createSelector(
       } else if (metaMatchingKey !== 'undefined') {
         if (metaMatchingKey === 'subcategories') metaMatchingKey = 'categories';
         const ids = externalFields[k].split(',');
-        console.log('ids: ',ids, ' sectionMeta[metaMatchingKey]: ',sectionMeta[metaMatchingKey])
         const filterObjects = sectionMeta[metaMatchingKey].filter(
           i =>
             ids.map(f => parseInt(f, 10)).includes(i.id) ||
             ids.includes(i.number) ||
             ids.includes(i.iso_code3) ||
             ids.includes(i.iso) ||
-            ids.includes(i.slug)
+            ids.map(f => f.toLowerCase()).includes(i.slug)
         );
-        console.log('filterObjects: ',filterObjects)
 
         const selectedIds = filterObjects.map(labelObject => {
           const label = POSSIBLE_VALUE_FIELDS.find(
@@ -545,7 +543,6 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
-    console.log('parseExternalParams: ',parsedFields)
     return parsedFields;
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -262,6 +262,7 @@ const getParsedFilterId = (
       findEqual(m, ['id', currentId], filterQuery[key][0])
     )[idLabel]
     : filterQuery[key];
+
   return isArray(id) ? id.join(',') : id;
 };
 
@@ -299,12 +300,26 @@ export const getLink = createSelector(
   [getLinkFilterQuery, getNonColumnQuery, getSection, getSectionMeta],
   (filterQuery, nonColumnQuery, section, sectionMeta) => {
     if (!section) return null;
-    const parsedQuery = parseQuery(
-      filterQuery,
-      section,
-      sectionMeta,
-      nonColumnQuery
-    );
+
+    const slugSections = ['lts-content', 'ndc-content'];
+    let query = filterQuery;
+    if (slugSections.includes(section)) {
+      const slugQuery =
+        filterQuery &&
+        Object.keys(filterQuery).reduce((acc, nextFilter) => {
+          const selectedFilter = sectionMeta[nextFilter]
+            ? sectionMeta[nextFilter].find(
+              ({ id }) => id === filterQuery[nextFilter][0]
+            )
+            : null;
+          return {
+            ...acc,
+            [nextFilter]: selectedFilter ? [selectedFilter.slug] : []
+          };
+        }, {});
+      query = slugQuery;
+    }
+    const parsedQuery = parseQuery(query, section, sectionMeta, nonColumnQuery);
     const stringifiedQuery = qs.stringify(parsedQuery);
     const urlParameters = stringifiedQuery ? `?${stringifiedQuery}` : '';
     const moduleName =
@@ -312,9 +327,10 @@ export const getLink = createSelector(
       DATA_EXPLORER_SECTIONS[section].moduleName;
     const subSection = moduleName === 'pathways' ? '/models' : '';
 
-    return `/${
+    const link = `/${
       isPageContained ? `${CONTAINED_PATHNAME}/` : ''
     }${moduleName}${subSection}${urlParameters}`;
+    return link;
   }
 );
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -205,6 +205,7 @@ function filterQueryIds(sectionMeta, search, section, isLinkQuery) {
     sectionMeta,
     isLinkQuery
   );
+
   return filterIds;
 }
 
@@ -296,29 +297,46 @@ const parseQuery = (filterQuery, section, sectionMeta, nonColumnQuery) => {
   return parsedQuery;
 };
 
+const parseSlugParams = (filterQuery, section, sectionMeta) => {
+  const SLUG_SECTIONS = ['historical-emissions', 'lts-content', 'ndc-content'];
+  if (SLUG_SECTIONS.includes(section)) {
+    const slugFilterQuery =
+      filterQuery &&
+      Object.keys(filterQuery).reduce((acc, nextFilter) => {
+        const selectedFilters = sectionMeta[nextFilter]
+          ? sectionMeta[nextFilter].filter(f => {
+            const isoCode = f.iso || f.iso_code3 || f.id;
+            return filterQuery[nextFilter].includes(isoCode);
+          })
+          : [];
+
+        const selectedSlugs = selectedFilters
+          .map(({ slug, iso, iso_code3 }) => {
+            if (
+              section === 'historical-emissions' &&
+              nextFilter === 'data_sources'
+            ) {
+              return slug.toUpperCase();
+            }
+            return slug || iso || iso_code3;
+          })
+          .join(',');
+
+        return {
+          ...acc,
+          [nextFilter]: selectedSlugs
+        };
+      }, {});
+    return slugFilterQuery;
+  }
+  return filterQuery;
+};
+
 export const getLink = createSelector(
   [getLinkFilterQuery, getNonColumnQuery, getSection, getSectionMeta],
   (filterQuery, nonColumnQuery, section, sectionMeta) => {
     if (!section) return null;
-
-    const slugSections = ['lts-content', 'ndc-content'];
-    let query = filterQuery;
-    if (slugSections.includes(section)) {
-      const slugQuery =
-        filterQuery &&
-        Object.keys(filterQuery).reduce((acc, nextFilter) => {
-          const selectedFilter = sectionMeta[nextFilter]
-            ? sectionMeta[nextFilter].find(
-              ({ id }) => id === filterQuery[nextFilter][0]
-            )
-            : null;
-          return {
-            ...acc,
-            [nextFilter]: selectedFilter ? [selectedFilter.slug] : []
-          };
-        }, {});
-      query = slugQuery;
-    }
+    const query = parseSlugParams(filterQuery, section, sectionMeta);
     const parsedQuery = parseQuery(query, section, sectionMeta, nonColumnQuery);
     const stringifiedQuery = qs.stringify(parsedQuery);
     const urlParameters = stringifiedQuery ? `?${stringifiedQuery}` : '';

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -1,15 +1,18 @@
 import { createSelector } from 'reselect';
-import remove from 'lodash/remove';
-import isEmpty from 'lodash/isEmpty';
-import isArray from 'lodash/isArray';
-import pick from 'lodash/pick';
-import flatten from 'lodash/flatten';
+import {
+  remove,
+  isEmpty,
+  isArray,
+  pick,
+  flatten,
+  kebabCase,
+  sortBy
+} from 'lodash';
 import qs from 'query-string';
 import { findEqual, isANumber, noEmptyValues } from 'utils/utils';
 import { isNoColumnField, isNonColumnKey } from 'utils/data-explorer';
 import { isPageContained } from 'utils/navigation';
 
-import sortBy from 'lodash/sortBy';
 import {
   DATA_EXPLORER_BLACKLIST,
   DATA_EXPLORER_METHODOLOGY_SOURCE,
@@ -65,20 +68,24 @@ const getMetaForNoModelFilters = createSelector(
     sectionFilters.forEach(field => {
       noModelFiltersMeta[field] = dataSection.meta[field].map(v => ({
         id: v,
-        title: v
+        title: v,
+        slug: kebabCase(v)
       }));
     });
+    // console.log('noModelFiltersMeta:', noModelFiltersMeta);
     return noModelFiltersMeta;
   }
 );
 
 const getSectionMeta = createSelector(
+  // HERE WE HAVE FILTERS!!!
   [getMeta, getRegions, getCountries, getSection, getMetaForNoModelFilters],
   (meta, regions, countries, section, noModelFiltersMeta) => {
     if (!meta || !meta[section] || !regions || !countries || !section) {
       return null;
     }
     const sectionMeta = { ...meta[section], ...noModelFiltersMeta };
+
     if (DATA_EXPLORER_FILTERS[section].includes('regions')) {
       return { ...sectionMeta, regions, countries };
     } else if (DATA_EXPLORER_FILTERS[section].includes('countries')) {
@@ -117,6 +124,12 @@ export const getSourceOptions = createSelector(
     ) {
       return null;
     }
+    // console.log('getSourceOptions()',sectionMeta.data_sources.map(option => {
+    //   const updatedOption = option;
+    //   updatedOption.dataSourceId = option.id;
+    //   updatedOption.name = option.display_name;
+    //   return updatedOption;
+    // }));
     return sectionMeta.data_sources.map(option => {
       const updatedOption = option;
       updatedOption.dataSourceId = option.id;
@@ -136,13 +149,16 @@ const removeFiltersPrefix = (selectedFields, prefix) => {
 };
 
 const findSelectedValueObject = (meta, selectedId) =>
+  // console.log('meta: ', meta, ' selectedId: ', selectedId);
   meta.find(
     option =>
       option.iso_code === selectedId ||
       option.iso_code3 === selectedId ||
       option.name === selectedId ||
+      String(option.slug) === selectedId ||
       String(option.id) === selectedId
-  );
+  )
+;
 
 const addTopEmittersMembers = (isosArray, regions, key) => {
   if (key === FILTER_NAMES.regions && isosArray.includes('TOP')) {
@@ -172,7 +188,7 @@ function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
       metadata.regions,
       key
     );
-
+    // console.log('selectedIds: ', selectedIds);
     const filters = [];
     if (metadataWithSubcategories[parsedKey]) {
       selectedIds.forEach(selectedId => {
@@ -183,6 +199,8 @@ function extractFilterIds(parsedFilters, metadata, isLinkQuery = false) {
         if (foundSelectedOption) filters.push(foundSelectedOption);
       });
     }
+    // console.log('filters: ', filters);
+
     if (filters && filters.length > 0) {
       filterIds[parsedKey] = filters.map(
         f => f.id || f.iso_code || f.iso_code3
@@ -447,6 +465,7 @@ export const getFilterOptions = createSelector(
         filterOptions[f] = optionsArray;
       }
     });
+    // console.log('filterOptions: ', filterOptions);
     return filterOptions;
   }
 );
@@ -490,6 +509,7 @@ const parseGroupsInOptions = createSelector(
         updatedOptions[key] = parseMultipleLevelOptions(updatedOptions[key]);
       }
     });
+
     return updatedOptions;
   }
 );
@@ -535,17 +555,20 @@ export const parseExternalParams = createSelector(
         parsedFields[keyWithoutPrefix] = selectedIds.join(',');
       }
     });
+    // console.log('parsedFields: ', parsedFields);
     return parsedFields;
   }
 );
 
 const findFilterOptions = (options, selectedFilters) =>
+  // console.log('options:', options, ' selectedFilters:', selectedFilters);
   options.filter(f =>
     POSSIBLE_VALUE_FIELDS.find(field => {
       const value = f[field] && String(f[field]);
       return selectedFilters.includes(value);
     })
-  );
+  )
+;
 
 export const getSelectedFilters = createSelector(
   [getSearch, getSection, getFilterOptions],
@@ -578,7 +601,7 @@ export const getSelectedFilters = createSelector(
         );
       }
     });
-
+    // console.log('selectedFilterObjects: ', selectedFilterObjects);
     return selectedFilterObjects;
   }
 );
@@ -772,6 +795,7 @@ export const getSelectedOptions = createSelector(
         }));
       }
     });
+    // console.log('selectedOptions: ',selectedOptions)
 
     return selectedOptions;
   }
@@ -811,6 +835,10 @@ const getYearColumnKeys = createSelector(
   [parseData, getSection],
   (data, section) => {
     if (!data || !data.length || !section) return null;
+    // console.log(
+    //   'Object.keys(data[0]).filter(k => isANumber(k)): ',
+    //   Object.keys(data[0]).filter(k => isANumber(k))
+    // );
     return Object.keys(data[0]).filter(k => isANumber(k));
   }
 );

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -381,6 +381,7 @@ const getValue = option =>
   option.iso ||
   option.iso_code ||
   option.iso_code3 ||
+  option.slug ||
   (option.id && String(option.id)) ||
   (option.dataSourceId && String(option.dataSourceId));
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,7 +47,7 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
-    // console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
+    console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
     // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
@@ -56,7 +56,7 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          // console.log('selected: ', selected);
+          console.log('selected: ', selected);
           handleFiltersChange({
             [field]: (selected && selected.slug) || selected.value
           });

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,8 +47,6 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
-    console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
-    // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
         key={label}
@@ -56,7 +54,6 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          console.log('selected: ', selected);
           handleFiltersChange({
             [field]: (selected && selected.slug) || selected.value
           });

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters-component.jsx
@@ -47,6 +47,8 @@ class DataExplorerFilters extends PureComponent {
     const value = isColumnField
       ? selectedOptions && selectedOptions[field] && selectedOptions[field][0]
       : selectedOptions && selectedOptions[field];
+    // console.log('value: ', value, ' selectedOptions[field]: ', selectedOptions);
+    // console.log('options: ', getOptions(filterOptions, field));
     return (
       <Dropdown
         key={label}
@@ -54,7 +56,10 @@ class DataExplorerFilters extends PureComponent {
         placeholder={`Filter by ${deburrCapitalize(label)}`}
         options={getOptions(filterOptions, field)}
         onValueChange={selected => {
-          handleFiltersChange({ [field]: selected && selected.value });
+          // console.log('selected: ', selected);
+          handleFiltersChange({
+            [field]: (selected && selected.slug) || selected.value
+          });
           handleChangeSelectorAnalytics();
         }}
         value={value || null}
@@ -91,11 +96,11 @@ class DataExplorerFilters extends PureComponent {
             return option.length > 0 && last(option).value === ALL_SELECTED
               ? ALL_SELECTED
               : option
-                .map(o => o.value)
+                .map(o => o.slug)
                 .filter(v => v !== ALL_SELECTED)
                 .join();
           }
-          return option && option.value;
+          return option && option.slug;
         };
 
         return (

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -87,6 +87,9 @@ const getParamsToUpdate = (updatedFilters, section) => {
   const paramsToUpdate = [];
   Object.keys(updatedFilters).forEach(filterName => {
     const value = updatedFilters[filterName];
+    // console.log('updatedFilters: ', updatedFilters);
+    // console.log('filterName: ', filterName);
+
     const parsedValue = isArray(value) ? parsedMultipleValues(value) : value;
     const blankValue = NON_COLUMN_KEYS.includes(filterName) ? '' : ALL_SELECTED;
     paramsToUpdate.push({

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -123,22 +123,24 @@ class DataExplorerFiltersContainer extends PureComponent {
           defaultOptionsToUpdate[key] = FILTER_DEFAULTS[section][key];
         } else {
           const defaultValues = FILTER_DEFAULTS[section][key].split(',');
+          console.log('[updateDefaultFilters]: filterOptions[key]: ',filterOptions[key])
           const defaultOptions = filterOptions[key].filter(
             f =>
-              defaultValues.includes(f.value) || defaultValues.includes(f.label)
+              defaultValues.includes(f.slug) || defaultValues.includes(f.label)
           );
           let updatedOptions = '';
           if (
             defaultOptions &&
             defaultOptions.length &&
-            defaultOptions[0].value
+            defaultOptions[0].slug
           ) {
-            updatedOptions = defaultOptions.map(o => o.value).join(',');
+            updatedOptions = defaultOptions.map(o => o.slug).join(',');
           }
           defaultOptionsToUpdate[key] = updatedOptions;
         }
       }
     });
+    console.log('[updateDefaultFilters]: defaultOptionsToUpdate: ',defaultOptionsToUpdate)
     this.handleFiltersChange(defaultOptionsToUpdate, true);
   }
 

--- a/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-filters/data-explorer-filters.js
@@ -87,9 +87,6 @@ const getParamsToUpdate = (updatedFilters, section) => {
   const paramsToUpdate = [];
   Object.keys(updatedFilters).forEach(filterName => {
     const value = updatedFilters[filterName];
-    // console.log('updatedFilters: ', updatedFilters);
-    // console.log('filterName: ', filterName);
-
     const parsedValue = isArray(value) ? parsedMultipleValues(value) : value;
     const blankValue = NON_COLUMN_KEYS.includes(filterName) ? '' : ALL_SELECTED;
     paramsToUpdate.push({
@@ -123,7 +120,6 @@ class DataExplorerFiltersContainer extends PureComponent {
           defaultOptionsToUpdate[key] = FILTER_DEFAULTS[section][key];
         } else {
           const defaultValues = FILTER_DEFAULTS[section][key].split(',');
-          console.log('[updateDefaultFilters]: filterOptions[key]: ',filterOptions[key])
           const defaultOptions = filterOptions[key].filter(
             f =>
               defaultValues.includes(f.slug) || defaultValues.includes(f.label)
@@ -140,7 +136,6 @@ class DataExplorerFiltersContainer extends PureComponent {
         }
       }
     });
-    console.log('[updateDefaultFilters]: defaultOptionsToUpdate: ',defaultOptionsToUpdate)
     this.handleFiltersChange(defaultOptionsToUpdate, true);
   }
 

--- a/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
+++ b/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
@@ -37,8 +37,12 @@ export function getPathwaysCategoryOptions(query, filtersMeta) {
   const scenarioIndicatorsIds = filtersMeta.scenarios.find(
     sc => sc.id === selectedScenarioId
   ).indicator_ids;
+
   const categories = scenarioIndicatorsIds.map(
-    indId => filtersMeta.indicators.find(ind => ind.id === indId).category
+    indId => {
+      const category = filtersMeta.indicators.find(ind => ind.id === indId).category;
+      return filtersMeta.categories.find(({ id }) => id === category.id);
+    }
   );
   return uniqBy(categories, 'id');
 }

--- a/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
+++ b/app/javascript/app/components/data-explorer-content/pathway-selector-utils/pathway-selector-utils.js
@@ -38,12 +38,11 @@ export function getPathwaysCategoryOptions(query, filtersMeta) {
     sc => sc.id === selectedScenarioId
   ).indicator_ids;
 
-  const categories = scenarioIndicatorsIds.map(
-    indId => {
-      const category = filtersMeta.indicators.find(ind => ind.id === indId).category;
-      return filtersMeta.categories.find(({ id }) => id === category.id);
-    }
-  );
+  const categories = scenarioIndicatorsIds.map(indId => {
+    const category = filtersMeta.indicators.find(ind => ind.id === indId)
+      .category;
+    return filtersMeta.categories.find(({ id }) => id === category.id);
+  });
   return uniqBy(categories, 'id');
 }
 

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-component.jsx
@@ -91,7 +91,7 @@ class EmissionPathwayGraph extends PureComponent {
                     },
                     {
                       type: 'download',
-                      section: 'ndcs-content',
+                      section: 'emission-pathways',
                       link: downloadLink
                     },
                     {

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -209,7 +209,6 @@ export const getCategoryOptions = createSelector(
   [getIndicatorsWithData],
   indicators => {
     if (!indicators) return null;
-    // console.log('indicators: ',indicators)
     const categories = indicators
       .filter(i => i.category)
       .map(i => ({
@@ -588,9 +587,6 @@ export const getLinkToDataExplorer = createSelector(
     const section = 'emission-pathways';
     let dataExplorerSearch = search || {};
     if (!categorySelected || !allScenarios.length) return null;
-
-    dataExplorerSearch.categories = categorySelected.value || '';
-
     if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
       // Data Explorer dropdown and table in case there's no scenario selected

--- a/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
+++ b/app/javascript/app/components/emission-pathways/emission-pathways-graph/emission-pathways-graph-selectors.js
@@ -209,10 +209,13 @@ export const getCategoryOptions = createSelector(
   [getIndicatorsWithData],
   indicators => {
     if (!indicators) return null;
-    const categories = indicators.filter(i => i.category).map(i => ({
-      label: i.category.name,
-      value: i.category.id
-    }));
+    // console.log('indicators: ',indicators)
+    const categories = indicators
+      .filter(i => i.category)
+      .map(i => ({
+        label: i.category.name,
+        value: i.category.id
+      }));
     return uniqBy(categories, 'value');
   }
 );
@@ -580,23 +583,26 @@ export const getModalData = createSelector(
 );
 
 export const getLinkToDataExplorer = createSelector(
-  [getSearch, getAllScenarios],
-  (search, allScenarios) => {
+  [getSearch, getCategorySelected, getAllScenarios],
+  (search, categorySelected, allScenarios) => {
     const section = 'emission-pathways';
-    if (!allScenarios.length) return null;
+    let dataExplorerSearch = search || {};
+    if (!categorySelected || !allScenarios.length) return null;
+
+    dataExplorerSearch.categories = categorySelected.value || '';
+
     if (!search.scenario && search.model) {
       // Adds the first scenario belonging to the selected model to populate
       // Data Explorer dropdown and table in case there's no scenario selected
       const scenarioId = allScenarios.find(
         s => s.model.id === parseInt(search.model, 10)
       ).id;
-      const filtersWithScenario = {
+      dataExplorerSearch = {
         ...search,
         scenario: scenarioId
       };
-      return generateLinkToDataExplorer(filtersWithScenario, section);
     }
-    return generateLinkToDataExplorer(search, section);
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
   }
 );
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -530,14 +530,14 @@ export const getLinkToDataExplorer = createSelector(
   [getOptionsSelected],
   (/* search, */ optionsSelected) => {
     const section = 'historical-emissions';
-    let dataExplorerSearch = search || {};
-    if (selectedCategory && selectedIndicator) {
-      dataExplorerSearch = {
-        category: selectedCategory.value,
-        gases: gasesSelected.value,
-        ...search
-      };
-    }
+    // let dataExplorerSearch = search || {};
+    // if (selectedCategory && selectedIndicator) {
+    //   dataExplorerSearch = {
+    //     category: selectedCategory.value,
+    //     gases: gasesSelected.value,
+    //     ...search
+    //   };
+    // }
     return generateLinkToDataExplorer({}, section);
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -6,6 +6,7 @@ import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -524,3 +525,19 @@ export const getOptionsSelected = createStructuredSelector({
   calculationSelected: getCalculationSelected,
   chartTypeSelected: getChartTypeSelected
 });
+
+export const getLinkToDataExplorer = createSelector(
+  [getOptionsSelected],
+  (/* search, */ optionsSelected) => {
+    const section = 'historical-emissions';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        gases: gasesSelected.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer({}, section);
+  }
+);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -17,7 +17,8 @@ import {
   getMeta,
   getRegions,
   getSources,
-  getSelection
+  getSelection,
+  getSearch
 } from './ghg-emissions-selectors-get';
 
 const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
@@ -527,8 +528,8 @@ export const getOptionsSelected = createStructuredSelector({
 });
 
 export const getLinkToDataExplorer = createSelector(
-  [getOptionsSelected],
-  (/* search, */ optionsSelected) => {
+  [getSearch, getOptionsSelected],
+  (search, optionsSelected) => {
     const section = 'historical-emissions';
     // let dataExplorerSearch = search || {};
     // if (selectedCategory && selectedIndicator) {
@@ -538,6 +539,7 @@ export const getLinkToDataExplorer = createSelector(
     //     ...search
     //   };
     // }
-    return generateLinkToDataExplorer({}, section);
+    console.log('getLinkToDataExplorer: ',generateLinkToDataExplorer(search, section))
+    return generateLinkToDataExplorer(search, section);
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -6,7 +6,6 @@ import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
 import { arrayToSentence } from 'utils';
 import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
-import { generateLinkToDataExplorer } from 'utils/data-explorer';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
@@ -17,8 +16,7 @@ import {
   getMeta,
   getRegions,
   getSources,
-  getSelection,
-  getSearch
+  getSelection
 } from './ghg-emissions-selectors-get';
 
 const FEATURE_NEW_GHG = process.env.FEATURE_NEW_GHG === 'true';
@@ -290,7 +288,6 @@ const getGasOptions = createSelector([getFieldOptions('gas')], options => {
   if (!options) return [];
 
   const valueByLabel = g => (options.find(opt => opt.label === g) || {}).value;
-
   return options.map(o => ({
     ...o,
     expandsTo:
@@ -343,7 +340,6 @@ const getFiltersSelected = field =>
     [getOptions, getSelection(field), getDefaults],
     (options, selected, defaults) => {
       if (!options || !defaults) return null;
-
       const fieldOptions =
         field === 'location' ? options.regions : options[toPlural(field)];
       const defaultSelection =
@@ -526,20 +522,3 @@ export const getOptionsSelected = createStructuredSelector({
   calculationSelected: getCalculationSelected,
   chartTypeSelected: getChartTypeSelected
 });
-
-export const getLinkToDataExplorer = createSelector(
-  [getSearch, getOptionsSelected],
-  (search, optionsSelected) => {
-    const section = 'historical-emissions';
-    // let dataExplorerSearch = search || {};
-    // if (selectedCategory && selectedIndicator) {
-    //   dataExplorerSearch = {
-    //     category: selectedCategory.value,
-    //     gases: gasesSelected.value,
-    //     ...search
-    //   };
-    // }
-    console.log('getLinkToDataExplorer: ',generateLinkToDataExplorer(search, section))
-    return generateLinkToDataExplorer(search, section);
-  }
-);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { toPlural } from 'utils/ghg-emissions';
-import { generateLinkToDataExplorer } from 'utils/data-explorer';
 
 // meta data for selectors
 export const getData = state =>
@@ -30,9 +29,4 @@ export const getSelection = field =>
 export const getDataZoomYears = createSelector(getSearch, search => {
   if (!search) return null;
   return { min: search.start_year, max: search.end_year };
-});
-
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'historical-emissions';
-  return generateLinkToDataExplorer(search, section);
 });

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { toPlural } from 'utils/ghg-emissions';
-
+import { generateLinkToDataExplorer } from 'utils/data-explorer';
 // meta data for selectors
 export const getData = state =>
   (state && state.emissions && state.emissions.data) || [];
@@ -29,4 +29,9 @@ export const getSelection = field =>
 export const getDataZoomYears = createSelector(getSearch, search => {
   if (!search) return null;
   return { min: search.start_year, max: search.end_year };
+});
+
+export const getLinkToDataExplorer = createSelector([getSearch], search => {
+  const section = 'historical-emissions';
+  return generateLinkToDataExplorer(search, section);
 });

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -1,11 +1,14 @@
 import { createStructuredSelector } from 'reselect';
-import { getSearch, getDataZoomYears } from './ghg-emissions-selectors-get';
+import {
+  getSearch,
+  getDataZoomYears,
+  getLinkToDataExplorer
+} from './ghg-emissions-selectors-get';
 import {
   getOptions,
   getOptionsSelected,
   getFiltersConflicts,
-  getModelSelected,
-  getLinkToDataExplorer
+  getModelSelected
 } from './ghg-emissions-selectors-filters';
 import {
   getChartConfig,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors.js
@@ -1,14 +1,11 @@
 import { createStructuredSelector } from 'reselect';
-import {
-  getSearch,
-  getLinkToDataExplorer,
-  getDataZoomYears
-} from './ghg-emissions-selectors-get';
+import { getSearch, getDataZoomYears } from './ghg-emissions-selectors-get';
 import {
   getOptions,
   getOptionsSelected,
   getFiltersConflicts,
-  getModelSelected
+  getModelSelected,
+  getLinkToDataExplorer
 } from './ghg-emissions-selectors-filters';
 import {
   getChartConfig,

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -181,11 +181,6 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-// export const getLinkToDataExplorer = createSelector([getSearch], search => {
-//   const section = 'lts-content';
-//   return generateLinkToDataExplorer(search, section);
-// });
-
 export const getLinkToDataExplorer = createSelector(
   [getSearch, getSelectedCategory, getSelectedIndicator],
   (search, selectedCategory, selectedIndicator) => {

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -181,10 +181,26 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'lts-content';
-  return generateLinkToDataExplorer(search, section);
-});
+// export const getLinkToDataExplorer = createSelector([getSearch], search => {
+//   const section = 'lts-content';
+//   return generateLinkToDataExplorer(search, section);
+// });
+
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'lts-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 const percentage = (value, total) => (value * 100) / total;
 

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -226,10 +226,21 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'ndc-content';
-  return generateLinkToDataExplorer(search, section);
-});
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'ndc-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 const percentage = (value, total) => (value * 100) / total;
 

--- a/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-map/ndcs-map-selectors.js
@@ -170,10 +170,21 @@ export const getPathsWithStyles = createSelector(
   }
 );
 
-export const getLinkToDataExplorer = createSelector([getSearch], search => {
-  const section = 'ndc-content';
-  return generateLinkToDataExplorer(search, section);
-});
+export const getLinkToDataExplorer = createSelector(
+  [getSearch, getSelectedCategory, getSelectedIndicator],
+  (search, selectedCategory, selectedIndicator) => {
+    const section = 'ndc-content';
+    let dataExplorerSearch = search || {};
+    if (selectedCategory && selectedIndicator) {
+      dataExplorerSearch = {
+        category: selectedCategory.value,
+        indicator: selectedIndicator.value,
+        ...search
+      };
+    }
+    return generateLinkToDataExplorer(dataExplorerSearch, section);
+  }
+);
 
 export default {
   getCategories,

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -378,7 +378,13 @@ export const POSSIBLE_LABEL_FIELDS = [
   'number'
 ];
 
-export const POSSIBLE_VALUE_FIELDS = ['id', 'value', 'iso_code3', 'iso'];
+export const POSSIBLE_VALUE_FIELDS = [
+  'slug',
+  'id',
+  'value',
+  'iso_code3',
+  'iso'
+];
 
 export const FIELD_ALIAS = {
   'historical-emissions': { 'data-sources': 'Data sources' },


### PR DESCRIPTION
This PR merges the updated URL structure of the data explorer (slugs instead of ids) to develop. Changes had been approved in the [previous PR](https://github.com/Vizzuality/climate-watch/pull/1121), so here I rebased the codebase with recent develop changes.

**Test:** Please check if data-explorer filters and download links across the app works