### PR TITLE
Fix/full content page params

### DIFF
--- a/app/javascript/app/components/result-card/result-card-component.jsx
+++ b/app/javascript/app/components/result-card/result-card-component.jsx
@@ -22,8 +22,7 @@ const ResultCard = props => {
         result.matches.map(match => (
           <NavLink
             key={`${match.fragment}-${match.idx}`}
-            to={`/ndcs/country/${result.location.iso_code3}/full?searchBy=${search.searchBy}
-              &query=${search.query}&idx=${match.idx}&document=${result.document_type}-${result.language}`}
+            to={`/ndcs/country/${result.location.iso_code3}/full?searchBy=${search.searchBy}&query=${search.query}&idx=${match.idx}&document=${result.document_type}-${result.language}`}
             className={styles.match}
           >
             <div
@@ -31,7 +30,12 @@ const ResultCard = props => {
               id={match.idx}
               dangerouslySetInnerHTML={{ __html: match.fragment }} // eslint-disable-line
             />
-            <Button className={styles.link} variant="secondary" square onClick={() => true}>
+            <Button
+              className={styles.link}
+              variant="secondary"
+              square
+              onClick={() => true}
+            >
               <Icon icon={iconLink} className={styles.iconLink} />
             </Button>
           </NavLink>

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-component.jsx
@@ -49,7 +49,9 @@ class NDCCountryFull extends PureComponent {
         </div>
       );
     }
-    return loaded ? <NoContent message="No content available" /> : null;
+    return loaded ? (
+      <NoContent className={styles.noContent} message="No content available" />
+    ) : null;
   }
 
   render() {

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-selectors.js
@@ -18,11 +18,14 @@ export const getSelectedContent = createSelector(
     if (!content || !content.length) return null;
     if (!selected) return content[0];
     const splitSelected = selected.split('-');
+    const selectedContent = content.find(
+      ({ document_type, language }) =>
+        document_type === splitSelected[0] && language === splitSelected[1]
+    );
+    if (selectedContent) return selectedContent;
     return content.find(
-      item =>
-        item.document_type === splitSelected[0] &&
-        (item.language === splitSelected[1] || DEFAULT_LANGUAGE),
-      10
+      ({ document_type, language }) =>
+        document_type === splitSelected[0] && language === DEFAULT_LANGUAGE
     );
   }
 );

--- a/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
+++ b/app/javascript/app/pages/ndc-country-full/ndc-country-full-styles.scss
@@ -72,7 +72,8 @@
   z-index: $z-index-over-base;
 }
 
-.loader {
+.loader,
+.noContent {
   position: absolute;
   min-height: 500px;
   top: 0;


### PR DESCRIPTION
This PR fixes two issues related to `NDC Search` and `NDC Full Content` pages.
[PIVOTAL](https://www.pivotaltracker.com/story/show/173054830)

![fc4ak-e75kj](https://user-images.githubusercontent.com/15097138/88180066-b6717800-cc24-11ea-83cf-db70ecb0408f.gif)

- Now the search text is correctly passed, from NDC Search to the NDC Full content page. There is a problem with the `NavLink` url in the `ResultCard` component. Between `...searchBy=${search.searchBy}` and `&query=${search.query}...` there is an "enter" character there, what in template literals breaks the line of the string, instead of formatting the code in the code editor, short explanation below:
![image](https://user-images.githubusercontent.com/15097138/88178339-26323380-cc22-11ea-9e5c-bf66920d7647.png)

- The selection of the document on the `NDC Full Content` works correctly now; there is a bug when a country has more than one language version of a document, so it always chooses the default language instead of the selected one. A small change of the logical expression solved the problem.

**Test:** On the `NDC Search`  type in the search text and click at one of the results, and on the `NDC Full Content` page test documents with different language versions, check if they display correctly.