### PR TITLE
Link to ndc_enhancement data explorer section when in 2020

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
@@ -167,7 +167,13 @@ export const getPathsWithStyles = createSelector(
 
 export const getLinkToDataExplorer = createSelector([getSearch], search => {
   const section = 'ndc-content';
-  return generateLinkToDataExplorer(search, section);
+  return generateLinkToDataExplorer(
+    {
+      category: 'ndc_enhancement',
+      ...search
+    },
+    section
+  );
 });
 
 // Chart data methods


### PR DESCRIPTION
When we now select the data explorer link on 2020 page it will link to the ndc-explorer ndc_enhancement section