### PR TITLE
Append unique record id for sorting to ensure order

### DIFF
--- a/app/services/api/v1/data/sanitised_sorting.rb
+++ b/app/services/api/v1/data/sanitised_sorting.rb
@@ -15,8 +15,19 @@ module Api
         def sanitised_order
           @query.klass.send(
             :sanitize_sql_for_order,
-            "#{@sorting_column} #{@sorting_direction}"
+            sorting_sql
           )
+        end
+
+        def sorting_sql
+          sql = "#{@sorting_column} #{@sorting_direction}"
+          id_column = alias_to_name('id')
+
+          return sql if id_column.nil? || @sorting_column.downcase.to_s == id_column
+
+          # append unique record identifier at the end of sorting phrase to ensure
+          # the order when sorting by non distinct columns like for example region
+          sql + ", #{id_column} ASC"
         end
 
         # @param column [String] name of column; can be a year


### PR DESCRIPTION
When downloading multiple pages we need to ensure the right order, especially when sorting by non-distinct values like country. I think the quickest way to fix that is to append ordering by `id` at the end of sorting SQL. Still, the API will return only the first sorting column to not introduce breaking change.

https://basecamp.com/1756858/projects/13795275/todos/431498778

To reproduce the error locally I created a small ruby script that downloads pages twice and we can easily compare the file sizes afterward.

```ruby
#!/usr/bin/env ruby

pages = 114
per_page = 200
from_page = 1

# api_endpoint = 'https://www.climatewatchdata.org/api/v1/data/historical_emissions'
api_endpoint = 'http://localhost:3000/api/v1/data/historical_emissions'

(from_page..pages).each do |page|
  system "wget -O #{page}_0.json '#{api_endpoint}?page=#{page}&per_page=#{per_page}' &"
end

(from_page..pages).each do |page|
  system "wget -O #{page}_1.json '#{api_endpoint}?page=#{page}&per_page=#{per_page}' &"
end
```

Appended `&` to start downloading pages not in order (as when downloaded synchronously in order, everything was fine on development, but in production won't be as there will be other queries ran against DB at the same time)

Here are the results:

Before fix (clearly we see different pages returned):
![before_pages](https://user-images.githubusercontent.com/1286444/105034531-e4136e80-5a59-11eb-9d5e-d2177634c88b.png)

After fix:
![page_responses_after](https://user-images.githubusercontent.com/1286444/105034546-e970b900-5a59-11eb-80a4-473b46916f5b.png)
 

