### PR TITLE
Feature/data explorer fixes

### DIFF
--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -1,12 +1,5 @@
 import { createSelector } from 'reselect';
-import {
-  remove,
-  isEmpty,
-  isArray,
-  pick,
-  flatten,
-  sortBy
-} from 'lodash';
+import { remove, isEmpty, isArray, pick, flatten, sortBy } from 'lodash';
 import qs from 'query-string';
 import { findEqual, isANumber, noEmptyValues, useSlug } from 'utils/utils';
 import { isNoColumnField, isNonColumnKey } from 'utils/data-explorer';

--- a/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
+++ b/app/javascript/app/components/data-explorer-content/data-explorer-content-selectors.js
@@ -5,11 +5,10 @@ import {
   isArray,
   pick,
   flatten,
-  kebabCase,
   sortBy
 } from 'lodash';
 import qs from 'query-string';
-import { findEqual, isANumber, noEmptyValues } from 'utils/utils';
+import { findEqual, isANumber, noEmptyValues, useSlug } from 'utils/utils';
 import { isNoColumnField, isNonColumnKey } from 'utils/data-explorer';
 import { isPageContained } from 'utils/navigation';
 
@@ -69,7 +68,7 @@ const getMetaForNoModelFilters = createSelector(
       noModelFiltersMeta[field] = dataSection.meta[field].map(v => ({
         id: v,
         title: v,
-        slug: kebabCase(v)
+        slug: useSlug(v)
       }));
     });
     return noModelFiltersMeta;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -2,9 +2,8 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
 import isEmpty from 'lodash/isEmpty';
-import kebabCase from 'lodash/kebabCase';
 import uniq from 'lodash/uniq';
-import { arrayToSentence } from 'utils';
+import { arrayToSentence, useSlug } from 'utils';
 import { getGhgEmissionDefaultSlugs, toPlural } from 'utils/ghg-emissions';
 import { sortLabelByAlpha } from 'utils/graphs';
 import {
@@ -323,15 +322,15 @@ const getDefaults = createSelector(
 );
 
 const isIncluded = (field, selectedValues, filter) => {
-  const kebabInclude = selectedValues.includes(kebabCase(filter.label));
+  const slugIncluded = selectedValues.includes(useSlug(filter.label));
   const valueOrIsoInclude =
     selectedValues.includes(String(filter.value)) ||
     selectedValues.includes(filter.iso_code3);
 
   return {
     location: valueOrIsoInclude,
-    gas: kebabInclude,
-    sector: kebabInclude
+    gas: slugIncluded,
+    sector: slugIncluded
   }[field];
 };
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -6,14 +6,13 @@ import { getLocationParamUpdated } from 'utils/navigation';
 import { handleAnalytics } from 'utils/analytics';
 import qs from 'query-string';
 import castArray from 'lodash/castArray';
-import kebabCase from 'lodash/kebabCase';
 import { actions as modalActions } from 'components/modal-metadata';
 import { actions as pngModalActions } from 'components/modal-png-download';
 import { actions as downloadModalActions } from 'components/modal-download';
 
 import { getStorageWithExpiration } from 'utils/localStorage';
 import { encodeAsCSVContent, invokeCSVDownload } from 'utils/csv';
-import { orderByColumns, stripHTML } from 'utils';
+import { orderByColumns, stripHTML, useSlug } from 'utils';
 import { GHG_TABLE_HEADER } from 'data/constants';
 import GhgEmissionsComponent from './ghg-emissions-component';
 import { getGHGEmissions } from './ghg-emissions-selectors/ghg-emissions-selectors';
@@ -153,7 +152,7 @@ function GhgEmissionsContainer(props) {
     updateUrlParam({
       name: [field],
       value: castArray(filters)
-        .map(v => kebabCase(v.label))
+        .map(v => useSlug(v.label))
         .join(',')
     });
     sendToAnalitics(field, filters);

--- a/app/javascript/app/utils/ghg-emissions.js
+++ b/app/javascript/app/utils/ghg-emissions.js
@@ -2,7 +2,7 @@ import {
   DEFAULT_EMISSIONS_SELECTIONS,
   GHG_CALCULATION_OPTIONS
 } from 'data/constants';
-import kebabCase from 'lodash/kebabCase';
+import { useSlug } from 'utils';
 
 export const getGhgEmissionDefaults = (source, meta) => {
   const sourceName = source.name || source.label;
@@ -24,8 +24,8 @@ export const getGhgEmissionDefaultSlugs = (source, meta) => {
   const gas = meta.gas.find(g => g.label === defaults.gas);
   const sector = meta.sector.find(s => s.label === defaults.sector);
   return {
-    gas: gas && kebabCase(gas.label),
-    sector: sector && kebabCase(sector.label),
+    gas: gas && useSlug(gas.label),
+    sector: sector && useSlug(sector.label),
     location: defaults.location
   };
 };

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -252,6 +252,23 @@ export function filterQuery(data, query, exceptions, objectValueKeys) {
   });
 }
 
+export const useSlug = string => {
+  const from = 'àáäâãåăæçèéëêǵḧìíïîḿńǹñòóöôœøṕŕßśșțùúüûǘẃẍÿź·/_,:;';
+  const to = 'aaaaaaaaceeeeghiiiimnnnooooooprssstuuuuuwxyz------';
+  const regex = new RegExp(from.split('').join('|'), 'g');
+
+  return string
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(regex, character => to.charAt(from.indexOf(character)))
+    .replace(/&/g, '-and-')
+    .replace(/[^\w\-]+/g, '')
+    .replace(/\-\-+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+};
+
 export default {
   arrayToSentence,
   compareIndexByKey,


### PR DESCRIPTION
This PR changes the way we convert labels to slugs on the `GHG emissions` page - from `lodash/kebabCase` to `useSlugs` from [here](https://github.com/stevenpersia/captain-hook/blob/master/useSlug.js). The main issue here is the case for gases slug - `kebabCase` converts the sample label `CH4` to `ch-4`, which is not compatible with slugs passed on the data explorer `ch4`. Function introduced in this PR solves that problem

**Test:** Try to switch between `GHG Emissions` and `Data Explorer` pages by using `Download/Go To Data Explorer`/`Visualize in...` buttons, having CH4 gas selected