### PR TITLE
Fix typos on metadata slugs

### DIFF
--- a/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
+++ b/app/javascript/app/components/country/country-ndc-sdg-linkages/country-ndc-sdg-linkages.js
@@ -78,7 +78,7 @@ const CountrySDGLinkagesContainer = props => {
   const handleInfoClick = () => {
     props.setModalMetadata({
       category: 'Country',
-      slugs: 'ndc_sdc_all indicators',
+      slugs: 'ndc_sdg_all indicators',
       open: true
     });
   };

--- a/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
+++ b/app/javascript/app/components/country/laws-and-policies/laws-and-policies-component.jsx
@@ -28,7 +28,7 @@ class LawsAndPolicies extends PureComponent {
   handleInfoOnClick = () => {
     this.props.setModalMetadata({
       category: 'Country',
-      slugs: ['national_laws_policies', 'ndc_cw'],
+      slugs: ['national_laws_politices', 'ndc_cw'],
       customTitle: 'Targets in Laws and Policies',
       open: true
     });

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -128,7 +128,7 @@ export const DATA_EXPLORER_METHODOLOGY_SOURCE = {
     'UNFCCC Non-Annex I': ['historical_emissions_unfccc'],
     GCP: ['historical_emissions_gcp']
   },
-  'ndc-sdg-linkages': ['ndc_sdc_all indicators'],
+  'ndc-sdg-linkages': ['ndc_sdg_all indicators'],
   'ndc-content': ['ndc_cw', 'ndc_wb', 'ndc_die'],
   'lts-content': ['lts'],
   'emission-pathways': [null] // model, scenario and indicator related metadata

--- a/app/services/api/v1/data/ndc_sdg/zipped_download.rb
+++ b/app/services/api/v1/data/ndc_sdg/zipped_download.rb
@@ -8,7 +8,7 @@ module Api
           def initialize(filter)
             @filter = filter
             @metadata_filter = Api::V1::Data::Metadata::Filter.new(
-              source_names: ['ndc_sdc_all indicators']
+              source_names: ['ndc_sdg_all indicators']
             )
             @filename = 'ndc_sdg'
             @metadata_filename = 'sources.csv'


### PR DESCRIPTION
This PR fixes the slugs for country page metadata (NDC-SDGs and LSE). The LSE is still national_laws_politices as this is how the metadata slug is in production and staging

![image](https://user-images.githubusercontent.com/9701591/88148283-aa72bf80-cbfe-11ea-9894-8c4b49d16c53.png)
![image](https://user-images.githubusercontent.com/9701591/88148219-916a0e80-cbfe-11ea-9859-0817bcddaeeb.png)
