### PR TITLE
Always have dataZoomYears, fixing the default

### DIFF
--- a/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
+++ b/app/javascript/app/components/ghg-emissions/data-zoom/data-zoom.js
@@ -23,10 +23,10 @@ function DataZoomContainer(props) {
       setWidth(refWidth);
 
       // Calculate initial position if we have year url params
-      if (data && years && years.min > data[0].x) {
+      if (data && years.min && years.min > data[0].x) {
         position.min = getPosition(refWidth, years.min);
       }
-      if (data && years && years.max < data[data.length - 1].x) {
+      if (data && years.max && years.max < data[data.length - 1].x) {
         position.max = getPosition(refWidth, years.max);
       }
 

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-get.js
@@ -26,10 +26,10 @@ export const getSelection = field =>
     return search[field] || search[toPlural(field)];
   });
 
-export const getDataZoomYears = createSelector(getSearch, search => {
-  if (!search) return null;
-  return { min: search.start_year, max: search.end_year };
-});
+export const getDataZoomYears = createSelector(getSearch, search => ({
+  min: search && search.start_year,
+  max: search && search.end_year
+}));
 
 export const getLinkToDataExplorer = createSelector([getSearch], search => {
   const section = 'historical-emissions';

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -36,6 +36,7 @@ function GhgEmissionsContainer(props) {
     dataZoomYears,
     setModalDownloadParams
   } = props;
+
   const handleSetYears = years => {
     const { min, max } = years || {};
     updateUrlParam([
@@ -66,7 +67,7 @@ function GhgEmissionsContainer(props) {
     if (!data) {
       return undefined;
     }
-    if (dataZoomYears) {
+    if (dataZoomYears.min && dataZoomYears.max) {
       setUpdatedData(
         data.filter(
           d =>
@@ -91,7 +92,6 @@ function GhgEmissionsContainer(props) {
       hasDataChanged &&
       data &&
       data.length &&
-      dataZoomYears &&
       (!dataZoomYears.min || !dataZoomYears.max)
     ) {
       const firstDataYear = data[0].x;


### PR DESCRIPTION
The default GHG emissions page was still not showing the years. This always inserts the min and max years