### PR TITLE
Feature/ghg chart rounding values

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -9,7 +9,8 @@ import {
   Chart,
   Multiselect,
   MultiLevelDropdown,
-  Dropdown
+  Dropdown,
+  TooltipChart
 } from 'cw-components';
 import LegendChart from 'components/charts/legend-chart';
 import EmissionsMetaProvider from 'providers/ghg-emissions-meta-provider';
@@ -25,7 +26,7 @@ import ModalPngDownload from 'components/modal-png-download';
 import ModalDownload from 'components/modal-download';
 import { TabletPortraitOnly, TabletLandscape } from 'components/responsive';
 import { toPlural } from 'utils/ghg-emissions';
-import { format } from 'd3-format';
+import { format, precisionPrefix, formatPrefix } from 'd3-format';
 import ModalShare from 'components/modal-share';
 import ModalMetadata from 'components/modal-metadata';
 import lineIcon from 'assets/icons/line_chart.svg';
@@ -256,6 +257,32 @@ function GhgEmissions(props) {
       }
       return value ? `${format('.2r')(value)}%` : '0%';
     };
+
+    // more about precision prefix: https://github.com/d3/d3-format#precisionPrefix
+    const billionsFormat = formatPrefix(
+      `.${precisionPrefix(1e7, 1.3e9)}`,
+      1.3e9
+    ); // format millions with two fixed decimals
+    const millionsFormat = formatPrefix(
+      `.${precisionPrefix(1e4, 1.3e6)}`,
+      1.3e6
+    ); // format millions with two fixed decimals
+    const thousandsFormat = formatPrefix(
+      `.${precisionPrefix(1e1, 1.3e3)}`,
+      1.3e3
+    ); // format thousands with two fixed decimals
+
+    const customLabelFormat = value => {
+      if (value > 1000000000) {
+        return billionsFormat(value);
+      } else if (value > 1000000) {
+        return millionsFormat(value);
+      } else if (value > 1000) {
+        return thousandsFormat(value);
+      }
+      return format('.2f')(value);
+    };
+
     return (
       <React.Fragment>
         <Chart
@@ -277,6 +304,15 @@ function GhgEmissions(props) {
             isPercentageChangeCalculation
               ? percentageChangeCustomLabelFormat
               : undefined
+          }
+          customTooltip={
+            <TooltipChart
+              getCustomYLabelFormat={
+                isPercentageChangeCalculation
+                  ? percentageChangeCustomLabelFormat
+                  : customLabelFormat
+              }
+            />
           }
           dataZoomComponent={
             FEATURE_NEW_GHG &&

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -262,7 +262,7 @@ function GhgEmissions(props) {
     const billionsFormat = formatPrefix(
       `.${precisionPrefix(1e7, 1.3e9)}`,
       1.3e9
-    ); // format millions with two fixed decimals
+    ); // format billions with two fixed decimals
     const millionsFormat = formatPrefix(
       `.${precisionPrefix(1e4, 1.3e6)}`,
       1.3e6


### PR DESCRIPTION
This PR changes the rounding of the GHG chart values: decimal notation with an SI prefix with **always two fixed decimals**.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172721145)

***
The modification introduced in this PR solves the issue described in point two:
> 2 - Check the rounding on the values. => I can see the values on the graph changing, but the label is the same number, see below for example - each year 2000-2004 is labeled 160 Mt, though the values are changing. It appears to be because only two significant figures are being represented, but when the numbers are over 100, it rounds off too far

_**Before:**_
![dq5jx-r9a81](https://user-images.githubusercontent.com/15097138/87919683-1246d000-ca70-11ea-854d-55565050e0e0.gif)

_**After:**_
![y1wl4-66e2j](https://user-images.githubusercontent.com/15097138/87919520-ce53cb00-ca6f-11ea-9bc2-e2e119908ec3.gif)


***
About point one, I can't reproduce this bug on the recent build:
> Could we round to two decimals in the yaxis for cases like this (See comment)

**_Bug (Jun 10, 2019):_**
![Pasted Image at 2020_05_07_17_05 pm](https://user-images.githubusercontent.com/15097138/87917223-88e1ce80-ca6c-11ea-8eb4-371d45c4dd27.png)

_**Current build:**_
![image](https://user-images.githubusercontent.com/15097138/87917168-736ca480-ca6c-11ea-8333-fdbe07ba4121.png)
 
