### PR TITLE
Fix link to GHG page

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/historical-emissions-graph/historical-emissions-graph-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { getGhgEmissionsFilter } from 'components/sectors-agriculture/drivers-of-emissions/card-pie-chart/ghg-metadata-selectors';
+import { useSlug } from 'utils';
 import {
   getLocationsOptions,
   getEmissionCountrySelected
@@ -15,16 +16,23 @@ import {
   getMetricOptions
 } from './historical-emissions-graph-selectors/line-chart-selectors';
 
+const getMeta = state =>
+  (state && state.ghgEmissionsMeta && state.ghgEmissionsMeta.meta) || null;
+
 const getAgricultureEmissionsLoading = state =>
   (state.agricultureEmissions && state.agricultureEmissions.loading) || false;
 
 const getExploreEmissionsButtonConfig = createSelector(
-  [getGhgEmissionsFilter, getEmissionCountrySelected],
-  (filters, location) => {
-    if (!filters || !location) return {};
+  [getGhgEmissionsFilter, getEmissionCountrySelected, getMeta],
+  (filters, location, meta) => {
+    if (!filters || !location || !meta) return {};
     const { source, gas } = filters;
+    const gasMeta = meta.gas.find(g => g.value === gas);
+    const gasSlug = gasMeta && useSlug(gasMeta.label);
+    const sourceMeta = meta.data_source.find(s => s.value === source);
+    const sourceSlug = sourceMeta && sourceMeta.label;
     return {
-      link: `/ghg-emissions?regions=${location.value}&source=${source}&gases=${gas}`
+      link: `/ghg-emissions?regions=${location.value}&source=${sourceSlug}&gases=${gasSlug}`
     };
   }
 );


### PR DESCRIPTION
In agriculture: Use correct label and slugs for sources and gases on link to GHG emissions page
 
![image](https://user-images.githubusercontent.com/9701591/92584940-95c4b680-f294-11ea-98a9-4ca4ed2250aa.png)
