### PR TITLE
Use S3 file prefix as base for redis namespace name,

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,15 @@
+redis_namespace =
+  if ENV['CW_FILES_PREFIX'].present?
+    ENV['CW_FILES_PREFIX'].gsub('/', ':').chomp(':')
+  else
+    "climate_watch"
+  end
+redis_namespace += "_#{Rails.env}"
+
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV['REDIS_SERVER'], namespace: "climate_watch_#{Rails.env}" }
+  config.redis = { url: ENV['REDIS_SERVER'], namespace: redis_namespace }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV['REDIS_SERVER'], namespace: "climate_watch_#{Rails.env}" }
+  config.redis = { url: ENV['REDIS_SERVER'], namespace: redis_namespace }
 end


### PR DESCRIPTION
Use S3 file prefix as base for redis namespace name, to avoid name collisions between staging (env = production) and production (env = production)