### PR TITLE
Remove first summary item and adjust styles

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
@@ -20,9 +20,9 @@ const renderButtonGroup = (clickHandler, downloadLink) => (
     <div>
       <p>
         <em>
-          Track which countries are
-          updating or enhancing their national climate commitments in 2020 or in the lead up to COP26.
-          To request changes or additions, please contact &nbsp;
+          Track which countries are updating or enhancing their national climate
+          commitments in 2020 or in the lead up to COP26. To request changes or
+          additions, please contact &nbsp;
           <a
             href="mailto:Rhys.Gerholdt@wri.org?subject=2020 NDC Tracker Update"
             target="_blank"
@@ -113,7 +113,7 @@ const NDCSEnhancementsViz = ({
           <div className={styles.containerUpper}>
             <div className={styles.containerCharts}>
               {!loading && summaryData && (
-                <div>
+                <div className={styles.summary}>
                   <div
                     data-tip
                     data-for="covid-update-tooltip"
@@ -133,7 +133,6 @@ const NDCSEnhancementsViz = ({
                     of COP26. The information below does not reflect these
                     possible delays.
                   </ReactTooltip>
-                  {renderCircular(summaryData.intend_2020.countries)}
                   {renderCircular(summaryData.enhance_2020.countries)}
                   {renderCircular(summaryData.submitted_2020.countries)}
                 </div>

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-styles.scss
@@ -58,6 +58,14 @@
   }
 }
 
+.summary {
+  min-height: 300px;
+
+  @media #{$tablet-landscape} {
+    min-height: 500px;
+  }
+}
+
 :global .__react_component_tooltip {
   max-width: 250px;
   white-space: pre-line;


### PR DESCRIPTION
Remove the first text on the 2020 page and adjust the height to match the map

![image](https://user-images.githubusercontent.com/9701591/101618819-c4c50280-3a12-11eb-8a33-a9ba561013cb.png)
