### PR TITLE
Assign lts document for LTS sectoral data when importing

### DIFF
--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -203,8 +203,10 @@ class ImportIndc
     }
   end
 
-  def value_wb_attributes(row, location, indicator)
-    doc_slug = row[:document]&.parameterize&.gsub('-', '_')
+  # for datasets that don't have multiple files we can pass the doc_slug
+  # as a param, for example for LTS
+  def value_wb_attributes(row, location, indicator, doc_slug = nil)
+    doc_slug ||= row[:document]&.parameterize&.gsub('-', '_')
     {
       location: location,
       indicator: indicator,
@@ -493,7 +495,7 @@ class ImportIndc
       next unless r[:responsetext]
 
       Indc::Value.create!(
-        value_wb_attributes(r, location, indicator)
+        value_wb_attributes(r, location, indicator, 'lts')
       )
     end
   end


### PR DESCRIPTION
Sectoral indicators' values didn't have document_id set to 'lts' document. The import script was not setting this for that data.

Related to this comment: https://basecamp.com/1756858/projects/13795275/todos/424937580#comment_782358723