### PR TITLE
Get categories from additional indicators request

### DIFF
--- a/app/javascript/app/pages/ndcs/ndcs-actions.js
+++ b/app/javascript/app/pages/ndcs/ndcs-actions.js
@@ -44,6 +44,7 @@ const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
   }
 
   // Used for indicators like ndce_ghg (emissions) that are needed but not included on category filtered calls
+  // and as it is not filtered by category also serves the whole list of categories
   if (
     additionalIndicatorSlugs &&
     ndcs &&
@@ -71,7 +72,10 @@ const fetchNDCS = createThunkAction('fetchNDCS', props => (dispatch, state) => {
           return response[0].data;
         }
         return {
-          categories: response[0].data.categories,
+          categories: {
+            ...response[0].data.categories,
+            ...response[1].data.categories
+          },
           indicators: uniqBy(
             response[0].data.indicators.concat(response[1].data.indicators),
             'id'


### PR DESCRIPTION
The new changes on the backend also filter the list of categories returned by the ndcs endpoint so the dropdown was being affected. We get the list of categories from the additional indicator request (emissions indicator) and merge it so we can populate the dropdown.

 ![image](https://user-images.githubusercontent.com/9701591/90230179-6e0b3b80-de19-11ea-85c3-f8831d8a2ca1.png)
