### PR TITLE
Fix/remove ndc map document filter

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -81,8 +81,7 @@ class NDCSExploreMapContainer extends PureComponent {
     this.props.fetchNDCS({
       subcategory:
         (search && search.category) || DEFAULT_NDC_EXPLORE_CATEGORY_SLUG,
-      additionalIndicatorSlug: 'ndce_ghg',
-      document: 'first_ndc'
+      additionalIndicatorSlug: 'ndce_ghg'
     });
   }
 
@@ -96,8 +95,7 @@ class NDCSExploreMapContainer extends PureComponent {
     ) {
       this.props.fetchNDCS({
         subcategory: selectedCategory.value,
-        additionalIndicatorSlug: 'ndce_ghg',
-        document: 'first_ndc'
+        additionalIndicatorSlug: 'ndce_ghg'
       });
     }
   }

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
-import { isEmpty, sortBy } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
 import { filterQuery } from 'app/utils';
 import { getMapIndicator } from 'components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors';
 import {
@@ -60,9 +61,11 @@ export const tableGetSelectedData = createSelector(
     ) {
       return [];
     }
-    const refIndicator =
-      indicators.find(i => i.value === 'submission') || indicators[0];
 
+    const refIndicator =
+      indicators.find(i => i.value === 'submission') ||
+      indicators.find(i => !isEmpty(i.locations));
+    if (!refIndicator) return null;
     return Object.keys(refIndicator.locations).map(iso => {
       if (refIndicator.locations[iso].value === 'No Document Submitted') {
         return false;


### PR DESCRIPTION
This PR removes the filter in NDC explore map allowing the data to display the info from the last available indicator.

https://climate-watch.vizzuality.com/ndcs-explore?category=mitigation&indicator=mitigation_contribution_type

Before:

![image](https://user-images.githubusercontent.com/9701591/88669241-f08ac000-d0e3-11ea-8f56-78cd0222a792.png)

After:

![image](https://user-images.githubusercontent.com/9701591/88669259-f7193780-d0e3-11ea-8637-54e1fddc45f3.png)

Also fixes a bug on the table, the reference indicator for the locations was picked from the first indicator. But it seems that some indicators don't have locations.
The table was not loading correctly on mitigation category at first