### PR TITLE
Ignore 'undefined' parameter value

### DIFF
--- a/app/controllers/api/v1/ndcs_controller.rb
+++ b/app/controllers/api/v1/ndcs_controller.rb
@@ -174,6 +174,7 @@ module Api
         @locations_documents = params[:locations_documents].split(',').map do |loc_doc|
           loc_doc.split('-')
         end
+        @locations_documents.reject! { |ld| ld.first == 'undefined' }
 
         lse_documents_prefixes = %w(framework sectoral)
 


### PR DESCRIPTION
When only 2 countries are selected, we get an "undefined" param for the third one that messes up the logic.