### PR TITLE
Dont filter ndc comparison by overview and merge categories

### DIFF
--- a/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
+++ b/app/javascript/app/components/custom-compare-accordion/custom-compare-accordion-selectors.js
@@ -64,7 +64,7 @@ export const getData = createSelector(
   }
 );
 
-export const groupIndicatorsByCategory = createSelector(
+const groupIndicatorsByCategory = createSelector(
   [getIndicators, getCategories],
   (indicators, categories) => {
     if (!indicators || !categories) return null;
@@ -79,7 +79,7 @@ export const groupIndicatorsByCategory = createSelector(
   }
 );
 
-export const getCategoriesWithSectors = createSelector(
+const getCategoriesWithSectors = createSelector(
   [groupIndicatorsByCategory],
   categories => {
     if (!categories) return null;

--- a/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
+++ b/app/javascript/app/components/ndcs/ndcs-country-accordion/ndcs-country-accordion-actions.js
@@ -14,7 +14,7 @@ const fetchNdcsCountryAccordionFailed = createAction(
 const fetchNdcsCountryAccordion = createThunkAction(
   'fetchNdcsCountryAccordion',
   params => dispatch => {
-    const { locations, category, compare, lts, document } = params;
+    const { locations, category, lts, document } = params;
     const documentParam = document ? `&document=${document}` : '';
     if (locations) {
       dispatch(fetchNdcsCountryAccordionInit());
@@ -25,7 +25,7 @@ const fetchNdcsCountryAccordion = createThunkAction(
           lts
             ? '&source=LTS'
             : '&source[]=CAIT&source[]=WB&source[]=NDC%20Explorer'
-        }${documentParam}${!compare ? '&filter=overview' : ''}`
+        }${documentParam}`
       )
         .then(response => {
           if (response.ok) return response.json();


### PR DESCRIPTION
Don't merge: We want to be sure if we should apply the filter=overview or not to the NDC comparison and Custom compare pages. Waiting for WRI answer

If we don't want this filter we should remove it from Custom compare call and apply the same merge of categories to this data.

On NDC comparison page we had duplicated categories as we don't have any category type filter like in custom compare (filter=overview). On the frontend, we have merged the indicators from these categories to display them together.

The sectoral info, which data is treated separately, doesn't have its indicators merged as we don't see this need. Take it into account if there is any problem.