### PR TITLE
Fix/ghg percentage format

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -260,7 +260,7 @@ function GhgEmissions(props) {
         return billionsFormat(value);
       } else if (value > 1000000 || value < -1000000) {
         return millionsFormat(value);
-      } else if (value > 1000 || value > -1000) {
+      } else if (value > 1000 || value < -1000) {
         return thousandsFormat(value);
       }
       return format('.2f')(value);

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -4,7 +4,11 @@ import startCase from 'lodash/startCase';
 import isArray from 'lodash/isArray';
 import { isPageContained } from 'utils/navigation';
 import cx from 'classnames';
-import { GHG_TABLE_HEADER, GHG_CALCULATION_OPTIONS } from 'data/constants';
+import {
+  GHG_TABLE_HEADER,
+  GHG_CALCULATION_OPTIONS,
+  CHART_TYPES
+} from 'data/constants';
 import {
   Chart,
   Multiselect,
@@ -224,10 +228,11 @@ function GhgEmissions(props) {
     }
 
     const tableDataReady = !loading && tableData && tableData.length;
-    const isPercentageChangeCalculation =
+    const isPercentageUnit =
       !loading &&
-      selectedOptions.calculationSelected.value ===
-        GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
+      (selectedOptions.calculationSelected.value ===
+        GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value ||
+        selectedOptions.chartTypeSelected.value === CHART_TYPES.percentage);
 
     const percentageChangeCustomLabelFormat = value => {
       if (value === undefined) {
@@ -278,14 +283,12 @@ function GhgEmissions(props) {
           onLegendChange={handleLegendChange}
           hideRemoveOptions={hideRemoveOptions}
           getCustomYLabelFormat={
-            isPercentageChangeCalculation
-              ? percentageChangeCustomLabelFormat
-              : undefined
+            isPercentageUnit ? percentageChangeCustomLabelFormat : undefined
           }
           customTooltip={
             <TooltipChart
               getCustomYLabelFormat={
-                isPercentageChangeCalculation
+                isPercentageUnit
                   ? percentageChangeCustomLabelFormat
                   : customLabelFormat
               }

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-data.js
@@ -22,7 +22,8 @@ import {
   CHART_COLORS_EXTENDED,
   CHART_COLORS_EXTRA,
   OTHER_COLOR,
-  GHG_CALCULATION_OPTIONS
+  GHG_CALCULATION_OPTIONS,
+  CHART_TYPES
 } from 'data/constants';
 import {
   getWBData,
@@ -36,6 +37,7 @@ import {
   getCalculationSelected,
   getOptionsSelected,
   getIsRegionAggregated,
+  getChartTypeSelected,
   getOptions
 } from './ghg-emissions-selectors-filters';
 
@@ -456,9 +458,12 @@ const getColorPalette = columns => {
   return CHART_COLORS_EXTRA;
 };
 
-export const getUnit = metric => {
+export const getUnit = (metric, chartType) => {
   let unit = DEFAULT_AXES_CONFIG.yLeft.unit;
-  if (metric === GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value) {
+  if (
+    metric === GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value ||
+    chartType === CHART_TYPES.percentage
+  ) {
     return '%';
   }
   if (metric === GHG_CALCULATION_OPTIONS.PER_GDP.value) {
@@ -474,9 +479,10 @@ export const getChartConfig = createSelector(
     getModelSelected,
     getMetricSelected,
     getSortedYColumnOptions,
-    getCalculationSelected
+    getCalculationSelected,
+    getChartTypeSelected
   ],
-  (model, metric, yColumns, calculationSelected) => {
+  (model, metric, yColumns, calculationSelected, chartType) => {
     if (!model || !yColumns) return null;
     const colorPalette = getColorPalette(yColumns);
     const isPercentageChangeCalculation =
@@ -484,7 +490,7 @@ export const getChartConfig = createSelector(
       GHG_CALCULATION_OPTIONS.PERCENTAGE_CHANGE.value;
     colorThemeCache = getThemeConfig(yColumns, colorPalette, colorThemeCache);
     const tooltip = getTooltipConfig(yColumns.filter(c => c && !c.hideLegend));
-    const unit = getUnit(metric);
+    const unit = getUnit(metric, chartType);
     return {
       axes: {
         ...DEFAULT_AXES_CONFIG,

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-filters.js
@@ -10,7 +10,8 @@ import { sortLabelByAlpha } from 'utils/graphs';
 import {
   GAS_AGGREGATES,
   TOP_EMITTERS_OPTION,
-  GHG_CALCULATION_OPTIONS
+  GHG_CALCULATION_OPTIONS,
+  CHART_TYPE_OPTIONS
 } from 'data/constants';
 import {
   getMeta,
@@ -272,12 +273,6 @@ const getGasOptions = createSelector([getFieldOptions('gas')], options => {
       GAS_AGGREGATES[o.label].map(valueByLabel).filter(v => v)
   }));
 });
-
-const CHART_TYPE_OPTIONS = [
-  { label: 'Line chart', value: 'line' },
-  { label: 'Stacked area Chart', value: 'area' },
-  { label: '100% stacked area chart', value: 'percentage' }
-];
 
 const getChartTypeOptions = () => CHART_TYPE_OPTIONS;
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -39,6 +39,18 @@ export const GHG_CALCULATION_OPTIONS = {
   }
 };
 
+export const CHART_TYPES = {
+  line: 'line',
+  area: 'area',
+  percentage: 'percentage'
+};
+
+export const CHART_TYPE_OPTIONS = [
+  { label: 'Line chart', value: CHART_TYPES.line },
+  { label: 'Stacked area Chart', value: CHART_TYPES.area },
+  { label: '100% stacked area chart', value: CHART_TYPES.percentage }
+];
+
 export const NOT_COVERED_LABEL = 'Not covered';
 
 export const CALCULATION_OPTIONS = {


### PR DESCRIPTION
- Show percentage on the tooltip when the chart type is percentage
![image](https://user-images.githubusercontent.com/9701591/105971369-bc8c5980-608a-11eb-889f-4ba4bd44c25a.png)

- Fix negative tooltip format for numbers on the negative thousands
![image](https://user-images.githubusercontent.com/9701591/105971802-3886a180-608b-11eb-8449-0c8fda350878.png)

