### PR TITLE
Net zero - importer, some frontend changes

### DIFF
--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -184,7 +184,7 @@ export const getPathsWithStyles = createSelector(
 export const getLinkToDataExplorer = createSelector(
   [getSearch, getSelectedCategory, getSelectedIndicator],
   (search, selectedCategory, selectedIndicator) => {
-    const section = 'lts-content';
+    const section = 'net-zero-content';
     let dataExplorerSearch = search || {};
     if (selectedCategory && selectedIndicator) {
       dataExplorerSearch = {
@@ -241,8 +241,8 @@ export const getTooltipCountryValues = createSelector(
       return null;
     }
     let updatedSelectedIndicator = selectedIndicator;
-    if (selectedIndicator.value === 'lts_submission') {
-      updatedSelectedIndicator = indicators.find(i => i.slug === 'lts_target');
+    if (selectedIndicator.value === 'nz_submission') {
+      updatedSelectedIndicator = indicators.find(i => i.slug === 'nz_target');
     }
 
     const tooltipCountryValues = {};
@@ -368,14 +368,14 @@ export const getSummaryCardData = createSelector(
   [getIndicatorsData],
   indicators => {
     if (!indicators) return null;
-    const LTSIndicator = indicators.find(i => i.slug === 'nz_status');
-    if (!LTSIndicator) return null;
-    let countriesNumber = Object.values(LTSIndicator.locations).filter(l =>
+    const netZeroIndicator = indicators.find(i => i.slug === 'nz_status');
+    if (!netZeroIndicator) return null;
+    let countriesNumber = Object.values(netZeroIndicator.locations).filter(l =>
       ['In Policy Document', 'In Law'].includes(l.value)
     ).length;
     const partiesNumber = countriesNumber;
     const europeanCountriesWithSubmission = europeanCountries.filter(
-      iso => LTSIndicator.locations[iso]
+      iso => netZeroIndicator.locations[iso]
     );
     countriesNumber +=
       europeanCountries.length - europeanCountriesWithSubmission.length - 1; // To avoid double counting, also substract the EUU 'country'

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -105,7 +105,7 @@ export const getSelectedIndicator = createSelector(
   (selected, indicators = []) => {
     if (!indicators || !indicators.length) return {};
     const defaultSelection =
-      indicators.find(i => i.slug === 'lts_submission') || indicators[0];
+      indicators.find(i => i.slug === 'nz_status') || indicators[0];
     return selected
       ? indicators.find(indicator => indicator.value === selected) ||
           defaultSelection
@@ -120,7 +120,7 @@ export const getMapIndicator = createSelector(
     const mapIndicator =
       selectedIndicator && selectedIndicator.label
         ? selectedIndicator
-        : indicators.find(indicator => indicator.slug === 'lts_submission') ||
+        : indicators.find(indicator => indicator.slug === 'nz_status') ||
           indicators[0];
     return mapIndicator;
   }
@@ -328,7 +328,7 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
 
-    const emissionsIndicator = indicators.find(i => i.slug === 'lts_ghg');
+    const emissionsIndicator = indicators.find(i => i.slug === 'nz_ghg');
     if (!emissionsIndicator) return null;
 
     let data = getIndicatorEmissionsData(
@@ -368,10 +368,10 @@ export const getSummaryCardData = createSelector(
   [getIndicatorsData],
   indicators => {
     if (!indicators) return null;
-    const LTSIndicator = indicators.find(i => i.slug === 'lts_document');
+    const LTSIndicator = indicators.find(i => i.slug === 'nz_status');
     if (!LTSIndicator) return null;
-    let countriesNumber = Object.values(LTSIndicator.locations).filter(
-      l => l.value
+    let countriesNumber = Object.values(LTSIndicator.locations).filter(l =>
+      ['In Policy Document', 'In Law'].includes(l.value)
     ).length;
     const partiesNumber = countriesNumber;
     const europeanCountriesWithSubmission = europeanCountries.filter(

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -328,8 +328,7 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
 
-    // TODO: This nz_ghg is wrong, should be other indicator
-    const emissionsIndicator = indicators.find(i => i.slug === 'nz_ghg');
+    const emissionsIndicator = indicators.find(i => i.slug === 'ndce_ghg');
     if (!emissionsIndicator) return null;
 
     let data = getIndicatorEmissionsData(

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -328,6 +328,7 @@ export const getEmissionsCardData = createSelector(
       return null;
     }
 
+    // TODO: This nz_ghg is wrong, should be other indicator
     const emissionsIndicator = indicators.find(i => i.slug === 'nz_ghg');
     if (!emissionsIndicator) return null;
 

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map.js
@@ -32,11 +32,11 @@ import {
 const actions = { ...fetchActions, ...modalActions, ...exploreMapActions };
 
 const mapStateToProps = (state, { location }) => {
-  const { data, loading } = state.LTS;
+  const { data, loading } = state.NetZero;
   const { countries } = state;
   const search = qs.parse(location.search);
 
-  const LTSWithSelection = {
+  const netZeroWithSelection = {
     ...state,
     ...data,
     countries: countries.data,
@@ -50,20 +50,20 @@ const mapStateToProps = (state, { location }) => {
 
   return {
     loading,
-    query: LTSWithSelection.query,
-    paths: getPathsWithStyles(LTSWithSelection),
-    isoCountries: getISOCountries(LTSWithSelection),
-    selectedIndicator: getMapIndicator(LTSWithSelection),
-    emissionsCardData: getEmissionsCardData(LTSWithSelection),
-    tooltipCountryValues: getTooltipCountryValues(LTSWithSelection),
-    legendData: getLegend(LTSWithSelection),
-    summaryCardData: getSummaryCardData(LTSWithSelection),
-    downloadLink: getLinkToDataExplorer(LTSWithSelection),
-    categories: getCategories(LTSWithSelection),
-    indicators: getCategoryIndicators(LTSWithSelection),
-    selectedCategory: getSelectedCategory(LTSWithSelection),
-    checked: getIsShowEUCountriesChecked(LTSWithSelection),
-    donutActiveIndex: getDonutActiveIndex(LTSWithSelection)
+    query: netZeroWithSelection.query,
+    paths: getPathsWithStyles(netZeroWithSelection),
+    isoCountries: getISOCountries(netZeroWithSelection),
+    selectedIndicator: getMapIndicator(netZeroWithSelection),
+    emissionsCardData: getEmissionsCardData(netZeroWithSelection),
+    tooltipCountryValues: getTooltipCountryValues(netZeroWithSelection),
+    legendData: getLegend(netZeroWithSelection),
+    summaryCardData: getSummaryCardData(netZeroWithSelection),
+    downloadLink: getLinkToDataExplorer(netZeroWithSelection),
+    categories: getCategories(netZeroWithSelection),
+    indicators: getCategoryIndicators(netZeroWithSelection),
+    selectedCategory: getSelectedCategory(netZeroWithSelection),
+    checked: getIsShowEUCountriesChecked(netZeroWithSelection),
+    donutActiveIndex: getDonutActiveIndex(netZeroWithSelection)
   };
 };
 
@@ -79,7 +79,7 @@ class NetZeroMapContainer extends PureComponent {
   componentWillMount() {
     // Note: This fetch is not filtered by category like the NDC as the data is not so big
     // If it starts getting big copy the logic in ndcs-explore-map.js with the lts emissions indicator
-    this.props.fetchLTS();
+    this.props.fetchNetZero();
   }
 
   handleOnChangeChecked = query => {
@@ -208,7 +208,7 @@ NetZeroMapContainer.propTypes = {
   isoCountries: PropTypes.array.isRequired,
   emissionsCardData: PropTypes.object.isRequired,
   setModalMetadata: PropTypes.func.isRequired,
-  fetchLTS: PropTypes.func.isRequired,
+  fetchNetZero: PropTypes.func.isRequired,
   query: PropTypes.string,
   summaryData: PropTypes.array,
   indicator: PropTypes.object,

--- a/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
@@ -41,7 +41,7 @@ export const tableGetSelectedData = createSelector(
       return [];
     }
     const refIndicator =
-      indicators.find(i => i.value === 'lts_submission') || indicators[0];
+      indicators.find(i => i.value === 'nz_submission') || indicators[0];
 
     return Object.keys(refIndicator.locations).map(iso => {
       if (refIndicator.locations[iso].value === 'No Document Submitted') {
@@ -64,11 +64,8 @@ export const tableGetSelectedData = createSelector(
 );
 
 const headerChanges = {
-  'Communication of Long-term Strategy':
-    'Latest submission (Current selection)',
-  Document: 'LTS submission Link',
-  'Submission Date': 'Date of LTS submission',
-  'Long-term Strategy Document': 'Long-term Strategies Document',
+  Document: 'Net Zero submission Link',
+  'Submission Date': 'Date of Net Zero submission',
   'Share of GHG Emissions': 'Share of global GHG emissions'
 };
 
@@ -84,7 +81,7 @@ export const getExtraColumn = createSelector(
   [getMapIndicator],
   selectedIndicator => {
     if (!selectedIndicator) return null;
-    return selectedIndicator.value === 'lts_submission' ? 'lts_target' : null;
+    return selectedIndicator.value === 'nz_submission' ? 'nz_target' : null;
   }
 );
 
@@ -173,7 +170,7 @@ export const getTitleLinks = createSelector([getFilteredDataBySearch], data => {
   return data.map(d => [
     {
       columnName: 'country',
-      url: `/lts/country/${d.iso}`
+      url: `/country/${d.iso}`
     }
   ]);
 });

--- a/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
@@ -95,9 +95,9 @@ export const getDefaultColumns = createSelector(
     const columnIds = [
       'country',
       selectedIndicatorHeader,
-      'lts_document',
-      'lts_date',
-      'lts_ghg'
+      'nz_source',
+      'nz_target',
+      'nz_ghg'
     ];
 
     if (extraColumn) {

--- a/app/javascript/app/components/ndcs/net-zero-table/net-zero-table.js
+++ b/app/javascript/app/components/ndcs/net-zero-table/net-zero-table.js
@@ -18,11 +18,11 @@ import {
 } from './net-zero-table-selectors';
 
 const mapStateToProps = (state, { location }) => {
-  const { data, loading } = state.LTS;
+  const { data, loading } = state.NetZero;
   const { countries } = state;
   const search = qs.parse(location.search);
 
-  const LTSWithSelection = {
+  const NetZeroWithSelection = {
     ...state,
     ...data,
     countries: countries.data,
@@ -35,12 +35,12 @@ const mapStateToProps = (state, { location }) => {
   };
   return {
     loading,
-    query: LTSWithSelection.query,
-    isoCountries: getISOCountries(LTSWithSelection),
-    tableData: removeIsoFromData(LTSWithSelection),
-    columns: getDefaultColumns(LTSWithSelection),
-    titleLinks: getTitleLinks(LTSWithSelection),
-    extraColumn: getExtraColumn(LTSWithSelection)
+    query: NetZeroWithSelection.query,
+    isoCountries: getISOCountries(NetZeroWithSelection),
+    tableData: removeIsoFromData(NetZeroWithSelection),
+    columns: getDefaultColumns(NetZeroWithSelection),
+    titleLinks: getTitleLinks(NetZeroWithSelection),
+    extraColumn: getExtraColumn(NetZeroWithSelection)
   };
 };
 

--- a/app/javascript/app/pages/net-zero/net-zero-actions.js
+++ b/app/javascript/app/pages/net-zero/net-zero-actions.js
@@ -19,7 +19,7 @@ const fetchLTS = createThunkAction('fetchLTS', () => (dispatch, state) => {
   ) {
     dispatch(fetchLTSInit());
     apiWithCache
-      .get('/api/v1/lts?source=LTS&filter=map')
+      .get('/api/v1/ndcs?source=ECIU&filter=map')
       .then(response => {
         if (response.data) return response.data;
         throw Error(response.statusText);

--- a/app/javascript/app/pages/net-zero/net-zero-actions.js
+++ b/app/javascript/app/pages/net-zero/net-zero-actions.js
@@ -6,48 +6,51 @@ import { apiWithCache } from 'services/api';
 /* @tmpfix: remove usage of indcTransform */
 import indcTransform from 'utils/indctransform';
 
-const fetchLTSInit = createAction('fetchLTSInit');
-const fetchLTSReady = createAction('fetchLTSReady');
-const fetchLTSFail = createAction('fetchLTSFail');
+const fetchNetZeroInit = createAction('fetchNetZeroInit');
+const fetchNetZeroReady = createAction('fetchNetZeroReady');
+const fetchNetZeroFail = createAction('fetchNetZeroFail');
 
-const fetchLTS = createThunkAction('fetchLTS', () => (dispatch, state) => {
-  const { LTS } = state();
-  if (
-    LTS &&
-    (isEmpty(LTS.data) || isEmpty(LTS.data.indicators)) &&
-    !LTS.loading
-  ) {
-    dispatch(fetchLTSInit());
-    Promise.all([
-      apiWithCache.get('/api/v1/ndcs?source=ECIU&filter=map'),
-      apiWithCache.get('/api/v1/ndcs?indicators=ndce_ghg')
-    ])
-      .then(responses => {
-        if (!responses[0].data) throw Error(responses[0].statusText);
-        if (!responses[1].data) throw Error(responses[1].statusText);
+const fetchNetZero = createThunkAction(
+  'fetchNetZero',
+  () => (dispatch, state) => {
+    const { NetZero } = state();
+    if (
+      NetZero &&
+      (isEmpty(NetZero.data) || isEmpty(NetZero.data.indicators)) &&
+      !NetZero.loading
+    ) {
+      dispatch(fetchNetZeroInit());
+      Promise.all([
+        apiWithCache.get('/api/v1/ndcs?source=ECIU&filter=map'),
+        apiWithCache.get('/api/v1/ndcs?indicators=ndce_ghg')
+      ])
+        .then(responses => {
+          if (!responses[0].data) throw Error(responses[0].statusText);
+          if (!responses[1].data) throw Error(responses[1].statusText);
 
-        return {
-          ...responses[0].data,
-          indicators: [
-            ...responses[0].data.indicators,
-            ...responses[1].data.indicators
-          ]
-        };
-      })
-      .then(data => indcTransform(data))
-      .then(data => {
-        dispatch(fetchLTSReady(data));
-      })
-      .catch(error => {
-        console.warn(error);
-        dispatch(fetchLTSFail());
-      });
+          return {
+            ...responses[0].data,
+            indicators: [
+              ...responses[0].data.indicators,
+              ...responses[1].data.indicators
+            ]
+          };
+        })
+        .then(data => indcTransform(data))
+        .then(data => {
+          dispatch(fetchNetZeroReady(data));
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchNetZeroFail());
+        });
+    }
   }
-});
+);
 
 export default {
-  fetchLTS,
-  fetchLTSInit,
-  fetchLTSReady,
-  fetchLTSFail
+  fetchNetZero,
+  fetchNetZeroInit,
+  fetchNetZeroReady,
+  fetchNetZeroFail
 };

--- a/app/javascript/app/pages/net-zero/net-zero-reducers.js
+++ b/app/javascript/app/pages/net-zero/net-zero-reducers.js
@@ -10,8 +10,8 @@ const setError = (state, error) => ({ ...state, error });
 const setLoaded = (state, loaded) => ({ ...state, loaded });
 
 export default {
-  fetchLTSInit: state => setLoading(state, true),
-  fetchLTSReady: (state, { payload }) =>
+  fetchNetZeroInit: state => setLoading(state, true),
+  fetchNetZeroReady: (state, { payload }) =>
     setLoaded(
       setLoading(
         {
@@ -25,5 +25,5 @@ export default {
       ),
       true
     ),
-  fetchLTSFail: state => setError(state, true)
+  fetchNetZeroFail: state => setError(state, true)
 };

--- a/app/javascript/app/pages/net-zero/net-zero.js
+++ b/app/javascript/app/pages/net-zero/net-zero.js
@@ -10,7 +10,7 @@ import Component from './net-zero-component';
 
 class NetZeroContainer extends PureComponent {
   componentWillMount() {
-    this.props.fetchLTS();
+    this.props.fetchNetZero();
   }
 
   render() {
@@ -19,7 +19,7 @@ class NetZeroContainer extends PureComponent {
 }
 
 NetZeroContainer.propTypes = {
-  fetchLTS: PropTypes.func.isRequired
+  fetchNetZero: PropTypes.func.isRequired
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -90,6 +90,7 @@ const providersReducers = {
 // Pages
 import * as NDCSEnhancementsPage from 'pages/ndcs-enhancements';
 import * as LTSPage from 'pages/lts-explore';
+import * as NetZeroPage from 'pages/net-zero';
 import * as countryNDCFullPage from 'pages/ndc-country-full';
 import * as ndcSearchPage from 'pages/ndc-search';
 import * as myCWEditor from 'pages/my-climate-watch/my-cw-editor';
@@ -97,6 +98,7 @@ import * as myCWEditor from 'pages/my-climate-watch/my-cw-editor';
 const pagesReducers = {
   ndcsEnhancements: handleActions(NDCSEnhancementsPage),
   LTS: handleActions(LTSPage),
+  NetZero: handleActions(NetZeroPage),
   countryNDCFull: handleActions(countryNDCFullPage),
   ndcSearch: handleActions(ndcSearchPage),
   myCWEditor: handleActions(myCWEditor)

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -28,38 +28,32 @@ class ImportIndc
       load_csvs
       load_locations
 
-      time_log('import documents') { import_documents }
-      time_log('import sources') { import_sources }
-      time_log('import category types') { import_category_types }
-      time_log('import categories') { import_categories }
-      time_log('import indicators') { import_indicators }
-      time_log('import_indicators_categories') { import_indicators_categories }
-      time_log('import_labels') { import_labels }
-      time_log('import_values_ndc') { import_values_ndc }
+      import_documents
+      import_sources
+      import_category_types
+      import_categories
+      import_indicators
+      import_indicators_categories
+      import_labels
+      import_values_ndc
 
-      time_log('import_sectors_lts') { import_sectors_lts }
-      time_log('import_values_lts') { import_values_lts }
-      time_log('import_sector_values_lts') { import_sector_values_lts }
+      import_sectors_lts
+      import_values_lts
+      import_sector_values_lts
 
-      time_log('import_sectors_wb') { import_sectors_wb }
-      time_log('import_values_wb') { import_values_wb }
+      import_sectors_wb
+      import_values_wb
 
-      time_log('import_values_pledges') { import_values_pledges }
+      import_values_pledges
 
       reject_map_indicators_without_values_or_labels
 
-      time_log('import_submissions') { import_submissions }
-      time_log('import_comparison_slugs') { import_comparison_slugs }
+      import_submissions
+      import_comparison_slugs
     end
 
-    time_log('generate_subsectors_map_data') { generate_subsectors_map_data }
-    time_log('refresh view') { Indc::SearchableValue.refresh }
-  end
-
-  def time_log(name)
-    TimedLogger.log(name) do
-      yield
-    end
+    generate_subsectors_map_data
+    Indc::SearchableValue.refresh
   end
 
   def generate_subsectors_map_data

--- a/app/services/import_indc.rb
+++ b/app/services/import_indc.rb
@@ -226,7 +226,7 @@ class ImportIndc
       indicator: indicator,
       sector: @sectors_index[row[:subsector]],
       value: row[:responsetext],
-      document: Indc::Document.where(slug: doc_slug).pluck(:id).first
+      document_id: Indc::Document.where(slug: doc_slug).pluck(:id).first
     }
   end
 
@@ -409,7 +409,7 @@ class ImportIndc
 
   def import_values_ndc
     valid_sources = [@sources_index['CAIT'], @sources_index['NDC Explorer'],
-                     @sources_index['WB'], @sources_index['Net Zero Tracker']]
+                     @sources_index['WB'], @sources_index['ECIU']]
     values = []
 
     Indc::Indicator.

--- a/lib/tasks/indc.rake
+++ b/lib/tasks/indc.rake
@@ -2,7 +2,9 @@ namespace :indc do
   desc 'Imports the INDC dataset from the csv sources'
   task import: :environment do
     TimedLogger.log('import indc data') do
-      ImportIndc.new.call
+      ActiveRecord::Base.connection.cache do
+        ImportIndc.new.call
+      end
     end
   end
 


### PR DESCRIPTION
- improving INDC importer, works 3x faster now
- changing Net Zero Tracker source name to ECIU
- couple frontend changes to test the data, not changing everything or renaming `lts` prefixes to `netZero` or smth.
- nz_ghg indicator has some strange data, not like lts_ghg, or ndcs_ghg which are percentage

New data was uploaded to staging folder on AWS. To test it just reimport indc data

```
bin/rails indc:import
```