### PR TITLE
Aborting stalled import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: ruby
 env:
   global:
@@ -19,23 +19,20 @@ addons:
   apt:
     packages:
       - postgresql-12
-      - postgresql-client-12
-      - postgresql-server-dev-12
 
 before_install:
   - nvm install 8.10.0
   - node -v
   - npm i -g yarn
-  - gem install bundler
+  - gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 install:
   - bundle install --jobs=3 --retry=3
-  - yarn
 before_script:
   - bundle exec rake db:create db:structure:load RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
 script:
-  - bundle exec rspec
+  - GFW_API=https://staging-api.globalforestwatch.org bundle exec rspec spec
   # Preferably you will run test-reporter on branch update events. But
   # if you setup travis to build PR updates only, you don't need to run
   # the line below

--- a/Gemfile
+++ b/Gemfile
@@ -104,9 +104,9 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
-  gem 'cw_data_uploader', '~> 0.4.5', require: 'data_uploader'
+  gem 'cw_data_uploader', '~> 0.5.0', require: 'data_uploader'
   gem 'climate_watch_engine', '~> 1.4.3'
 end
 
 # for debugging
-# gem 'cw_data_uploader', '~> 0.2.0', require: 'data_uploader', path: '../climate-watch-gems'
+# gem 'cw_data_uploader', '~> 0.5.0', require: 'data_uploader', path: '../climate-watch-gems'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: 7a5b30d70389515aec173974af5444abaa1a17a0
+  revision: 77440ef0fbe0f140805ae737de5d9d0ed4cf00e2
   specs:
     climate_watch_engine (1.4.3)
       aws-sdk-s3 (~> 1)
       rails (~> 5.2.0)
-    cw_data_uploader (0.4.5)
+    cw_data_uploader (0.5.0)
       activeadmin
       aws-sdk-rails (~> 2)
       aws-sdk-s3 (~> 1)
@@ -414,7 +414,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   climate_watch_engine (~> 1.4.3)!
   coffee-rails (~> 4.2)
-  cw_data_uploader (~> 0.4.5)!
+  cw_data_uploader (~> 0.5.0)!
   devise
   dotenv-rails
   factory_bot_rails

--- a/app/admin/global_cw_platform/adaptation.rb
+++ b/app/admin/global_cw_platform/adaptation.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Adaptation' do
       download_single_data_file_path:
           admin_global_cw_platform_adaptation_download_datafile_path,
       import_path: admin_global_cw_platform_adaptation_run_importer_path,
+      abort_path: admin_global_cw_platform_adaptation_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/agriculture_contexts.rb
+++ b/app/admin/global_cw_platform/agriculture_contexts.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Agriculture Contexts' do
       download_single_data_file_path:
           admin_global_cw_platform_agriculture_contexts_download_datafile_path,
       import_path: admin_global_cw_platform_agriculture_contexts_run_importer_path,
+      abort_path: admin_global_cw_platform_agriculture_contexts_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/agriculture_emissions.rb
+++ b/app/admin/global_cw_platform/agriculture_emissions.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Agriculture Emissions' do
       download_single_data_file_path:
           admin_global_cw_platform_agriculture_emissions_download_datafile_path,
       import_path: admin_global_cw_platform_agriculture_emissions_run_importer_path,
+      abort_path: admin_global_cw_platform_agriculture_emissions_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/agriculture_metadata.rb
+++ b/app/admin/global_cw_platform/agriculture_metadata.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Agriculture Metadata' do
       download_single_data_file_path:
           admin_global_cw_platform_agriculture_metadata_download_datafile_path,
       import_path: admin_global_cw_platform_agriculture_metadata_run_importer_path,
+      abort_path: admin_global_cw_platform_agriculture_metadata_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/agriculture_profile.rb
+++ b/app/admin/global_cw_platform/agriculture_profile.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Agriculture Profile' do
       download_single_data_file_path:
           admin_global_cw_platform_agriculture_profile_download_datafile_path,
       import_path: admin_global_cw_platform_agriculture_profile_run_importer_path,
+      abort_path: admin_global_cw_platform_agriculture_profile_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/blog_stories.rb
+++ b/app/admin/global_cw_platform/blog_stories.rb
@@ -47,6 +47,7 @@ ActiveAdmin.register_page 'Global Cw Platform Blog Stories' do
   content do
     render partial: 'admin/blog_stories', locals: {
       import_path: admin_global_cw_platform_blog_stories_run_importer_path,
+      abort_path: admin_global_cw_platform_blog_stories_abort_importer_path,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }
   end

--- a/app/admin/global_cw_platform/historical_emissions.rb
+++ b/app/admin/global_cw_platform/historical_emissions.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Historical Emissions' do
       download_single_data_file_path:
           admin_global_cw_platform_historical_emissions_download_datafile_path,
       import_path: admin_global_cw_platform_historical_emissions_run_importer_path,
+      abort_path: admin_global_cw_platform_historical_emissions_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/indc.rb
+++ b/app/admin/global_cw_platform/indc.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Indc' do
       download_single_data_file_path:
           admin_global_cw_platform_indc_download_datafile_path,
       import_path: admin_global_cw_platform_indc_run_importer_path,
+      abort_path: admin_global_cw_platform_indc_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/locations.rb
+++ b/app/admin/global_cw_platform/locations.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Locations' do
       download_single_data_file_path:
           admin_global_cw_platform_locations_download_datafile_path,
       import_path: admin_global_cw_platform_locations_run_importer_path,
+      abort_path: admin_global_cw_platform_locations_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/locations_members.rb
+++ b/app/admin/global_cw_platform/locations_members.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Locations Members' do
       download_single_data_file_path:
           admin_global_cw_platform_locations_members_download_datafile_path,
       import_path: admin_global_cw_platform_locations_members_run_importer_path,
+      abort_path: admin_global_cw_platform_locations_members_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/ndc_sdgs_targets.rb
+++ b/app/admin/global_cw_platform/ndc_sdgs_targets.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Ndc Sdgs Targets' do
       download_single_data_file_path:
           admin_global_cw_platform_ndc_sdgs_targets_download_datafile_path,
       import_path: admin_global_cw_platform_ndc_sdgs_targets_run_importer_path,
+      abort_path: admin_global_cw_platform_ndc_sdgs_targets_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/ndc_texts.rb
+++ b/app/admin/global_cw_platform/ndc_texts.rb
@@ -48,6 +48,7 @@ ActiveAdmin.register_page 'Global CW Platform NDC Texts' do
   content do
     render partial: 'admin/form_upload_ndc_texts', locals: {
       import_path: admin_global_cw_platform_ndc_texts_run_importer_path,
+      abort_path: admin_global_cw_platform_ndc_texts_abort_importer_path,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }
   end

--- a/app/admin/global_cw_platform/quantifications.rb
+++ b/app/admin/global_cw_platform/quantifications.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Quantifications' do
       download_single_data_file_path:
           admin_global_cw_platform_quantifications_download_datafile_path,
       import_path: admin_global_cw_platform_quantifications_run_importer_path,
+      abort_path: admin_global_cw_platform_quantifications_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/sdgs.rb
+++ b/app/admin/global_cw_platform/sdgs.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Sdgs' do
       download_single_data_file_path:
           admin_global_cw_platform_sdgs_download_datafile_path,
       import_path: admin_global_cw_platform_sdgs_run_importer_path,
+      abort_path: admin_global_cw_platform_sdgs_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/socioeconomics.rb
+++ b/app/admin/global_cw_platform/socioeconomics.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Socioeconomics' do
       download_single_data_file_path:
           admin_global_cw_platform_socioeconomics_download_datafile_path,
       import_path: admin_global_cw_platform_socioeconomics_run_importer_path,
+      abort_path: admin_global_cw_platform_socioeconomics_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/timeline.rb
+++ b/app/admin/global_cw_platform/timeline.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Timeline' do
       download_single_data_file_path:
           admin_global_cw_platform_timeline_download_datafile_path,
       import_path: admin_global_cw_platform_timeline_run_importer_path,
+      abort_path: admin_global_cw_platform_timeline_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/wb_extra.rb
+++ b/app/admin/global_cw_platform/wb_extra.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Wb Extra' do
       download_single_data_file_path:
           admin_global_cw_platform_wb_extra_download_datafile_path,
       import_path: admin_global_cw_platform_wb_extra_run_importer_path,
+      abort_path: admin_global_cw_platform_wb_extra_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/admin/global_cw_platform/wri_metadata.rb
+++ b/app/admin/global_cw_platform/wri_metadata.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page 'Global Cw Platform Wri Metadata' do
       download_single_data_file_path:
           admin_global_cw_platform_wri_metadata_download_datafile_path,
       import_path: admin_global_cw_platform_wri_metadata_run_importer_path,
+      abort_path: admin_global_cw_platform_wri_metadata_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }


### PR DESCRIPTION
Adds an "Abort" button next to started jobs, which can be used to unblock a stalled import. 