### PR TITLE
Fix/agriculture tooltip format

### DIFF
--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator-styles.scss
@@ -26,11 +26,6 @@
     margin-left: 100px;
   }
 
-  .countriesLabel {
-    display: block;
-    text-align: right;
-  }
-
   .noData {
     color: $theme-color;
   }
@@ -47,6 +42,15 @@
 
 .countryDataLabel {
   margin: -5px 10px 13px 0;
+  max-width: 100px;
+}
+
+.countriesLabel {
+  text-align: right;
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .countryData {

--- a/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
+++ b/app/javascript/app/components/sectors-agriculture/countries-context/context-by-indicator/context-by-indicator.js
@@ -32,7 +32,7 @@ class ContextByIndicatorContainer extends PureComponent {
   // eslint-disable-next-line react/sort-comp
   indicatorValueFormat = (value, unit) => {
     if (!value) return 'No Data';
-    if (unit === '%' || !unit) return `${Math.round(value * 10) / 10} %`;
+    if (unit.startsWith('%') || !unit) { return `${Math.round(value * 10) / 10} %`; }
     return `${format(',.2s')(value)} ${unit}`;
   };
 


### PR DESCRIPTION
Fix format with units that start with %

Also, fix the problem with countries on the bar chart expanding many lines

![image](https://user-images.githubusercontent.com/9701591/92628481-2d45fb80-f2cd-11ea-8b1e-4ae60212ac2d.png)
