### PR TITLE
fix query to get indicators when location, document pair is found

### DIFF
--- a/app/serializers/api/v1/indc/ndc_indicators_serializer.rb
+++ b/app/serializers/api/v1/indc/ndc_indicators_serializer.rb
@@ -6,8 +6,7 @@ module Api
 
         attribute :sectors
 
-        has_many :indicators,
-                 serializer: IndicatorSerializer
+        has_many :indicators, serializer: IndicatorSerializer
 
         def categories
           IndexedSerializer.serialize(


### PR DESCRIPTION
Fixing issue with fetching too many indicators, even if some do not have any value for any location, document pair.
https://basecamp.com/1756858/projects/13795275/todos/408564766#comment_784446273

The query was wrong to check if the indicator has a value for any selected document and any selected location, not a value for the pair of document-location.