### PR TITLE
Fix/ghg gdp data

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data-utils.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data-utils.js
@@ -9,35 +9,14 @@ const expandRegionToCountries = (iso, regions) => {
   return flatMap(region.members, expandRegionToCountries);
 };
 
-const expandRegionsToCountries = (isos, regions) =>
-  uniq(flatMap(isos, iso => expandRegionToCountries(iso, regions)));
-
-export const getMetricData = (
-  year,
-  column,
-  metricField,
-  calculationData,
-  regions
-) => {
+export const getMetricData = (year, iso, metricField, calculationData) => {
   const getMetricForYearAndRegion = (y, r) =>
     metricField &&
     calculationData &&
     calculationData[y] &&
     calculationData[y][r] &&
     calculationData[y][r][metricField];
-  let metricData = getMetricForYearAndRegion(year, column.iso);
-  // if no metric data for expandable column then use expanded regions to
-  // calculate metric data
-  if (!metricData && column.expandsTo && column.expandsTo.length) {
-    const expandedCountries = expandRegionsToCountries(
-      column.expandsTo,
-      regions
-    );
-    metricData = expandedCountries.reduce(
-      (acc, iso3) => acc + (getMetricForYearAndRegion(year, iso3) || 0),
-      0
-    );
-  }
+  let metricData = getMetricForYearAndRegion(year, iso);
 
   // GDP is in dollars and we want to display it in million dollars
   if (metricField === 'gdp' && metricData) metricData /= 1000000;

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data-utils.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data-utils.js
@@ -36,3 +36,21 @@ export const getRegionsWithOwnData = (regions, data) => {
 
   return regions.filter(r => regionsISOsWithOwnData.includes(r.iso_code3));
 };
+
+// If there is no value for any legend item
+// remove those element from the start and the end of chart
+// leave those in the middle
+export const trimWithNoData = dataToTrim => {
+  const indexesToString = dataToTrim
+    .map((d, idx) => (Object.keys(d).length > 1 ? idx : '_'))
+    .join(',')
+    .replace(/_,/g, '')
+    .trim();
+  const middleIndexes = indexesToString.split(',');
+  const firstNotEmptyIndex = Number(middleIndexes[0]);
+  const lastNotEmptyIndex = Number(middleIndexes[middleIndexes.length - 1]);
+
+  return dataToTrim.filter(
+    (_d, idx) => idx >= firstNotEmptyIndex && idx <= lastNotEmptyIndex
+  );
+};

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -41,7 +41,8 @@ import {
 
 import {
   getMetricData,
-  getRegionsWithOwnData
+  getRegionsWithOwnData,
+  trimWithNoData
 } from './ghg-emissions-selectors-data-utils';
 
 const getShouldExpand = filter =>
@@ -255,7 +256,6 @@ export const getChartData = createSelector(
     const isBreakByRegions = model === 'regions';
     const groupByKey = isBreakByRegions ? 'location' : model;
     const groupedData = groupBy(data, groupByKey);
-
     const expandedData = column => {
       if (!column.expandsTo) return null;
 
@@ -264,8 +264,6 @@ export const getChartData = createSelector(
       ).filter(d => d);
     };
 
-    const dataParsed = [];
-    const yItems = {};
     const accumulatedValues = {};
     const previousYearValues = {};
 
@@ -304,6 +302,9 @@ export const getChartData = createSelector(
       return null;
     };
 
+    const dataParsed = [];
+    const yItems = {};
+
     yearValues.forEach(year => {
       yColumnOptions.forEach(column => {
         const dataForColumn =
@@ -341,23 +342,6 @@ export const getChartData = createSelector(
       });
     });
 
-    // if there is no value for any legend item
-    // remove those element from the start and the end of chart
-    // leave those in the middle
-    const trimWithNoData = dataToTrim => {
-      const indexesToString = dataToTrim
-        .map((d, idx) => (Object.keys(d).length > 1 ? idx : '_'))
-        .join(',')
-        .replace(/_,/g, '')
-        .trim();
-      const middleIndexes = indexesToString.split(',');
-      const firstNotEmptyIndex = Number(middleIndexes[0]);
-      const lastNotEmptyIndex = Number(middleIndexes[middleIndexes.length - 1]);
-
-      return dataToTrim.filter(
-        (_d, idx) => idx >= firstNotEmptyIndex && idx <= lastNotEmptyIndex
-      );
-    };
     return trimWithNoData(dataParsed);
   }
 );

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -317,7 +317,13 @@ export const getChartData = createSelector(
 
           const yearEmissions = d.emissions.find(e => e.year === year);
           const metricRatio = shouldHaveMetricData
-            ? getMetricData(year, column, metricField, calculationData, regions)
+            ? getMetricData(
+              year,
+              d.iso_code3,
+              metricField,
+              calculationData,
+              regions
+            )
             : 1;
 
           if (yearEmissions && yearEmissions.value && metricRatio) {

--- a/app/models/wb_extra/country_data.rb
+++ b/app/models/wb_extra/country_data.rb
@@ -1,7 +1,7 @@
 module WbExtra
   class CountryData < ApplicationRecord
     belongs_to :location
-    validates :year, :population, :gdp, presence: true
+    validates :year, presence: true
 
     def self.filter_by_dates(start_year, end_year)
       return all unless start_year || end_year

--- a/spec/services/import_wb_extra_spec.rb
+++ b/spec/services/import_wb_extra_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe ImportWbExtra do
   end
 
   it 'Creates new wb_extra_country_data records' do
-    expect { subject }.to change { WbExtra::CountryData.count }.by(38)
+    expect { subject }.to change { WbExtra::CountryData.count }.by(61)
   end
 end


### PR DESCRIPTION
This PR fixes two problems:

- WB country data import: The rails model had a validation that prevented missing GDP or population data to be imported. This was hiding existing population data on the frontend. The validation has been removed.

- Calculation double counting: Due to changes in the way we group the regions the calculation data (population, gdp) was double or multiple counted. Fixed now:

Before:

![image](https://user-images.githubusercontent.com/9701591/98939358-9b838600-24e9-11eb-87e6-7e5d97c68a13.png)

After:

![image](https://user-images.githubusercontent.com/9701591/98940235-fb2e6100-24ea-11eb-9990-5476eefe8b40.png)


