### PR TITLE
Fix/map display ndcs

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -81,7 +81,8 @@ module Api
         render json: NdcIndicators.new(indicators, categories, sectors),
                serializer: Api::V1::Indc::NdcIndicatorsSerializer,
                locations_documents: @locations_documents,
-               lse_data: get_lse_data
+               lse_data: get_lse_data,
+               filter: params[:filter]
       end
 
       def content_overview

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -40,6 +40,8 @@ module Api
         def locations
           values = if instance_options[:locations_documents]
                      object.values_for instance_options[:locations_documents]
+                   elsif instance_options[:filter] == 'map'
+                     object.values.joins(:label)
                    else
                      object.values
                    end

--- a/app/serializers/api/v1/indc/indicator_serializer.rb
+++ b/app/serializers/api/v1/indc/indicator_serializer.rb
@@ -40,7 +40,7 @@ module Api
         def locations
           values = if instance_options[:locations_documents]
                      object.values_for instance_options[:locations_documents]
-                   elsif instance_options[:filter] == 'map'
+                   elsif instance_options[:filter] == 'map' && !['submission', 'submission_date', 'ndce_ghg'].include?(object.slug)
                      object.values.joins(:label)
                    else
                      object.values


### PR DESCRIPTION
So this `/api/v1/ndcs` endpoint is used everywhere and has a lot of variations :/ so sorry about that!

We now have indicators values for different NDC versions (indc, first ndc, second ndc, etc), but on the map page we don't have a filter by document and they'd like to display the latest value for each country. So if a country had submitted a second ndc their value for that document should show next to other countries' first ndc values. The simplest way I thought of doing this was telling them to only include the map versions of the values for the latest submission, so that we don't need to filter by document and just get the value available for each indicator. Turns out that the difference between "map" and "table" indicator is that the values for the map version have a label associated with this. So this PR passes the `params[:filter]` to the serializer to join values with labels and only fetch those!

This seems to fix the map view, there are many more values available. To ensure that the table indicators also appear (the last 3 columns) I had to put an exception on the serializer based on their slugs. :/ This would benefit from a proper refactor and maybe some views. Also maybe not using the same endpoint in so many frontend pages! 😅  but maybe something for another time!

