### PR TITLE
Mixed content was causing an error on the download

### DIFF
--- a/app/javascript/app/components/download-menu/download-menu.js
+++ b/app/javascript/app/components/download-menu/download-menu.js
@@ -10,7 +10,7 @@ import Component from './download-menu-component';
 const { S3_BUCKET_NAME } = process.env;
 const { CW_FILES_PREFIX } = process.env;
 
-const server = `http://${S3_BUCKET_NAME}.s3.amazonaws.com`;
+const server = `https://${S3_BUCKET_NAME}.s3.amazonaws.com`;
 const folder = `/${CW_FILES_PREFIX}climate-watch-download-zip`;
 const url = `${server}${folder}`;
 


### PR DESCRIPTION
There was an error on the download when the page was served over https and the download was in HTTP. This was causing a mixed content problem and not allowing the download 