### PR TITLE
Fixing INDC categories relations

### DIFF
--- a/app/models/indc/category.rb
+++ b/app/models/indc/category.rb
@@ -14,6 +14,6 @@ module Indc
 
     validates :slug, presence: true
     validates :name, presence: true
-    validates :slug, uniqueness: {scope: :category_type}
+    validates :slug, uniqueness: {scope: [:category_type, :parent_id]}
   end
 end

--- a/app/models/indc/category_type.rb
+++ b/app/models/indc/category_type.rb
@@ -2,6 +2,8 @@ module Indc
   class CategoryType < ApplicationRecord
     GLOBAL = 'global'.freeze
     OVERVIEW = 'overview'.freeze
+    MAP = 'map'.freeze
+
     has_many :categories, class_name: 'Indc::Category'
 
     validates :name, uniqueness: true

--- a/db/migrate/20200818134235_change_indc_categories_slug_unique_index.rb
+++ b/db/migrate/20200818134235_change_indc_categories_slug_unique_index.rb
@@ -1,0 +1,6 @@
+class ChangeIndcCategoriesSlugUniqueIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :indc_categories, [:slug, :category_type_id]
+    add_index :indc_categories, [:slug, :category_type_id, :parent_id], name: 'index_indc_categories_on_slug_category_type_and_parent', unique: true
+  end
+end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -5,11 +5,26 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -
@@ -122,3 +137,5 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20180917120344'),
 ('20181004091403');
+
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,9 +5,22 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: emissions_filter_by_year_range(jsonb, integer, integer); Type: FUNCTION; Schema: public; Owner: -
@@ -29,6 +42,8 @@ CREATE FUNCTION public.emissions_filter_by_year_range(emissions jsonb, start_yea
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
@@ -3280,10 +3295,10 @@ CREATE INDEX index_indc_categories_on_parent_id ON public.indc_categories USING 
 
 
 --
--- Name: index_indc_categories_on_slug_and_category_type_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_indc_categories_on_slug_category_type_and_parent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_indc_categories_on_slug_and_category_type_id ON public.indc_categories USING btree (slug, category_type_id);
+CREATE UNIQUE INDEX index_indc_categories_on_slug_category_type_and_parent ON public.indc_categories USING btree (slug, category_type_id, parent_id);
 
 
 --
@@ -4258,4 +4273,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200317210928'),
 ('20200423085052'),
 ('20200503165104'),
-('20200521120158');
+('20200521120158'),
+('20200818134235');
+
+

--- a/spec/services/import_indc_spec.rb
+++ b/spec/services/import_indc_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 object_contents = {
   "#{CW_FILES_PREFIX}indc/NDC_metadata.csv" => <<~END,
-    global_category,main_category,map_category,column_name,long_name,Definition,Source,multiple_version
+    global_category,overview_category,map_category,column_name,long_name,Definition,Source,multiple_version
     Overview,UNFCCC Process,Other,domestic_approval,Domestic Approval Processes Category,,CAIT,TRUE
     Mitigation,Target,,M_TarYr,Target year,The year by which mitigation objectives are expected to be achieved,WB,TRUE
     Mitigation,Target,,M_TarYr_2,Second target year,Whether the NDC has a second-year target,WB,TRUE


### PR DESCRIPTION
Based on the client feedback, the `map` category has no relation with `global` category. Global category is a parent category for overview categories. That's why I'm removing relations between `map` and `global` categories. 

Another thing to change was the uniqueness of categories slug. From now on it will be unique in the scope of category_type (map, overview, global) and parent_id to allow the same-named categories under different parents. Example: `Planning Process` is under both `Overview` and `Adaptation`, that's why we will create 2 different categories.

This hopefully should fix the issues with duplicated categories and missing indicators in comparison pages. 

Importer was changed, so please run `bin/rails indc:import`