### PR TITLE
Add LSE data to Overview with new provider

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { isEmbededComponent } from 'utils/navigation';
 import CountriesDocumentsProvider from 'providers/countries-documents-provider';
+import LSEProvider from 'providers/lse-provider';
 import ModalShare from 'components/modal-share';
 import ModalMetadata from 'components/modal-metadata';
 import layout from 'styles/layout.scss';
@@ -63,6 +64,7 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
         </div>
       </div>
       <ModalShare analyticsName="NDC Overview" />
+      <LSEProvider />
       <ModalMetadata />
     </div>
   );

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -77,6 +77,7 @@ export const commitmentsData = [
         questionText:
           'How many Parties have an economy-wide target in a national law or policy?',
         link: 'https://climate-laws.org/',
+        source: 'lse',
         metadataSlug: 'national_laws_politices',
         hasExternalLink: true
       }

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
@@ -5,6 +5,8 @@ import { europeSlug, europeanCountries } from 'app/data/european-countries';
 
 const getIndicators = state =>
   (state.ndcs && state.ndcs.data.indicators) || null;
+const getLSECountriesData = state =>
+  (state.lse && state.lse.data && state.lse.data.countries) || null;
 const getSlug = (state, { slug }) => slug || null;
 const getAnswerLabel = (state, { answerLabel }) => answerLabel || null;
 const getSource = (state, { source }) => source || null;
@@ -16,7 +18,7 @@ export const getTotalCountriesNumber = state =>
 const getFirstNDCSubmittedIsos = createSelector(
   [getSource, getCountriesDocuments, getAnswerLabel],
   (source, countriesDocuments, answerLabel) => {
-    if (!source || !countriesDocuments) return null;
+    if (!source || source !== 'countriesDocuments' || !countriesDocuments) { return null; }
     return Object.keys(countriesDocuments).filter(iso =>
       countriesDocuments[iso].some(
         doc => doc.slug === answerLabel && doc.submission_date
@@ -25,10 +27,25 @@ const getFirstNDCSubmittedIsos = createSelector(
   }
 );
 
+const getLSEIsos = createSelector(
+  [getSource, getLSECountriesData],
+  (source, lse) => {
+    if (!source || source !== 'lse' || !lse) return null;
+    return lse;
+  }
+);
+
 const getPositiveAnswerIsos = createSelector(
-  [getIndicators, getSlug, getAnswerLabel, getFirstNDCSubmittedIsos],
-  (indicators, slug, answerLabel, firstNDCSubmittedIsos) => {
+  [
+    getIndicators,
+    getSlug,
+    getAnswerLabel,
+    getFirstNDCSubmittedIsos,
+    getLSEIsos
+  ],
+  (indicators, slug, answerLabel, firstNDCSubmittedIsos, lseIsos) => {
     if (firstNDCSubmittedIsos) return firstNDCSubmittedIsos;
+    if (lseIsos) return lseIsos;
     if (!indicators || !slug || !answerLabel) return null;
     const indicator = indicators.find(i => i.slug === slug);
     if (!indicator) return null;

--- a/app/javascript/app/providers/lse-provider/lse-provider-actions.js
+++ b/app/javascript/app/providers/lse-provider/lse-provider-actions.js
@@ -1,0 +1,40 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import isEmpty from 'lodash/isEmpty';
+import { apiWithCache } from 'services/api';
+
+export const fetchLSEInit = createAction('fetchLSEInit');
+export const fetchLSEReady = createAction('fetchLSEReady');
+export const fetchLSEFail = createAction('fetchLSEFail');
+
+export const fetchLSE = createThunkAction(
+  'fetchLSE',
+  () => (dispatch, state) => {
+    const { lse } = state();
+    if (lse && isEmpty(lse.data) && !lse.loading) {
+      dispatch(fetchLSEInit());
+      apiWithCache
+        .get(
+          '//laws-pathways-staging.vizzuality.com/cclow/api/targets/economy-wide-countries'
+        )
+        .then(response => {
+          if (response.data) return response.data;
+          throw Error(response.statusText);
+        })
+        .then(data => {
+          dispatch(fetchLSEReady(data));
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchLSEFail());
+        });
+    }
+  }
+);
+
+export default {
+  fetchLSE,
+  fetchLSEInit,
+  fetchLSEReady,
+  fetchLSEFail
+};

--- a/app/javascript/app/providers/lse-provider/lse-provider-actions.js
+++ b/app/javascript/app/providers/lse-provider/lse-provider-actions.js
@@ -14,9 +14,7 @@ export const fetchLSE = createThunkAction(
     if (lse && isEmpty(lse.data) && !lse.loading) {
       dispatch(fetchLSEInit());
       apiWithCache
-        .get(
-          '//laws-pathways-staging.vizzuality.com/cclow/api/targets/economy-wide-countries'
-        )
+        .get('//climate-laws.org/cclow/api/targets/economy-wide-countries')
         .then(response => {
           if (response.data) return response.data;
           throw Error(response.statusText);

--- a/app/javascript/app/providers/lse-provider/lse-provider-reducers.js
+++ b/app/javascript/app/providers/lse-provider/lse-provider-reducers.js
@@ -1,0 +1,26 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  error: false,
+  data: null
+};
+
+const setLoading = (state, loading) => ({ ...state, loading });
+const setError = (state, error) => ({ ...state, error });
+const setLoaded = (state, loaded) => ({ ...state, loaded });
+
+export default {
+  fetchLSEInit: state => setLoading(state, true),
+  fetchLSEReady: (state, { payload }) =>
+    setLoaded(
+      setLoading(
+        {
+          ...state,
+          data: payload
+        },
+        false
+      ),
+      true
+    ),
+  fetchLSEFail: state => setError(state, true)
+};

--- a/app/javascript/app/providers/lse-provider/lse-provider.js
+++ b/app/javascript/app/providers/lse-provider/lse-provider.js
@@ -1,0 +1,24 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import reducers, { initialState } from './lse-provider-reducers';
+import * as actions from './lse-provider-actions';
+
+class LSEProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchLSE } = this.props;
+    fetchLSE();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+LSEProvider.propTypes = {
+  fetchLSE: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(null, actions)(LSEProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -7,6 +7,7 @@ import * as loginProvider from 'providers/login-provider';
 import * as countriesProvider from 'providers/countries-provider';
 import * as regionsProvider from 'providers/regions-provider';
 import * as documentsProvider from 'providers/documents-provider';
+import * as LSEProvider from 'providers/lse-provider';
 import * as countriesDocumentsProvider from 'providers/countries-documents-provider';
 import * as espLocationsProvider from 'providers/esp-locations-provider';
 import * as espTimeSeriesProvider from 'providers/esp-time-series-provider';
@@ -46,6 +47,7 @@ const providersReducers = {
   countries: handleActions(countriesProvider),
   regions: handleActions(regionsProvider),
   documents: handleActions(documentsProvider),
+  lse: handleActions(LSEProvider),
   countriesDocuments: handleActions(countriesDocumentsProvider),
   adaptations: handleActions(adaptationsProvider),
   emissions: handleActions(emissionsProvider),


### PR DESCRIPTION
On the Overview page for the last question we had to import some data from an external endpoint. This data is stored on the state via a provider. Then we calculate the number and emissions from the isos that are provided.

Currently, the endpoint returns an empty array so the number is 0 but when this change it will show the correct number and data.

![image](https://user-images.githubusercontent.com/9701591/87667168-2afe6f80-c76a-11ea-8b5f-bc05ee99e388.png)
