### PR TITLE
Fix/ndc explore

### DIFF
--- a/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
+++ b/app/javascript/app/components/ndcs/shared/donut-tooltip/donut-tooltip.jsx
@@ -31,7 +31,7 @@ const DonutTooltip = props => {
       <React.Fragment>
         GHG emissions{' '}
         <span className={styles.legendItem}>
-          not covered by national inventories
+          Not covered by national inventories
         </span>
       </React.Fragment>
     ) : (

--- a/app/javascript/app/utils/map.js
+++ b/app/javascript/app/utils/map.js
@@ -10,7 +10,7 @@ const buckets = colorArray.map((_, i) => colorArray.slice(0, i + 1));
 export function getColorByIndex(data, index, colors = buckets) {
   const length = Object.keys(data).length;
   if (index === -2 || length === 1) return CHART_NAMED_GRAY_COLORS.grayColor1;
-  return colors[length - 2][index - 1] || CHART_NAMED_GRAY_COLORS.grayColor2;
+  return colors[length - 1][index - 1] || CHART_NAMED_GRAY_COLORS.grayColor2;
 }
 
 export function createLegendBuckets(


### PR DESCRIPTION
This PR solves some problems on the NDC explore page:

- Updates the logic of the fetch so the loading state is more accurate and when we select long categories like sectoral adaptation measures, it will show loading instead of no data

- Capitalizes text on the No represented label of the donut chart tooltip

- Fix the color buckets so when we have some elements on a legend the last one is not always gray
