### PR TITLE
Fix for LSE indicators, data that comes from climate laws API

### DIFF
--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -567,7 +567,7 @@ class ImportIndc
   # to be able to compare values for different indicators
   def import_comparison_slugs
     @comparison_indicators.each do |ind|
-      slugs = [ind[:pledges_slug], ind[:ndc_slug], ind[:lts_slug]]
+      slugs = [ind[:pledges_slug], ind[:ndc_slug], ind[:lts_slug], ind[:lse_slug]]
       Indc::Indicator.where(slug: slugs).update_all(normalized_label: ind[:normalized_label],
                                                     normalized_slug: ind[:normalized_slug])
     end


### PR DESCRIPTION
This PR changes how LSE indicators (targets that we get from climate laws API) are treated. LSE indicators from now on should be present in NDC_metadata file for full control over those indicators order and categories. Comparison matrix file should also be changed to apply normalized slugs for those new indicators. Those files were already changed on staging by me. 

Previous SQL queries had some bugs like looking up normalized indicators only those with values but if we compare only LSE data that data is not in the database and some indicators could not be returned. We should always return LSE indicators when comparing LSE data, and then distinct over normalized slugs when comparing with NDC, INDC documents data to eliminate duplicates as it was before.

To test this you have to run importers again using staging data.