### PR TITLE
Use no comparable data available text instead of -

### DIFF
--- a/app/javascript/app/components/definition-list/definition-list-component.jsx
+++ b/app/javascript/app/components/definition-list/definition-list-component.jsx
@@ -26,9 +26,15 @@ const DefinitionList = ({
             {descriptions &&
               descriptions.map(({ iso, value }) => (
                 <dd key={`${slug}-${iso}`} className={styles.definitionDesc}>
-                  <div
-                    dangerouslySetInnerHTML={{ __html: value }} // eslint-disable-line
-                  />
+                  {compare && value === '-' ? (
+                    <div className={styles.noComparable}>
+                      No comparable data available
+                    </div>
+                  ) : (
+                    <div
+                      dangerouslySetInnerHTML={{ __html: value }} // eslint-disable-line
+                    />
+                  )}
                 </dd>
               ))}
           </div>

--- a/app/javascript/app/components/definition-list/definition-list-styles.scss
+++ b/app/javascript/app/components/definition-list/definition-list-styles.scss
@@ -35,6 +35,11 @@
   flex: 0.4;
 }
 
+.noComparable {
+  color: $gray1;
+  font-style: $font-style-italic;
+}
+
 .definitionDesc {
   color: $theme-color;
   font-family: $font-family-1;


### PR DESCRIPTION
We needed to change the hyphens with 'No comparable data available' and style it on gray

![image](https://user-images.githubusercontent.com/9701591/89018984-ea335880-d31c-11ea-93cb-9c076b16938e.png)
