### PR TITLE
Add not represented emissions sector on donut and tooltip

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -350,7 +350,11 @@ export const getEmissionsCardData = createSelector(
       hideLegend: true,
       innerHoverLabel: true,
       minAngle: 3,
-      ...getLabels(legend, NO_DOCUMENT_SUBMITTED, true)
+      ...getLabels({
+        legend,
+        notInformationLabel: NO_DOCUMENT_SUBMITTED,
+        noLabelOverride: true
+      })
     };
 
     return {

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -19,7 +19,8 @@ import {
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
 import {
   DEFAULT_NDC_EXPLORE_CATEGORY_SLUG,
-  CATEGORY_SOURCES
+  CATEGORY_SOURCES,
+  NOT_COVERED_LABEL
 } from 'data/constants';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
@@ -325,7 +326,11 @@ export const getEmissionsCardData = createSelector(
       hideLegend: true,
       innerHoverLabel: true,
       minAngle: 3,
-      ...getLabels(legend, NOT_APPLICABLE_LABEL)
+      ...getLabels({
+        legend,
+        notInformationLabel: NOT_APPLICABLE_LABEL,
+        hasNotCovered: data.some(d => d.name === NOT_COVERED_LABEL)
+      })
     };
 
     return {

--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
+import { NOT_COVERED_LABEL } from 'data/constants';
 import styles from './donut-tooltip-styles.scss';
 
 const DonutTooltip = props => {
@@ -25,10 +26,24 @@ const DonutTooltip = props => {
 
   // Avoid covering the label on the center
   const left = coordinate.x > 40 ? coordinate.x + 80 : coordinate.x;
+  const countriesContent =
+    legendItemName === NOT_COVERED_LABEL ? (
+      <React.Fragment>
+        GHG emissions{' '}
+        <span className={styles.legendItem}>
+          not covered by national inventories
+        </span>
+      </React.Fragment>
+    ) : (
+      <React.Fragment>
+        {`${itemName} with `}
+        <span className={styles.legendItem}>{legendItemName}</span>
+      </React.Fragment>
+    );
+
   return ReactDOM.createPortal(
     <div className={styles.tooltip} style={{ left, top }}>
-      {`${itemName} with `}
-      <span className={styles.legendItem}>{legendItemName}</span>
+      {countriesContent}
       {` represent ${percentage}% of global GHG emissions`}
     </div>,
     reference

--- a/app/javascript/app/components/ndcs/shared/utils.js
+++ b/app/javascript/app/components/ndcs/shared/utils.js
@@ -1,4 +1,5 @@
 import camelCase from 'lodash/camelCase';
+import { NOT_COVERED_LABEL } from 'data/constants';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 const NOT_APPLICABLE_OR_NOT_INFO_LABEL = 'Not applicable or No information';
@@ -13,8 +14,7 @@ export const sortByIndexAndNotInfo = (a, b) => {
 export const getIndicatorEmissionsData = (
   emissionsIndicator,
   selectedIndicator,
-  legend,
-  noInformationLabel = NOT_APPLICABLE_OR_NOT_INFO_LABEL
+  legend
 ) => {
   if (!emissionsIndicator) return null;
   const emissionPercentages = emissionsIndicator.locations;
@@ -40,28 +40,21 @@ export const getIndicatorEmissionsData = (
   });
 
   if (summedPercentage < 100) {
-    const notApplicableDataItem = data.find(d => d.name === 'Not Applicable');
-    if (notApplicableDataItem) {
-      const notApplicablePosition = data.indexOf(notApplicableDataItem);
-      data[notApplicablePosition] = {
-        name: noInformationLabel,
-        value: notApplicableDataItem.value + (100 - summedPercentage)
-      };
-    } else {
-      data.push({
-        name: noInformationLabel,
-        value: 100 - summedPercentage
-      });
-    }
+    data.push({
+      name: NOT_COVERED_LABEL,
+      value: 100 - summedPercentage
+    });
   }
+
   return data;
 };
 
-export const getLabels = (
+export const getLabels = ({
   legend,
   noInformationLabel = NOT_APPLICABLE_OR_NOT_INFO_LABEL,
-  noLabelOverride
-) => {
+  noLabelOverride,
+  hasNotCovered
+}) => {
   const tooltip = {};
   const theme = {};
   const getNoInfoLabel = () =>
@@ -69,6 +62,7 @@ export const getLabels = (
     (noInformationLabel === NOT_APPLICABLE_LABEL
       ? NOT_APPLICABLE_OR_NOT_INFO_LABEL
       : noInformationLabel);
+
   legend.forEach(l => {
     const legendName =
       l.name === noInformationLabel ? getNoInfoLabel() : l.name;
@@ -80,6 +74,15 @@ export const getLabels = (
       stroke: l.color
     };
   });
+  if (hasNotCovered) {
+    tooltip.notCovered = {
+      label: NOT_COVERED_LABEL
+    };
+    theme.notCovered = {
+      label: NOT_COVERED_LABEL,
+      stroke: '#83A2E5'
+    };
+  }
   return {
     tooltip,
     theme

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -39,6 +39,8 @@ export const GHG_CALCULATION_OPTIONS = {
   }
 };
 
+export const NOT_COVERED_LABEL = 'Not covered';
+
 export const CALCULATION_OPTIONS = {
   ABSOLUTE_VALUE: {
     label: 'Total',


### PR DESCRIPTION
This PR adds a new color for Not covered emissions and changes the label on the tooltip. 
![image](https://user-images.githubusercontent.com/9701591/88085274-ecabea80-cb85-11ea-9abe-5f97d4fe0cdc.png)
