### PR TITLE
Don't display intended Second NDC

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-selectors.js
@@ -50,10 +50,16 @@ export const getSelectedDocument = createSelector(
   [getCountryDocuments, getSearch],
   (countryDocuments, search) => {
     if (isEmpty(countryDocuments)) return null;
-    const ndcDocuments = countryDocuments.filter(d => d.is_ndc);
+    // Intended submission documents don't have submission date
+    const ndcDocuments = countryDocuments.filter(
+      d => d.is_ndc && d.submission_date
+    );
     const lastDocument = ndcDocuments[ndcDocuments.length - 1];
     if (!search || !search.document) return lastDocument;
-    return countryDocuments.find(document => document.slug === search.document) || lastDocument;
+    return (
+      countryDocuments.find(document => document.slug === search.document) ||
+      lastDocument
+    );
   }
 );
 

--- a/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
+++ b/app/javascript/app/pages/ndc-country/ndc-country-selectors.js
@@ -69,8 +69,11 @@ export const getDocumentsOptions = createSelector(
   [getCountryDocuments],
   documents => {
     if (isEmpty(documents)) return null;
+    // Intended submission documents don't have submission date
     return sortBy(
-      documents.filter(d => d.is_ndc).map(document => documentOption(document)),
+      documents
+        .filter(d => d.is_ndc && d.submission_date)
+        .map(document => documentOption(document)),
       'ordering'
     );
   }
@@ -80,7 +83,7 @@ export const getDocumentSelected = createSelector(
   [getCountryDocuments, getSearch],
   (documents, search) => {
     if (!documents || isEmpty(documents)) return null;
-    const ndcDocuments = documents.filter(d => d.is_ndc);
+    const ndcDocuments = documents.filter(d => d.is_ndc && d.submission_date);
     const lastDocument = ndcDocuments[ndcDocuments.length - 1];
     if (!search || !search.document) {
       return documentOption(lastDocument);


### PR DESCRIPTION
We were displaying the intended Second NDC as the last document and able to select it. Now it's filtered (It doesn't have a submission date)

The image is Kiribati country page
![image](https://user-images.githubusercontent.com/9701591/92623401-78104500-f2c6-11ea-86af-d1b74ef902a1.png)
