### PR TITLE
Use label source for submitted second NDC

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/ndcs-overview-section-data.js
@@ -51,7 +51,7 @@ export const commitmentsData = [
       {
         questionText: 'How many Parties submitted an updated or second NDC?',
         link: '/2020-ndc-tracker',
-        slug: 'ndce_status_2020',
+        source: 'submittedSecondNDCLabel',
         metadataSlug: 'ndc_cw',
         answerLabel: '2020 NDC Submitted'
       }

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
@@ -30,6 +30,25 @@ const getFirstNDCSubmittedIsos = createSelector(
   }
 );
 
+const getSecondNDCSubmittedIsos = createSelector(
+  [getSource, getIndicators],
+  (source, indicators) => {
+    if (!source || source !== 'submittedSecondNDCLabel' || !indicators) {
+      return null;
+    }
+    const submittedIndicator = indicators.find(
+      ind => ind.slug === 'ndce_status_2020'
+    );
+    if (!submittedIndicator) return null;
+
+    const submittedIsos = Object.keys(submittedIndicator.locations).filter(
+      iso => submittedIndicator.locations[iso].label_slug === 'submitted_2020'
+    );
+
+    return submittedIsos;
+  }
+);
+
 const getLSEIsos = createSelector(
   [getSource, getLSECountriesData],
   (source, lse) => {
@@ -38,17 +57,20 @@ const getLSEIsos = createSelector(
   }
 );
 
-const getPositiveAnswerIsos = createSelector(
-  [
-    getIndicators,
-    getSlug,
-    getAnswerLabel,
-    getFirstNDCSubmittedIsos,
-    getLSEIsos
-  ],
-  (indicators, slug, answerLabel, firstNDCSubmittedIsos, lseIsos) => {
+const getOtherSourceIsos = createSelector(
+  [getFirstNDCSubmittedIsos, getSecondNDCSubmittedIsos, getLSEIsos],
+  (firstNDCSubmittedIsos, secondNDCSubmittedIsos, lseIsos) => {
     if (firstNDCSubmittedIsos) return firstNDCSubmittedIsos;
+    if (secondNDCSubmittedIsos) return secondNDCSubmittedIsos;
     if (lseIsos) return lseIsos;
+    return null;
+  }
+);
+
+const getPositiveAnswerIsos = createSelector(
+  [getIndicators, getSlug, getAnswerLabel, getOtherSourceIsos],
+  (indicators, slug, answerLabel, otherSourceIsos) => {
+    if (otherSourceIsos) return otherSourceIsos;
     if (!indicators || !slug || !answerLabel) return null;
     const indicator = indicators.find(i => i.slug === slug);
     if (!indicator) return null;


### PR DESCRIPTION
The second question of the second section on the Overview page was not showing on staging. This probably is caused because the calculation for the submitted second NDC had the wrong source.

![image](https://user-images.githubusercontent.com/9701591/97976519-13a3ca80-1dcb-11eb-9645-fe0b9cfe0c87.png)

Now we get the labels like in the other parts of the application.