### PR TITLE
Don't fetch if we don't have document

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -63,8 +63,7 @@ export const getSelectedDocument = createSelector(
     const lastDocument = countryDocuments[countryDocuments.length - 1];
     if (!search || !search.document) return lastDocument;
     return FEATURE_NDC_FILTERING
-      ? countryDocuments.find(document => document.slug === search.document) ||
-          lastDocument
+      ? countryDocuments.find(document => document.slug === search.document)
       : countryDocuments.find(
         document => legacyDocumentValue(document) === search.document
       ) || lastDocument;

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview.js
@@ -35,16 +35,24 @@ const mapStateToProps = (state, { location, match }) => {
 };
 
 function CountryNdcOverviewContainer(props) {
-  const { iso, fetchNdcsCountryAccordion, setModalMetadata } = props;
+  const {
+    iso,
+    fetchNdcsCountryAccordion,
+    setModalMetadata,
+    selectedDocument
+  } = props;
 
   useEffect(() => {
-    fetchNdcsCountryAccordion({
-      locations: iso,
-      category: 'summary',
-      compare: false,
-      lts: false
-    });
-  }, [iso]);
+    if (selectedDocument) {
+      fetchNdcsCountryAccordion({
+        locations: iso,
+        category: 'summary',
+        compare: false,
+        lts: false,
+        document: selectedDocument.slug
+      });
+    }
+  }, [iso, selectedDocument]);
 
   const handleAnalyticsClick = () => {
     handleAnalytics('Country', 'Leave page to explore data', 'Ndc Overview');

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion.js
@@ -47,7 +47,7 @@ class NdcsCountryAccordionContainer extends PureComponent {
       document
     } = this.props;
     const locations = iso || search.locations;
-    if (document || !compare) {
+    if (document) {
       fetchNdcsCountryAccordion({
         locations,
         category,
@@ -69,7 +69,10 @@ class NdcsCountryAccordionContainer extends PureComponent {
     const newLocations =
       nextProps.iso || qs.parse(nextProps.location.search).locations;
     const oldLocations = iso || qs.parse(this.props.location.search).locations;
-    if (newLocations !== oldLocations || document !== nextProps.document) {
+    if (
+      newLocations !== oldLocations ||
+      (document !== nextProps.document && nextProps.document)
+    ) {
       fetchNdcsCountryAccordion({
         locations: newLocations,
         category: nextProps.category,


### PR DESCRIPTION
We were showing extra categories not related with the document on NDC countries page (overview):

![image](https://user-images.githubusercontent.com/9701591/89885623-9f8ec780-dbcb-11ea-8a5b-92f6c8901f62.png)

Now we don't fetch until we have a selected document. Same for the summary 