### PR TITLE
Adds link to Climate Laws at end of each target for nrm_summary

### DIFF
--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -60,7 +60,14 @@ module Api
                 value = []
                 data.each do |target|
                   next unless target['sources'].map{|p| p['id']}.include?(law_id.to_i) && target['sector'] != 'economy-wide'
-                  value << if object.normalized_slug == 'nrm_link'
+
+                  value << if object.normalized_slug == 'nrm_summary'
+                             val = target[LSE_INDICATORS_MAP[object.normalized_slug.to_sym]]
+                             target['sources'].select{|t| t['id'] == law_id.to_i}.map{|t| t['link']}.each do |link|
+                               val += " (<a href='#{link}' target='_blank' rel='noopener noreferrer'>View on Climate Laws</a>)<br>"
+                             end
+                             val
+                          elsif object.normalized_slug == 'nrm_link'
                              target['sources'].select{|t| t['id'] == law_id.to_i}.map{|t| t['link']}.join(',')
                           elsif object.normalized_slug == 'nrm_type_of_commitment'
                             target['ghg_target'] ? 'GHG target' : 'Non GHG target'


### PR DESCRIPTION
This PR adds a "View on Climate Laws" link to the end of the LSE related targets' summary data.

You can see it in this example: http://localhost:3000/custom-compare/overview?section=ndc&targets=DZA-framework_1002%2CDZA-first_ndc

![Screenshot 2020-07-16 at 10 37 33](https://user-images.githubusercontent.com/10764/87655602-63914f80-c750-11ea-9864-a40e0bf2f9bd.png)
