### PR TITLE
Use label instead of value for ndcs-explore card

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -345,7 +345,7 @@ export const getSummaryCardData = createSelector(
     );
     if (!submittedIndicator) return null;
     const submittedIsos = Object.keys(submittedIndicator.locations).filter(
-      iso => submittedIndicator.locations[iso].value === '2020 NDC Submitted'
+      iso => submittedIndicator.locations[iso].label_slug === 'submitted_2020'
     );
     if (!submittedIsos.length) return null;
     const submittedCountriesAndParties = getCountriesAndParties(submittedIsos);


### PR DESCRIPTION
Use the 'ndce_status_2020_label' instead of 'ndce_status_2020' for the summary card calculation