### PR TITLE
Enabling importing targets for multiple NDC documents

### DIFF
--- a/app/controllers/api/v1/ndc_texts_controller.rb
+++ b/app/controllers/api/v1/ndc_texts_controller.rb
@@ -124,8 +124,8 @@ module Api
           ndcs = ndcs.where(id: ::NdcSdg::Sector.ndc_ids(params[:sector])) if params[:sector]
         end
 
-        linkages = Ndc.linkages(params)
         ndcs.map do |ndc|
+          linkages = Ndc.linkages(params, ndc)
           ndc_linkages = linkages.
             select { |linkage| linkage.ndc_id == ndc.id }
 

--- a/app/models/ndc.rb
+++ b/app/models/ndc.rb
@@ -58,7 +58,7 @@ class Ndc < ApplicationRecord
     update_all(sql)
   end
 
-  def self.linkages(params)
+  def self.linkages(params, ndc = nil)
     query_params = {}
 
     filters = {
@@ -75,11 +75,15 @@ class Ndc < ApplicationRecord
       }
     end
 
-    ::NdcSdg::NdcTarget.includes(
+    targets = ::NdcSdg::NdcTarget.includes(
       target: [:goal],
       ndc_target_sectors: [:sector],
       ndc: [:location]
-    ).where(query_params).
+    ).where(query_params)
+
+    targets = targets.where(ndc_id: ndc.id) if ndc
+
+    targets.
       reject { |n| n.starts_at.nil? }.
       uniq(&:indc_text).
       sort_by(&:starts_at)

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -550,6 +550,7 @@ class ImportIndc
       begin
         Indc::Submission.create!(submission_attributes(location, sub))
       rescue
+        puts "This row failed #{sub}"
       end
     end
   end

--- a/app/services/import_ndc_sdg_targets.rb
+++ b/app/services/import_ndc_sdg_targets.rb
@@ -23,29 +23,31 @@ class ImportNdcSdgTargets
       ndc = nil
       if row[:indc_text].present?
         row[:indc_text] = TextNormalizer.normalize(row[:indc_text])
-        ndc = ndc(row)
+        ndcs = ndcs(row)
         target = target(row)
       end
 
-      unless ndc && target
+      unless ndcs.present? && target
         @failed_lines.append(row)
         next
       end
 
-      indc_text = row[:indc_text]
-      starts_at = ndc.full_text.downcase.index(indc_text.downcase)
-      ends_at = starts_at + indc_text.length - 1 if starts_at
-      ndc_target = NdcSdg::NdcTarget.find_or_create_by(
-        ndc: ndc,
-        target: target,
-        indc_text: indc_text,
-        status: row[:status],
-        climate_response: row[:climate_response],
-        type_of_information: row[:type_of_information],
-        starts_at: starts_at,
-        ends_at: ends_at
-      )
-      import_ndc_target_sectors(row, ndc_target)
+      ndcs.each do |ndc|
+        indc_text = row[:indc_text]
+        starts_at = ndc.full_text.downcase.index(indc_text.downcase)
+        ends_at = starts_at + indc_text.length - 1 if starts_at
+        ndc_target = NdcSdg::NdcTarget.find_or_create_by(
+          ndc: ndc,
+          target: target,
+          indc_text: indc_text,
+          status: row[:status],
+          climate_response: row[:climate_response],
+          type_of_information: row[:type_of_information],
+          starts_at: starts_at,
+          ends_at: ends_at
+        )
+        import_ndc_target_sectors(row, ndc_target)
+      end
     end
 
     unless @failed_lines.empty?
@@ -69,6 +71,22 @@ class ImportNdcSdgTargets
         sector: sector_rec
       )
     end
+  end
+
+  def ndcs(row)
+    iso_code3 = row[:iso_code3] && row[:iso_code3].upcase
+    location = iso_code3 && Location.find_by_iso_code3(iso_code3)
+    unless location
+      Rails.logger.error "Location not found #{row}"
+      return nil
+    end
+    indc_text = row[:indc_text]
+    ndcs = location.ndcs.select do |n|
+      !n.full_text.downcase.index(indc_text.downcase).nil?
+    end.uniq
+
+    Rails.logger.error "NDC not found #{row}" unless ndcs.present?
+    ndcs
   end
 
   def ndc(row)


### PR DESCRIPTION
This PR is the first step to fixing a couple of issues with the NDC SDG Linkages pages, that are meant to be done under the ongoing maintenance contract, the issues to fix are:

- matching SDG goals and targets against multiple versions of the NDC documents;
- importing of translated versions of the documents (see: https://basecamp.com/1756858/projects/13795275/todos/420299366#comment_769964171)

To test this you'll need to run the ndc_sdg_targets importer, but to be safe you might want to reimport these:

```
bundle exec rails ndcs:full:import ndcs:full:index
bundle exec rails sdgs:import
bundle exec rails ndc_sdg_targets:import
```

The last one is the one that has been changed in this PR.

After the importing is ran you should see that more files on the Full Text pages have targets on the Goals/Targets dropdown. One good example to test it with is Andorra: http://localhost:3000/ndcs/country/AND/full?document=first_ndc-EN

There's something that I'm not 100% sure that it's working which is rendering the Translated versions, see the case of Andorra where there are a lot of options in there, not sure if the ones that are translated work well (they'll have true on the translated attribute of the API response.

If you need help with the importers, Agnieszka should be able to help as she has worked on this (ages ago) or reach out to me on WhatsApp! =)

Take care!

PS: I'm PRing from a fork, because I removed myself from the Vizz org... 😅 