### PR TITLE
Fix agriculture chart for safari

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-component.jsx
@@ -135,11 +135,27 @@ class ContextByIndicatorComponent extends Component {
               </div>
               {topTenCountries && (
                 <div className={styles.topTenSection}>
-                  <p
-                    className={styles.title}
-                  >{`${selectedIndicator.label} (${selectedIndicator.unit})`}</p>
+                  <p className={styles.title}>
+                    {`${selectedIndicator.label} (${selectedIndicator.unit})`}
+                  </p>
                   {topTenCountries.length ? (
-                    <React.Fragment>
+                    <div className={styles.topTenChart}>
+                      <ul className={styles.countriesLabels}>
+                        {topTenCountries.map(c => (
+                          <li
+                            key={`${c.value}-label-${Math.random()}-${
+                              selectedIndicator.label
+                            }`}
+                            className={styles.countryDataLabel}
+                            data-for="cc-chart-tooltip"
+                            data-tip={c.label}
+                          >
+                            <span className={styles.countriesLabel}>
+                              {c.label}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
                       <ul className={styles.countriesContainer}>
                         {topTenCountries.map(c => (
                           <li
@@ -151,7 +167,6 @@ class ContextByIndicatorComponent extends Component {
                             data-tip={c.label}
                           >
                             <span
-                              data-label={c.label}
                               data-value={c.valueLabel}
                               style={{
                                 width: `${c.chartWidth}%`,
@@ -167,7 +182,7 @@ class ContextByIndicatorComponent extends Component {
                         className={styles.tooltipContainer}
                         id="cc-chart-tooltip"
                       />
-                    </React.Fragment>
+                    </div>
                   ) : (
                     <div
                       className={styles.noData}

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
@@ -16,10 +16,6 @@
   @include columns((6, 6));
 }
 
-.visualizationsContainer {
-  @include columns();
-}
-
 .topTenSection {
   min-height: 160px;
 
@@ -27,6 +23,12 @@
     color: $theme-color;
     font-weight: $font-weight-bold;
     margin-bottom: 40px;
+    margin-left: 100px;
+  }
+
+  .countriesLabel {
+    display: block;
+    text-align: right;
   }
 
   .noData {
@@ -34,24 +36,29 @@
   }
 }
 
+.topTenSection {
+  margin-top: 40px;
+  margin-bottom: 20px;
+
+  .topTenChart {
+    display: flex;
+  }
+}
+
+.countryDataLabel {
+  margin: -5px 10px 13px 0;
+}
+
 .countryData {
   position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-bottom: 30px;
-  width: 95%;
+  margin-bottom: 15px;
+  width: 270px;
 
   span {
     position: relative;
-
-    &::before {
-      position: absolute;
-      content: attr(data-label);
-      color: $theme-color;
-      width: max-content;
-      top: -20px;
-    }
 
     &::after {
       content: attr(data-value);
@@ -137,30 +144,12 @@
   }
 
   .visualizationsContainer {
-    @include columns((8, 3));
-
-    > *:last-child {
-      @include column-offset(1, $gutters: true);
-    }
+    @include columns((6, 6));
   }
+}
 
-  .topTenSection {
-    margin-top: 40px;
-    margin-bottom: 20px;
-  }
-
-  .countryData {
-    margin-bottom: 15px;
-    width: 100%;
-
-    span::before {
-      padding-right: 15px;
-      transform: translate(-100%, 0);
-      top: -5px;
-      max-width: 151px;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-    }
+@media #{$desktop} {
+  .visualizationsContainer {
+    @include columns((8, 4));
   }
 }


### PR DESCRIPTION
The chart was using :before with some transformations and that was not playing well on safari. I changed it to a different label column, also tweaking the responsive

![image](https://user-images.githubusercontent.com/9701591/92621077-ac363680-f2c3-11ea-9064-94d64291fb47.png)
