### PR TITLE
Fix overview embed

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-component.jsx
@@ -20,7 +20,7 @@ const NdcsOverviewSection = ({ data, section, location, handleInfoClick }) => {
         [styles.commitmentContainer]: !isEmbed
       })}
     >
-      {section === 1 && <CountriesDocumentsProvider />}
+      {parseInt(section, 10) === 1 && <CountriesDocumentsProvider />}
       <div className={layout.content}>
         <div className={cx(styles.section, { [styles.padded]: !isEmbed })}>
           <div className={styles.commitmentWrapper}>


### PR DESCRIPTION
Parse the section number as it comes as a string on the embed:

![image](https://user-images.githubusercontent.com/9701591/92106629-f8c1d380-ede4-11ea-9935-edbc97317887.png)

